### PR TITLE
feat(media): seekable transcode + broader format support

### DIFF
--- a/src/main/audio-formats.ts
+++ b/src/main/audio-formats.ts
@@ -3,16 +3,21 @@ export const AUDIO_EXTENSIONS = new Set([
   ".flac",
   ".wav",
   ".ogg",
+  ".oga",
   ".aac",
   ".m4a",
   ".wma",
   ".opus",
+  ".webm",
   ".aiff",
   ".aif",
+  ".mka",
+  ".mp2",
 ]);
 
 export const MIME_TYPES: Record<string, string> = {
   mp3: "audio/mpeg",
+  mp2: "audio/mpeg",
   m4a: 'audio/mp4; codecs="mp4a.40.2"',
   mp4: 'audio/mp4; codecs="mp4a.40.2"',
   aac: "audio/aac",
@@ -22,15 +27,20 @@ export const MIME_TYPES: Record<string, string> = {
   wav: "audio/wav",
   flac: "audio/flac",
   webm: "audio/webm",
+  mka: "audio/x-matroska",
 };
 
-// m4a/mp4 excluded: Chromium's pipeline rejects our Range responses for moov-at-end
-// containers even when bytes match. Route through ffmpeg → wav instead.
+// Formats Chromium plays directly via <audio> + Range. m4a/mp4 are NOT
+// listed here because their playability depends on whether the moov atom
+// precedes mdat (faststart) — that runtime check lives in
+// transcode.ts:shouldTranscode.
 export const NATIVE_FORMATS = new Set([
   "mp3",
   "wav",
   "flac",
   "ogg",
+  "oga",
   "opus",
   "aac",
+  "webm",
 ]);

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -3,14 +3,28 @@ import fs from "fs";
 import { stat } from "fs/promises";
 import * as db from "./db";
 import * as config from "./config";
-import { needsTranscode, transcodeToWav } from "./transcode";
+import {
+  shouldTranscode,
+  transcodeRange,
+  transcodeToWav,
+  transcodedTotalSize,
+} from "./transcode";
 import { MIME_TYPES } from "./audio-formats";
 import * as ipc from "./ipc";
 import * as logger from "./logger";
 import { createMainWindow } from "./mainWindow";
 
 protocol.registerSchemesAsPrivileged([
-  { scheme: "media", privileges: { stream: true, supportFetchAPI: true } },
+  {
+    scheme: "media",
+    privileges: {
+      standard: true,
+      secure: true,
+      stream: true,
+      supportFetchAPI: true,
+      bypassCSP: true,
+    },
+  },
 ]);
 
 const mediaHandler = async (request: Request) => {
@@ -19,18 +33,24 @@ const mediaHandler = async (request: Request) => {
   const track = await db.getTrack(id);
   if (!track) return new Response("Not found", { status: 404 });
 
-  if (needsTranscode(track.format)) {
-    const stream = transcodeToWav(track.path);
-    return new Response(stream, {
+  const transcoding = await shouldTranscode(track.format, track.path);
+
+  // No-duration transcode fallback: stream the whole WAV with no Range
+  // support. Browser can play sequentially but cannot seek.
+  if (transcoding && (!track.duration || track.duration <= 0)) {
+    return new Response(transcodeToWav(track.path), {
       headers: { "Content-Type": "audio/wav" },
     });
   }
 
-  const range = request.headers.get("range");
-  const stats = await stat(track.path);
-  const total = stats.size;
-  const contentType = MIME_TYPES[track.format] || "application/octet-stream";
+  const total = transcoding
+    ? transcodedTotalSize(track.duration)
+    : (await stat(track.path)).size;
+  const contentType = transcoding
+    ? "audio/wav"
+    : MIME_TYPES[track.format] || "application/octet-stream";
 
+  const range = request.headers.get("range");
   let start = 0;
   let end = total - 1;
   let status = 200;
@@ -58,6 +78,11 @@ const mediaHandler = async (request: Request) => {
 
   const length = end - start + 1;
   headers["Content-Length"] = String(length);
+
+  if (transcoding) {
+    const body = transcodeRange(track.path, track.duration, start, end);
+    return new Response(body, { status, headers });
+  }
 
   const fd = await fs.promises.open(track.path, "r");
   try {

--- a/src/main/transcode.ts
+++ b/src/main/transcode.ts
@@ -1,4 +1,5 @@
 import { spawn } from "child_process";
+import { open } from "fs/promises";
 import { Readable } from "stream";
 import ffmpegStatic from "ffmpeg-static";
 import { NATIVE_FORMATS } from "./audio-formats";
@@ -7,29 +8,102 @@ import { NATIVE_FORMATS } from "./audio-formats";
 const FFMPEG_PATH =
   ffmpegStatic?.replace("app.asar", "app.asar.unpacked") ?? "ffmpeg";
 
+const MP4_FORMATS = new Set(["m4a", "mp4"]);
+const MOOV_SCAN_BYTES = 64 * 1024;
+
+// Transcode output format: PCM s16le stereo @ 44100Hz
+const SAMPLE_RATE = 44100;
+const CHANNELS = 2;
+const BYTES_PER_SAMPLE = 2;
+const BYTES_PER_FRAME = CHANNELS * BYTES_PER_SAMPLE;
+const PCM_BYTES_PER_SECOND = SAMPLE_RATE * BYTES_PER_FRAME;
+export const WAV_HEADER_SIZE = 44;
+
 export function needsTranscode(format: string): boolean {
   return !NATIVE_FORMATS.has(format.toLowerCase());
 }
 
-export function transcodeToWav(filePath: string): ReadableStream {
-  const proc = spawn(
-    FFMPEG_PATH,
-    [
-      "-i",
-      filePath,
-      "-f",
-      "wav",
-      "-acodec",
-      "pcm_s16le",
-      "-ar",
-      "44100",
-      "-ac",
-      "2",
-      "pipe:1",
-    ],
-    { stdio: ["ignore", "pipe", "pipe"] },
-  );
+// MP4 files are streamable by Chromium only when the 'moov' atom precedes
+// 'mdat' (faststart layout). Files with moov-at-end fail mid-playback even
+// with byte-correct Range responses, so we transcode those.
+export async function isMp4FastStart(filePath: string): Promise<boolean> {
+  let fd;
+  try {
+    fd = await open(filePath, "r");
+  } catch {
+    return false;
+  }
+  try {
+    const buf = Buffer.alloc(MOOV_SCAN_BYTES);
+    const { bytesRead } = await fd.read(buf, 0, buf.length, 0);
+    let offset = 0;
+    while (offset + 8 <= bytesRead) {
+      const size = buf.readUInt32BE(offset);
+      const type = buf.toString("ascii", offset + 4, offset + 8);
+      if (type === "moov") return true;
+      if (type === "mdat") return false;
+      let advance: number;
+      if (size === 0) return false; // atom extends to EOF — moov not seen
+      if (size === 1) {
+        if (offset + 16 > bytesRead) return false;
+        const hi = buf.readUInt32BE(offset + 8);
+        const lo = buf.readUInt32BE(offset + 12);
+        advance = hi * 0x1_0000_0000 + lo;
+      } else {
+        advance = size;
+      }
+      if (advance < 8) return false; // malformed
+      offset += advance;
+    }
+    return false;
+  } finally {
+    await fd.close();
+  }
+}
 
+export async function shouldTranscode(
+  format: string,
+  filePath: string,
+): Promise<boolean> {
+  const fmt = format.toLowerCase();
+  if (MP4_FORMATS.has(fmt)) return !(await isMp4FastStart(filePath));
+  return needsTranscode(fmt);
+}
+
+export function pcmBytesForDuration(durationSeconds: number): number {
+  // Round down to whole sample frames (4 bytes for s16le stereo).
+  return (
+    Math.floor((durationSeconds * PCM_BYTES_PER_SECOND) / BYTES_PER_FRAME) *
+    BYTES_PER_FRAME
+  );
+}
+
+export function transcodedTotalSize(durationSeconds: number): number {
+  return WAV_HEADER_SIZE + pcmBytesForDuration(durationSeconds);
+}
+
+export function buildWavHeader(pcmBytes: number): Buffer {
+  const buf = Buffer.alloc(WAV_HEADER_SIZE);
+  buf.write("RIFF", 0, "ascii");
+  buf.writeUInt32LE(36 + pcmBytes, 4);
+  buf.write("WAVE", 8, "ascii");
+  buf.write("fmt ", 12, "ascii");
+  buf.writeUInt32LE(16, 16); // fmt chunk body size
+  buf.writeUInt16LE(1, 20); // PCM format
+  buf.writeUInt16LE(CHANNELS, 22);
+  buf.writeUInt32LE(SAMPLE_RATE, 24);
+  buf.writeUInt32LE(PCM_BYTES_PER_SECOND, 28);
+  buf.writeUInt16LE(BYTES_PER_FRAME, 32);
+  buf.writeUInt16LE(BYTES_PER_SAMPLE * 8, 34);
+  buf.write("data", 36, "ascii");
+  buf.writeUInt32LE(pcmBytes, 40);
+  return buf;
+}
+
+function attachFfmpegLogging(
+  proc: ReturnType<typeof spawn>,
+  filePath: string,
+): void {
   proc.stderr!.on("data", (chunk: Buffer) => {
     process.stderr.write(`[ffmpeg ${filePath}] ${chunk}`);
   });
@@ -41,6 +115,179 @@ export function transcodeToWav(filePath: string): ReadableStream {
       console.error(`[ffmpeg exit ${code}] ${filePath} signal=${signal}`);
     }
   });
+}
 
+const FFMPEG_QUIET = ["-nostdin", "-hide_banner", "-loglevel", "error"];
+
+// Spawns ffmpeg with input-side seek and outputs raw PCM s16le.
+function spawnPcmDecoder(
+  filePath: string,
+  seekSeconds: number,
+): ReturnType<typeof spawn> {
+  const args = [...FFMPEG_QUIET];
+  if (seekSeconds > 0) args.push("-ss", seekSeconds.toFixed(6));
+  args.push(
+    "-i",
+    filePath,
+    "-f",
+    "s16le",
+    "-acodec",
+    "pcm_s16le",
+    "-ar",
+    String(SAMPLE_RATE),
+    "-ac",
+    String(CHANNELS),
+    "pipe:1",
+  );
+  const proc = spawn(FFMPEG_PATH, args, {
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  attachFfmpegLogging(proc, filePath);
+  return proc;
+}
+
+// Returns up to pcmLengthBytes of raw PCM starting at pcmOffsetBytes.
+// Pads with zero-filled silence if the source ends before the requested
+// length, so callers can honor a precomputed Content-Length.
+function pcmRangeStream(
+  filePath: string,
+  pcmOffsetBytes: number,
+  pcmLengthBytes: number,
+): ReadableStream {
+  const seekSeconds = pcmOffsetBytes / PCM_BYTES_PER_SECOND;
+  const proc = spawnPcmDecoder(filePath, seekSeconds);
+  let remaining = pcmLengthBytes;
+  let closed = false;
+  const close = (controller: ReadableStreamDefaultController<Uint8Array>) => {
+    if (closed) return;
+    closed = true;
+    try {
+      controller.close();
+    } catch {
+      /* already closed */
+    }
+  };
+
+  // Pads with zero-filled silence on EOF or stream error so the response
+  // body always matches the promised Content-Length. Otherwise Chromium
+  // reports PIPELINE_ERROR_READ on short reads.
+  const finish = (controller: ReadableStreamDefaultController<Uint8Array>) => {
+    if (closed) return;
+    if (remaining > 0) {
+      controller.enqueue(new Uint8Array(remaining));
+      remaining = 0;
+    }
+    close(controller);
+  };
+
+  // Backpressure: ffmpeg can dump tens of MB into the pipe in <100ms.
+  // Without flow control, the entire body queues into the ReadableStream
+  // buffer and Electron's protocol pipe sees close() before downstream
+  // drains, surfacing as Chromium PIPELINE_ERROR_READ. We pause stdout
+  // when the controller's queue is full and resume from `pull`.
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      proc.stdout!.on("data", (chunk: Buffer) => {
+        if (closed || remaining <= 0) return;
+        const slice =
+          chunk.length > remaining ? chunk.subarray(0, remaining) : chunk;
+        controller.enqueue(new Uint8Array(slice));
+        remaining -= slice.length;
+        if (remaining <= 0) {
+          close(controller);
+          proc.kill("SIGTERM");
+          return;
+        }
+        if ((controller.desiredSize ?? 0) <= 0) {
+          proc.stdout!.pause();
+        }
+      });
+      proc.stdout!.on("end", () => finish(controller));
+      proc.stdout!.on("error", (err) => {
+        console.error(`[ffmpeg stdout error] ${filePath}:`, err);
+        finish(controller);
+      });
+      proc.on("error", () => finish(controller));
+      proc.on("exit", () => {
+        if (!closed && remaining > 0) finish(controller);
+      });
+    },
+    pull() {
+      if (!closed && proc.stdout!.isPaused()) proc.stdout!.resume();
+    },
+    cancel() {
+      proc.kill("SIGTERM");
+    },
+  });
+}
+
+// Returns a ReadableStream covering byte range [start, end] of the
+// virtual transcoded WAV file (header + PCM).
+export function transcodeRange(
+  filePath: string,
+  durationSeconds: number,
+  start: number,
+  end: number,
+): ReadableStream {
+  const pcmTotal = pcmBytesForDuration(durationSeconds);
+  const header = buildWavHeader(pcmTotal);
+
+  const headerSlice =
+    start < WAV_HEADER_SIZE
+      ? header.subarray(start, Math.min(WAV_HEADER_SIZE, end + 1))
+      : Buffer.alloc(0);
+
+  const pcmStart = Math.max(0, start - WAV_HEADER_SIZE);
+  const pcmEnd = end - WAV_HEADER_SIZE;
+  const pcmLength = pcmEnd >= 0 ? pcmEnd - pcmStart + 1 : 0;
+
+  if (pcmLength <= 0) {
+    return new ReadableStream<Uint8Array>({
+      start(controller) {
+        if (headerSlice.length) controller.enqueue(new Uint8Array(headerSlice));
+        controller.close();
+      },
+    });
+  }
+
+  const pcm = pcmRangeStream(filePath, pcmStart, pcmLength);
+  return new ReadableStream<Uint8Array>({
+    async start(controller) {
+      if (headerSlice.length) controller.enqueue(new Uint8Array(headerSlice));
+      const reader = pcm.getReader();
+      try {
+        for (;;) {
+          const { value, done } = await reader.read();
+          if (done) break;
+          if (value) controller.enqueue(value);
+        }
+        controller.close();
+      } catch (err) {
+        controller.error(err);
+      }
+    },
+  });
+}
+
+export function transcodeToWav(filePath: string): ReadableStream {
+  const proc = spawn(
+    FFMPEG_PATH,
+    [
+      ...FFMPEG_QUIET,
+      "-i",
+      filePath,
+      "-f",
+      "wav",
+      "-acodec",
+      "pcm_s16le",
+      "-ar",
+      String(SAMPLE_RATE),
+      "-ac",
+      String(CHANNELS),
+      "pipe:1",
+    ],
+    { stdio: ["ignore", "pipe", "pipe"] },
+  );
+  attachFfmpegLogging(proc, filePath);
   return Readable.toWeb(proc.stdout!) as ReadableStream;
 }

--- a/tests/main/transcode.test.ts
+++ b/tests/main/transcode.test.ts
@@ -6,7 +6,17 @@ import { join } from "path";
 import ffmpegStatic from "ffmpeg-static";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { AUDIO_EXTENSIONS } from "../../src/main/audio-formats";
-import { needsTranscode, transcodeToWav } from "../../src/main/transcode";
+import {
+  buildWavHeader,
+  isMp4FastStart,
+  needsTranscode,
+  pcmBytesForDuration,
+  shouldTranscode,
+  transcodeRange,
+  transcodeToWav,
+  transcodedTotalSize,
+  WAV_HEADER_SIZE,
+} from "../../src/main/transcode";
 
 const FFMPEG = ffmpegStatic!;
 
@@ -15,6 +25,7 @@ interface FormatSpec {
   codec: string;
   container?: string;
   sampleRate: number;
+  extraArgs?: string[];
 }
 
 const FORMATS: FormatSpec[] = [
@@ -22,16 +33,41 @@ const FORMATS: FormatSpec[] = [
   { ext: "flac", codec: "flac", sampleRate: 44100 },
   { ext: "wav", codec: "pcm_s16le", sampleRate: 44100 },
   { ext: "ogg", codec: "libvorbis", sampleRate: 44100 },
+  { ext: "oga", codec: "libvorbis", container: "ogg", sampleRate: 44100 },
   { ext: "aac", codec: "aac", container: "adts", sampleRate: 44100 },
-  { ext: "m4a", codec: "aac", container: "ipod", sampleRate: 44100 },
+  // m4a fixture is faststart so isMp4FastStart returns true; the
+  // transcodeToWav check below works regardless of layout.
+  {
+    ext: "m4a",
+    codec: "aac",
+    container: "ipod",
+    sampleRate: 44100,
+    extraArgs: ["-movflags", "+faststart"],
+  },
   { ext: "wma", codec: "wmav2", container: "asf", sampleRate: 44100 },
   { ext: "opus", codec: "libopus", container: "ogg", sampleRate: 48000 },
+  { ext: "webm", codec: "libopus", container: "webm", sampleRate: 48000 },
   { ext: "aiff", codec: "pcm_s16be", sampleRate: 44100 },
   { ext: "aif", codec: "pcm_s16be", sampleRate: 44100 },
+  { ext: "mka", codec: "libvorbis", container: "matroska", sampleRate: 44100 },
+  { ext: "mp2", codec: "mp2", container: "mp2", sampleRate: 44100 },
 ];
+
+const NATIVE_EXTS = new Set([
+  "mp3",
+  "wav",
+  "flac",
+  "ogg",
+  "oga",
+  "opus",
+  "aac",
+  "webm",
+]);
 
 let tmp: string;
 const fixtures = new Map<string, string>();
+let m4aFastStart: string;
+let m4aSlow: string;
 
 async function drain(stream: ReadableStream): Promise<Buffer> {
   const chunks: Uint8Array[] = [];
@@ -61,6 +97,7 @@ function encode(spec: FormatSpec, outPath: string): void {
     spec.codec,
   ];
   if (spec.container) args.push("-f", spec.container);
+  if (spec.extraArgs) args.push(...spec.extraArgs);
   args.push(outPath);
   const r = spawnSync(FFMPEG, args, { stdio: "pipe" });
   if (r.status !== 0) {
@@ -77,6 +114,17 @@ beforeAll(() => {
     encode(spec, p);
     fixtures.set(spec.ext, p);
   }
+  m4aFastStart = fixtures.get("m4a")!;
+  m4aSlow = join(tmp, "moov-at-end.m4a");
+  encode(
+    {
+      ext: "m4a",
+      codec: "aac",
+      container: "ipod",
+      sampleRate: 44100,
+    },
+    m4aSlow,
+  );
 });
 
 afterAll(() => {
@@ -93,21 +141,183 @@ describe("AUDIO_EXTENSIONS coverage", () => {
 });
 
 describe("needsTranscode", () => {
-  it("returns false for native formats", () => {
-    for (const f of ["mp3", "wav", "flac", "ogg", "opus", "aac"]) {
+  it("returns false for Chromium-native formats", () => {
+    for (const f of NATIVE_EXTS) {
       expect(needsTranscode(f)).toBe(false);
     }
   });
 
   it("is case-insensitive", () => {
     expect(needsTranscode("MP3")).toBe(false);
-    expect(needsTranscode("FLAC")).toBe(false);
-    expect(needsTranscode("M4A")).toBe(true);
+    expect(needsTranscode("WEBM")).toBe(false);
+    expect(needsTranscode("WMA")).toBe(true);
   });
 
-  it("returns true for non-native formats", () => {
-    for (const f of ["m4a", "wma", "aiff", "aif", "weird"]) {
+  it("returns true for non-native formats including m4a", () => {
+    // m4a/mp4 require a runtime moov-position check (shouldTranscode);
+    // by extension alone they default to "transcode".
+    for (const f of ["m4a", "mp4", "wma", "aiff", "aif", "mka", "mp2"]) {
       expect(needsTranscode(f)).toBe(true);
+    }
+  });
+});
+
+describe("isMp4FastStart", () => {
+  it("returns true when moov precedes mdat", async () => {
+    expect(await isMp4FastStart(m4aFastStart)).toBe(true);
+  });
+
+  it("returns false when mdat precedes moov", async () => {
+    expect(await isMp4FastStart(m4aSlow)).toBe(false);
+  });
+
+  it("returns false on missing files", async () => {
+    expect(await isMp4FastStart(join(tmp, "ghost.m4a"))).toBe(false);
+  });
+
+  it("returns false on non-MP4 input", async () => {
+    expect(await isMp4FastStart(fixtures.get("mp3")!)).toBe(false);
+  });
+});
+
+describe("shouldTranscode", () => {
+  it("skips transcode for Chromium-native formats", async () => {
+    for (const ext of NATIVE_EXTS) {
+      expect(await shouldTranscode(ext, fixtures.get(ext)!)).toBe(false);
+    }
+  });
+
+  it("requires transcode for wma / aiff / mka / mp2", async () => {
+    for (const ext of ["wma", "aiff", "aif", "mka", "mp2"]) {
+      expect(await shouldTranscode(ext, fixtures.get(ext)!)).toBe(true);
+    }
+  });
+
+  it("skips transcode for faststart m4a", async () => {
+    expect(await shouldTranscode("m4a", m4aFastStart)).toBe(false);
+  });
+
+  it("requires transcode for moov-at-end m4a", async () => {
+    expect(await shouldTranscode("m4a", m4aSlow)).toBe(true);
+  });
+
+  it("is case-insensitive on the format string", async () => {
+    expect(await shouldTranscode("M4A", m4aFastStart)).toBe(false);
+    expect(await shouldTranscode("WMA", fixtures.get("wma")!)).toBe(true);
+  });
+});
+
+describe("pcmBytesForDuration / transcodedTotalSize", () => {
+  it("computes zero PCM for zero duration", () => {
+    expect(pcmBytesForDuration(0)).toBe(0);
+    expect(transcodedTotalSize(0)).toBe(WAV_HEADER_SIZE);
+  });
+
+  it("uses 176400 bytes per second for stereo s16le @ 44100Hz", () => {
+    expect(pcmBytesForDuration(1)).toBe(176_400);
+    expect(transcodedTotalSize(1)).toBe(WAV_HEADER_SIZE + 176_400);
+  });
+
+  it("rounds down to whole sample frames (4 bytes)", () => {
+    // 1 sample = 1/44100s; pick a duration whose raw byte count is not
+    // 4-aligned and confirm it's truncated to a frame boundary.
+    const d = 0.0001;
+    const raw = d * 176_400; // ≈ 17.64
+    expect(pcmBytesForDuration(d) % 4).toBe(0);
+    expect(pcmBytesForDuration(d)).toBeLessThanOrEqual(raw);
+  });
+});
+
+describe("buildWavHeader", () => {
+  it("produces a valid 44-byte RIFF/WAVE/fmt/data header", () => {
+    const pcm = 176_400;
+    const h = buildWavHeader(pcm);
+    expect(h.length).toBe(WAV_HEADER_SIZE);
+    expect(h.subarray(0, 4).toString("ascii")).toBe("RIFF");
+    expect(h.readUInt32LE(4)).toBe(36 + pcm);
+    expect(h.subarray(8, 12).toString("ascii")).toBe("WAVE");
+    expect(h.subarray(12, 16).toString("ascii")).toBe("fmt ");
+    expect(h.readUInt32LE(16)).toBe(16);
+    expect(h.readUInt16LE(20)).toBe(1); // PCM
+    expect(h.readUInt16LE(22)).toBe(2); // stereo
+    expect(h.readUInt32LE(24)).toBe(44100);
+    expect(h.readUInt32LE(28)).toBe(176_400); // byte rate
+    expect(h.readUInt16LE(32)).toBe(4); // block align
+    expect(h.readUInt16LE(34)).toBe(16); // bits per sample
+    expect(h.subarray(36, 40).toString("ascii")).toBe("data");
+    expect(h.readUInt32LE(40)).toBe(pcm);
+  });
+});
+
+describe("transcodeRange (Range/seek support)", () => {
+  // 0.2s sine fixture used for transcode tests; use it as the source.
+  const DURATION = 0.2;
+  const TOTAL_PCM = 0.2 * 176_400; // 35_280
+  const TOTAL = WAV_HEADER_SIZE + TOTAL_PCM; // 35_324
+
+  it("returns total size matching transcodedTotalSize", () => {
+    expect(transcodedTotalSize(DURATION)).toBe(TOTAL);
+  });
+
+  it("range covering only the WAV header returns header bytes", async () => {
+    const src = fixtures.get("mp3")!;
+    const buf = await drain(transcodeRange(src, DURATION, 0, 43));
+    expect(buf.length).toBe(44);
+    expect(buf.subarray(0, 4).toString("ascii")).toBe("RIFF");
+    expect(buf.subarray(8, 12).toString("ascii")).toBe("WAVE");
+    expect(buf.readUInt32LE(40)).toBe(TOTAL_PCM);
+  });
+
+  it("range covering only PCM returns exactly the requested length", async () => {
+    const src = fixtures.get("mp3")!;
+    const start = 1000;
+    const end = 5000;
+    const buf = await drain(transcodeRange(src, DURATION, start, end));
+    expect(buf.length).toBe(end - start + 1);
+  });
+
+  it("range straddling header/PCM boundary splices both sections", async () => {
+    const src = fixtures.get("mp3")!;
+    const start = 40;
+    const end = 200;
+    const buf = await drain(transcodeRange(src, DURATION, start, end));
+    expect(buf.length).toBe(end - start + 1);
+    // First 4 bytes are the tail of the data-size field (offset 40..43)
+    // followed by PCM samples.
+    expect(buf.readUInt32LE(0)).toBe(TOTAL_PCM);
+  });
+
+  it("full-file range produces a valid playable WAV", async () => {
+    const src = fixtures.get("mp3")!;
+    const buf = await drain(transcodeRange(src, DURATION, 0, TOTAL - 1));
+    expect(buf.length).toBe(TOTAL);
+    expect(buf.subarray(0, 4).toString("ascii")).toBe("RIFF");
+    expect(buf.subarray(8, 12).toString("ascii")).toBe("WAVE");
+    // PCM body should be non-silent (sine wave) for at least part of it.
+    const pcm = buf.subarray(WAV_HEADER_SIZE);
+    const nonZero = pcm.some((b) => b !== 0);
+    expect(nonZero).toBe(true);
+  });
+
+  it("pads with silence when source ends short of the requested length", async () => {
+    const src = fixtures.get("mp3")!;
+    // Claim a 2-second duration for a 0.2s source. Request the second
+    // half (mostly past EOF). pcmRangeStream must zero-pad to match
+    // the promised Content-Length.
+    const fakeDuration = 2;
+    const fakeTotal = transcodedTotalSize(fakeDuration);
+    const start = Math.floor(fakeTotal * 0.6);
+    const end = fakeTotal - 1;
+    const buf = await drain(transcodeRange(src, fakeDuration, start, end));
+    expect(buf.length).toBe(end - start + 1);
+  });
+
+  it("returns deterministic byte length regardless of seek position", async () => {
+    const src = fixtures.get("mp3")!;
+    for (const start of [0, 100, WAV_HEADER_SIZE, 1024, 8192]) {
+      const end = Math.min(start + 4095, TOTAL - 1);
+      const buf = await drain(transcodeRange(src, DURATION, start, end));
+      expect(buf.length).toBe(end - start + 1);
     }
   });
 });


### PR DESCRIPTION
## Summary

- Audio playback now seeks reliably for transcoded formats (wma, aiff, aif, mka, mp2, moov-at-end m4a) by serving a precomputed-size WAV with full Range / 206 / Content-Length support.
- Faststart m4a/mp4 (moov before mdat) detected at runtime and streamed natively — no more unnecessary transcode for the common case.
- Library scan picks up `.oga`, `.webm`, `.mka`, `.mp2`. `.oga` and `.webm` route through native playback.
- `media://` protocol privileges expanded (`standard`, `secure`, `bypassCSP`) — required for Chromium's media pipeline to honor 206 Partial Content responses, fixing `PIPELINE_ERROR_READ` on seek.

Closes #23
Closes #24

## Implementation notes

- `transcode.ts`
  - `isMp4FastStart` parses MP4 atoms in the first 64 KB to detect faststart layout.
  - `shouldTranscode(format, path)` routes m4a/mp4 by moov position; everything else via the extension-only `needsTranscode`.
  - `transcodeRange(path, duration, start, end)` builds the requested byte slice of a virtual WAV: header bytes + ffmpeg PCM via input-side `-ss`, truncated or zero-padded to match the promised `Content-Length`.
  - Backpressure: `proc.stdout` paused when controller queue is full, resumed on `pull`.
  - All ffmpeg invocations now use `-nostdin -hide_banner -loglevel error`.
- `main.ts` `mediaHandler` shares Range parsing between native and transcoded paths; falls back to plain streaming when `track.duration` is missing.

## Test plan

- [x] `pnpm test` — 80 tests pass (40 in transcode.test.ts covering all 14 supported extensions, faststart detection, Range slicing, padding on EOF)
- [x] `pnpm lint` clean
- [x] `pnpm typecheck` clean
- [x] Manual: play wma file, drag seek bar to mid-song — playback resumes from seek position without `PIPELINE_ERROR_READ`

🤖 Generated with [Claude Code](https://claude.com/claude-code)