### PR TITLE
feat(renderer): show track metadata tooltip on hover

### DIFF
--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -5,6 +5,7 @@
   import PlaylistPanel from "./components/PlaylistPanel.svelte";
   import PathsOverlay from "./components/PathsOverlay.svelte";
   import ScanOverlay from "./components/ScanOverlay.svelte";
+  import TrackTooltip from "./components/TrackTooltip.svelte";
 </script>
 
 <Toolbar />
@@ -15,3 +16,4 @@
 </main>
 <PathsOverlay />
 <ScanOverlay />
+<TrackTooltip />

--- a/src/renderer/components/LibraryPanel.svelte
+++ b/src/renderer/components/LibraryPanel.svelte
@@ -17,6 +17,11 @@
     e.stopPropagation();
     app.addToPlaylist(track);
   }
+
+  function onEnter(track: Track, e: MouseEvent): void {
+    const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+    app.setHover(track, rect);
+  }
 </script>
 
 <section id="library-panel">
@@ -40,6 +45,8 @@
         <div
           class="track-row"
           ondblclick={() => app.addToPlaylist(track)}
+          onmouseenter={(e) => onEnter(track, e)}
+          onmouseleave={() => app.clearHover()}
           role="button"
           tabindex="0"
         >

--- a/src/renderer/components/PlaylistPanel.svelte
+++ b/src/renderer/components/PlaylistPanel.svelte
@@ -1,8 +1,13 @@
 <script lang="ts">
-  import { app, formatTime } from "../state.svelte";
+  import { app, formatTime, type Track } from "../state.svelte";
 
   let dragFromIndex = $state(-1);
   let dragOverIndex = $state(-1);
+
+  function onEnter(track: Track, e: MouseEvent): void {
+    const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+    app.setHover(track, rect);
+  }
 
   function onDragStart(i: number): void {
     dragFromIndex = i;
@@ -59,6 +64,8 @@
           ondragover={(e) => onDragOver(e, i)}
           ondragleave={() => onDragLeave(i)}
           ondrop={(e) => onDrop(e, i)}
+          onmouseenter={(e) => onEnter(track, e)}
+          onmouseleave={() => app.clearHover()}
           role="listitem"
         >
           <span class="pl-drag">&#8942;</span>

--- a/src/renderer/components/TrackTooltip.svelte
+++ b/src/renderer/components/TrackTooltip.svelte
@@ -25,17 +25,42 @@
     return Math.min(Math.max(GAP, app.hoverY), max);
   });
 
-  function formatRate(hz: number): string {
-    return `${(hz / 1000).toFixed(1)} kHz`;
+  const UNKNOWN = "Unknown";
+
+  function formatRate(hz: number | null | undefined): string {
+    return hz ? `${(hz / 1000).toFixed(1)} kHz` : UNKNOWN;
   }
 
-  function formatBitrate(bps: number): string {
-    return `${Math.round(bps / 1000)} kbps`;
+  function formatBitrate(bps: number | null | undefined): string {
+    return bps ? `${Math.round(bps / 1000)} kbps` : UNKNOWN;
+  }
+
+  function strOr(v: string | null | undefined): string {
+    return v && v.trim() ? v : UNKNOWN;
+  }
+
+  function numOr(v: number | null | undefined): string {
+    return v != null ? String(v) : UNKNOWN;
+  }
+
+  function isUnknown(v: string): boolean {
+    return v === UNKNOWN;
   }
 </script>
 
 {#if app.hoveredTrack}
   {@const t = app.hoveredTrack}
+  {@const fields = [
+    { label: "Album", value: strOr(t.album) },
+    { label: "Genre", value: strOr(t.genre) },
+    { label: "Year", value: numOr(t.year) },
+    { label: "Duration", value: t.duration ? formatTime(t.duration) : UNKNOWN },
+    { label: "BPM", value: numOr(t.bpm) },
+    { label: "Format", value: t.format ? t.format.toUpperCase() : UNKNOWN },
+    { label: "Bitrate", value: formatBitrate(t.bitrate) },
+    { label: "Sample rate", value: formatRate(t.sample_rate) },
+    { label: "Plays", value: String(t.play_count ?? 0) },
+  ]}
   <div
     class="track-tooltip"
     bind:this={tooltip}
@@ -44,39 +69,15 @@
     style:width="{TOOLTIP_WIDTH}px"
     role="tooltip"
   >
-    <div class="tt-title">{t.title}</div>
-    <div class="tt-artist">{t.artist}</div>
+    <div class="tt-title">{strOr(t.title)}</div>
+    <div class="tt-artist" class:unknown={isUnknown(strOr(t.artist))}>
+      {strOr(t.artist)}
+    </div>
     <dl class="tt-meta">
-      <dt>Album</dt>
-      <dd>{t.album}</dd>
-      {#if t.genre}
-        <dt>Genre</dt>
-        <dd>{t.genre}</dd>
-      {/if}
-      {#if t.year}
-        <dt>Year</dt>
-        <dd>{t.year}</dd>
-      {/if}
-      <dt>Duration</dt>
-      <dd>{formatTime(t.duration)}</dd>
-      {#if t.bpm}
-        <dt>BPM</dt>
-        <dd>{t.bpm}</dd>
-      {/if}
-      {#if t.format}
-        <dt>Format</dt>
-        <dd>{t.format.toUpperCase()}</dd>
-      {/if}
-      {#if t.bitrate}
-        <dt>Bitrate</dt>
-        <dd>{formatBitrate(t.bitrate)}</dd>
-      {/if}
-      {#if t.sample_rate}
-        <dt>Sample rate</dt>
-        <dd>{formatRate(t.sample_rate)}</dd>
-      {/if}
-      <dt>Plays</dt>
-      <dd>{t.play_count ?? 0}</dd>
+      {#each fields as { label, value } (label)}
+        <dt>{label}</dt>
+        <dd class:unknown={isUnknown(value)}>{value}</dd>
+      {/each}
     </dl>
   </div>
 {/if}

--- a/src/renderer/components/TrackTooltip.svelte
+++ b/src/renderer/components/TrackTooltip.svelte
@@ -1,0 +1,82 @@
+<script lang="ts">
+  import { app, formatTime } from "../state.svelte";
+
+  const TOOLTIP_WIDTH = 280;
+  const GAP = 8;
+
+  let tooltip: HTMLDivElement | undefined = $state();
+  let height = $state(0);
+
+  $effect(() => {
+    if (app.hoveredTrack && tooltip) {
+      height = tooltip.offsetHeight;
+    }
+  });
+
+  let left = $derived.by(() => {
+    const x = app.hoverX + GAP;
+    const max = window.innerWidth - TOOLTIP_WIDTH - GAP;
+    if (x > max) return Math.max(GAP, app.hoverX - TOOLTIP_WIDTH - GAP);
+    return x;
+  });
+
+  let top = $derived.by(() => {
+    const max = window.innerHeight - height - GAP;
+    return Math.min(Math.max(GAP, app.hoverY), max);
+  });
+
+  function formatRate(hz: number): string {
+    return `${(hz / 1000).toFixed(1)} kHz`;
+  }
+
+  function formatBitrate(bps: number): string {
+    return `${Math.round(bps / 1000)} kbps`;
+  }
+</script>
+
+{#if app.hoveredTrack}
+  {@const t = app.hoveredTrack}
+  <div
+    class="track-tooltip"
+    bind:this={tooltip}
+    style:left="{left}px"
+    style:top="{top}px"
+    style:width="{TOOLTIP_WIDTH}px"
+    role="tooltip"
+  >
+    <div class="tt-title">{t.title}</div>
+    <div class="tt-artist">{t.artist}</div>
+    <dl class="tt-meta">
+      <dt>Album</dt>
+      <dd>{t.album}</dd>
+      {#if t.genre}
+        <dt>Genre</dt>
+        <dd>{t.genre}</dd>
+      {/if}
+      {#if t.year}
+        <dt>Year</dt>
+        <dd>{t.year}</dd>
+      {/if}
+      <dt>Duration</dt>
+      <dd>{formatTime(t.duration)}</dd>
+      {#if t.bpm}
+        <dt>BPM</dt>
+        <dd>{t.bpm}</dd>
+      {/if}
+      {#if t.format}
+        <dt>Format</dt>
+        <dd>{t.format.toUpperCase()}</dd>
+      {/if}
+      {#if t.bitrate}
+        <dt>Bitrate</dt>
+        <dd>{formatBitrate(t.bitrate)}</dd>
+      {/if}
+      {#if t.sample_rate}
+        <dt>Sample rate</dt>
+        <dd>{formatRate(t.sample_rate)}</dd>
+      {/if}
+      <dt>Plays</dt>
+      <dd>{t.play_count ?? 0}</dd>
+    </dl>
+  </div>
+{/if}

--- a/src/renderer/state.svelte.ts
+++ b/src/renderer/state.svelte.ts
@@ -1,14 +1,7 @@
-import type { ContentType, LibraryStats } from "../types";
+import type { ContentType, LibraryStats, Track } from "../types";
 import logger from "electron-log/renderer";
 
-export type Track = {
-  id: number;
-  title: string;
-  artist: string;
-  album: string;
-  duration: number;
-  play_count: number;
-};
+export type { Track };
 
 const AUTO_PLAYLIST_BUFFER = 5;
 
@@ -35,6 +28,10 @@ export class AppState {
   volume = $state(1);
   currentTime = $state(0);
   duration = $state(0);
+
+  hoveredTrack = $state<Track | null>(null);
+  hoverX = $state(0);
+  hoverY = $state(0);
 
   audio: HTMLAudioElement;
 
@@ -204,6 +201,16 @@ export class AppState {
       const tracks = await window.api.generatePlaylist(count);
       this.playlist.push(...tracks);
     }
+  }
+
+  setHover(track: Track, rect: DOMRect): void {
+    this.hoveredTrack = track;
+    this.hoverX = rect.right;
+    this.hoverY = rect.top;
+  }
+
+  clearHover(): void {
+    this.hoveredTrack = null;
   }
 
   seekToPct(pct: number): void {

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -665,6 +665,12 @@ body {
   word-break: break-word;
 }
 
+.track-tooltip .unknown {
+  color: var(--text-secondary);
+  font-style: italic;
+  opacity: 0.7;
+}
+
 /* --- Scrollbar --- */
 
 ::-webkit-scrollbar {

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -616,6 +616,55 @@ body {
   transition: width 0.2s;
 }
 
+/* --- Track Tooltip --- */
+
+.track-tooltip {
+  position: fixed;
+  z-index: 200;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 12px 14px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.5);
+  font-size: 12px;
+  pointer-events: none;
+}
+
+.track-tooltip .tt-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-primary);
+  word-break: break-word;
+}
+
+.track-tooltip .tt-artist {
+  font-size: 12px;
+  color: var(--accent);
+  margin-bottom: 8px;
+  word-break: break-word;
+}
+
+.track-tooltip .tt-meta {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  column-gap: 10px;
+  row-gap: 3px;
+}
+
+.track-tooltip .tt-meta dt {
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  font-size: 10px;
+  letter-spacing: 0.5px;
+  align-self: center;
+}
+
+.track-tooltip .tt-meta dd {
+  color: var(--text-primary);
+  font-variant-numeric: tabular-nums;
+  word-break: break-word;
+}
+
 /* --- Scrollbar --- */
 
 ::-webkit-scrollbar {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,20 @@
 export type ContentType = "music" | "commercial" | "jingle";
 
+export interface Track {
+  id: number;
+  title: string;
+  artist: string;
+  album: string;
+  duration: number;
+  play_count: number;
+  genre?: string | null;
+  year?: number | null;
+  bpm?: number | null;
+  sample_rate?: number | null;
+  bitrate?: number | null;
+  format?: string;
+}
+
 export interface LibraryStats {
   totalTracks: number;
   totalArtists: number;


### PR DESCRIPTION
Closes #32.

## Summary
- Hovering a row in the library or playlist surfaces a floating tooltip with album, genre, year, duration, BPM, format, bitrate, sample rate, and play count
- Every field renders unconditionally — missing values display a muted italic **Unknown** so the tooltip shape stays constant and gaps in the scan are visible
- Metadata already lives in SQLite via `music-metadata` ingest; only the renderer side was missing
- Shared `Track` type lifted into `src/types.ts` so renderer and main agree; renderer state re-exports it

## Test plan
- [x] `pnpm dev` — hover library and playlist rows; tooltip appears anchored to row's right edge with all 9 fields populated
- [x] Hover near right viewport edge — tooltip flips to row's left side instead of overflowing
- [x] Move quickly between rows — tooltip follows without flicker; leaving list clears it
- [x] Track with sparse metadata (no genre/year/bpm) — those rows show italic "Unknown" instead of disappearing

🤖 Generated with [Claude Code](https://claude.com/claude-code)