### PR TITLE
refactor(playlist): split current track from queue

### DIFF
--- a/e2e/playback.spec.ts
+++ b/e2e/playback.spec.ts
@@ -20,8 +20,10 @@ test.describe("playback", () => {
 
     await win.locator("#track-list .btn-play-track").first().click();
 
-    await waitForPlaylistCount(win, 1);
     await expect(win.locator("#np-title")).toHaveText("first-song");
+    await expect(win.locator("#playlist .empty")).toContainText(
+      "Playlist empty",
+    );
     await win.waitForFunction(() => {
       const a = document.getElementById("audio") as HTMLAudioElement;
       return !!a.src && a.src.startsWith("media://track/");
@@ -76,7 +78,10 @@ test.describe("playback", () => {
     expect(hasSrc).toBe(false);
   });
 
-  test("next/prev navigate the playlist", async ({ launch, library }) => {
+  test("next consumes queue head; prev restarts current", async ({
+    launch,
+    library,
+  }) => {
     const fx = await library({
       music: [
         { name: "song-a", durationSec: 1 },
@@ -100,32 +105,67 @@ test.describe("playback", () => {
     await waitForPlaylistCount(win, 3);
 
     await win.locator("#playlist .playlist-row").first().dblclick();
-    await win.waitForFunction(
-      () =>
-        document
-          .querySelector("#playlist .playlist-row.active")
-          ?.textContent?.includes("song-a") ?? false,
-    );
+    await expect(win.locator("#np-title")).toHaveText("song-a");
+    await expect(win.locator("#playlist .playlist-row")).toHaveCount(2);
 
     await win.click("#btn-next");
-    await win.waitForFunction(
-      () =>
-        document
-          .querySelector("#playlist .playlist-row.active")
-          ?.textContent?.includes("song-b") ?? false,
-    );
+    await expect(win.locator("#np-title")).toHaveText("song-b");
+    await expect(win.locator("#playlist .playlist-row")).toHaveCount(1);
 
     await win.evaluate(() => {
       const a = document.getElementById("audio") as HTMLAudioElement;
-      a.currentTime = 0;
+      a.currentTime = 5;
     });
     await win.click("#btn-prev");
-    await win.waitForFunction(
-      () =>
-        document
-          .querySelector("#playlist .playlist-row.active")
-          ?.textContent?.includes("song-a") ?? false,
+    await expect(win.locator("#np-title")).toHaveText("song-b");
+    const t = await win.evaluate(
+      () => (document.getElementById("audio") as HTMLAudioElement).currentTime,
     );
+    expect(t).toBe(0);
+  });
+
+  test("clearing playlist keeps current track playing", async ({
+    launch,
+    library,
+  }) => {
+    const fx = await library({
+      music: [
+        { name: "keep-playing", durationSec: 1 },
+        { name: "queued-1", durationSec: 1 },
+        { name: "queued-2", durationSec: 1 },
+      ],
+    });
+    const { win } = await launch({ musicPaths: [fx.musicDir] });
+
+    await clickScan(win);
+    await waitForTrackCount(win, 3);
+    await win.evaluate(() => {
+      (document.getElementById("audio") as HTMLAudioElement).muted = true;
+    });
+
+    const addButtons = win.locator("#track-list .btn-add");
+    const count = await addButtons.count();
+    for (let i = 0; i < count; i++) {
+      await addButtons.nth(i).click();
+    }
+    await waitForPlaylistCount(win, 3);
+
+    await win.locator("#playlist .playlist-row").first().dblclick();
+    await expect(win.locator("#np-title")).toHaveText("keep-playing");
+    await win.waitForFunction(() => {
+      const a = document.getElementById("audio") as HTMLAudioElement;
+      return a.paused === false;
+    });
+
+    await win.click("#btn-clear-playlist");
+    await expect(win.locator("#playlist .empty")).toContainText(
+      "Playlist empty",
+    );
+    await expect(win.locator("#np-title")).toHaveText("keep-playing");
+    const paused = await win.evaluate(
+      () => (document.getElementById("audio") as HTMLAudioElement).paused,
+    );
+    expect(paused).toBe(false);
   });
 
   test("volume slider updates audio volume", async ({ launch, library }) => {

--- a/src/renderer/components/PlaylistPanel.svelte
+++ b/src/renderer/components/PlaylistPanel.svelte
@@ -53,7 +53,6 @@
       {#each app.playlist as track, i (i + "-" + track.id)}
         <div
           class="playlist-row"
-          class:active={i === app.currentIndex}
           class:dragging={i === dragFromIndex}
           class:drag-over={i === dragOverIndex && i !== dragFromIndex}
           draggable="true"

--- a/src/renderer/state.svelte.ts
+++ b/src/renderer/state.svelte.ts
@@ -21,7 +21,7 @@ export class AppState {
   scanTotal = $state(0);
 
   playlist = $state<Track[]>([]);
-  currentIndex = $state(-1);
+  currentTrack = $state<Track | null>(null);
   autoPlaylistActive = $state(false);
   autoAdvance = $state(true);
   isPlaying = $state(false);
@@ -50,7 +50,7 @@ export class AppState {
       this.duration =
         isFinite(this.audio.duration) && this.audio.duration > 0
           ? this.audio.duration
-          : (this.playlist[this.currentIndex]?.duration ?? 0);
+          : (this.currentTrack?.duration ?? 0);
     });
     this.audio.addEventListener("ended", () => {
       void this.handleEnded();
@@ -68,12 +68,6 @@ export class AppState {
       this.scanProcessed = processed;
       this.scanTotal = total;
     });
-  }
-
-  get currentTrack(): Track | null {
-    return this.currentIndex >= 0
-      ? (this.playlist[this.currentIndex] ?? null)
-      : null;
   }
 
   get progressPct(): number {
@@ -99,42 +93,31 @@ export class AppState {
   }
 
   playNow(track: Track): void {
-    this.addToPlaylist(track);
-    this.playIndex(this.playlist.length - 1);
+    this.playTrack(track);
   }
 
   removeFromPlaylist(index: number): void {
     this.playlist.splice(index, 1);
-    if (index < this.currentIndex) {
-      this.currentIndex--;
-    } else if (index === this.currentIndex) {
-      this.stop();
-      this.currentIndex = -1;
-    }
   }
 
   movePlaylistItem(from: number, to: number): void {
     if (from === to) return;
     const [item] = this.playlist.splice(from, 1);
     this.playlist.splice(to, 0, item);
-    if (this.currentIndex === from) {
-      this.currentIndex = to;
-    } else if (from < this.currentIndex && to >= this.currentIndex) {
-      this.currentIndex--;
-    } else if (from > this.currentIndex && to <= this.currentIndex) {
-      this.currentIndex++;
-    }
   }
 
   clearPlaylist(): void {
-    this.stop();
     this.playlist.length = 0;
   }
 
   playIndex(index: number): void {
     if (index < 0 || index >= this.playlist.length) return;
-    this.currentIndex = index;
-    const track = this.playlist[index];
+    const [track] = this.playlist.splice(index, 1);
+    this.playTrack(track);
+  }
+
+  private playTrack(track: Track): void {
+    this.currentTrack = track;
     this.audio.src = window.api.getMediaUrl(track.id);
     void this.audio.play();
     void window.api.trackPlayed(track.id);
@@ -143,7 +126,7 @@ export class AppState {
   }
 
   togglePlay(): void {
-    if (this.currentIndex === -1) {
+    if (!this.currentTrack) {
       if (this.playlist.length > 0) this.playIndex(0);
       return;
     }
@@ -158,7 +141,7 @@ export class AppState {
     this.audio.pause();
     this.audio.removeAttribute("src");
     this.audio.load();
-    this.currentIndex = -1;
+    this.currentTrack = null;
     this.autoPlaylistActive = false;
     this.currentTime = 0;
     this.duration = 0;
@@ -166,17 +149,11 @@ export class AppState {
   }
 
   next(): void {
-    if (this.currentIndex < this.playlist.length - 1) {
-      this.playIndex(this.currentIndex + 1);
-    }
+    if (this.playlist.length > 0) this.playIndex(0);
   }
 
   prev(): void {
-    if (this.audio.currentTime > 3) {
-      this.audio.currentTime = 0;
-    } else if (this.currentIndex > 0) {
-      this.playIndex(this.currentIndex - 1);
-    }
+    if (this.currentTrack) this.audio.currentTime = 0;
   }
 
   toggleMode(): void {
@@ -186,18 +163,18 @@ export class AppState {
   toggleAutoPlaylist(): void {
     this.autoPlaylistActive = !this.autoPlaylistActive;
     if (this.autoPlaylistActive) {
-      void this.maybeRefillPlaylist();
-      if (this.currentIndex === -1 && this.playlist.length > 0) {
+      if (!this.currentTrack && this.playlist.length > 0) {
         this.playIndex(0);
+      } else {
+        void this.maybeRefillPlaylist();
       }
     }
   }
 
   async maybeRefillPlaylist(): Promise<void> {
     if (!this.autoPlaylistActive) return;
-    const remaining = this.playlist.length - this.currentIndex - 1;
-    if (remaining < AUTO_PLAYLIST_BUFFER) {
-      const count = AUTO_PLAYLIST_BUFFER - remaining;
+    if (this.playlist.length < AUTO_PLAYLIST_BUFFER) {
+      const count = AUTO_PLAYLIST_BUFFER - this.playlist.length;
       const tracks = await window.api.generatePlaylist(count);
       this.playlist.push(...tracks);
     }
@@ -253,13 +230,11 @@ export class AppState {
 
   private async handleEnded(): Promise<void> {
     if (!this.autoAdvance) return;
-    if (this.currentIndex < this.playlist.length - 1) {
-      this.playIndex(this.currentIndex + 1);
+    if (this.playlist.length > 0) {
+      this.playIndex(0);
     } else if (this.autoPlaylistActive) {
       await this.maybeRefillPlaylist();
-      if (this.currentIndex < this.playlist.length - 1) {
-        this.playIndex(this.currentIndex + 1);
-      }
+      if (this.playlist.length > 0) this.playIndex(0);
     } else {
       this.stop();
     }

--- a/tests/renderer/state.test.ts
+++ b/tests/renderer/state.test.ts
@@ -116,40 +116,22 @@ describe("AppState playlist mutations", () => {
     expect(app.playlist[1].id).toBe(2);
   });
 
-  it("removeFromPlaylist decrements currentIndex when removing before current", () => {
+  it("removeFromPlaylist splices the entry without touching currentTrack", () => {
     app.addToPlaylist(t(1));
     app.addToPlaylist(t(2));
     app.addToPlaylist(t(3));
-    app.currentIndex = 2;
+    app.currentTrack = t(99);
     app.removeFromPlaylist(0);
-    expect(app.playlist.length).toBe(2);
-    expect(app.currentIndex).toBe(1);
+    expect(app.playlist.map((x) => x.id)).toEqual([2, 3]);
+    expect(app.currentTrack?.id).toBe(99);
   });
 
-  it("removeFromPlaylist stops playback when removing the current track", () => {
+  it("clearPlaylist empties the queue but leaves currentTrack playing", () => {
     app.addToPlaylist(t(1));
-    app.addToPlaylist(t(2));
-    app.currentIndex = 1;
-    app.removeFromPlaylist(1);
-    expect(app.currentIndex).toBe(-1);
-  });
-
-  it("removeFromPlaylist leaves currentIndex alone when removing after current", () => {
-    app.addToPlaylist(t(1));
-    app.addToPlaylist(t(2));
-    app.addToPlaylist(t(3));
-    app.currentIndex = 0;
-    app.removeFromPlaylist(2);
-    expect(app.playlist.length).toBe(2);
-    expect(app.currentIndex).toBe(0);
-  });
-
-  it("clearPlaylist empties and resets currentIndex", () => {
-    app.addToPlaylist(t(1));
-    app.currentIndex = 0;
+    app.currentTrack = t(99);
     app.clearPlaylist();
     expect(app.playlist.length).toBe(0);
-    expect(app.currentIndex).toBe(-1);
+    expect(app.currentTrack?.id).toBe(99);
   });
 
   it("movePlaylistItem reorders entries", () => {
@@ -158,36 +140,6 @@ describe("AppState playlist mutations", () => {
     app.addToPlaylist(t(3));
     app.movePlaylistItem(0, 2);
     expect(app.playlist.map((x) => x.id)).toEqual([2, 3, 1]);
-  });
-
-  it("movePlaylistItem follows the playing track", () => {
-    app.addToPlaylist(t(1));
-    app.addToPlaylist(t(2));
-    app.addToPlaylist(t(3));
-    app.currentIndex = 0;
-    app.movePlaylistItem(0, 2);
-    expect(app.currentIndex).toBe(2);
-    expect(app.playlist[app.currentIndex].id).toBe(1);
-  });
-
-  it("movePlaylistItem decrements currentIndex when an earlier item moves past it", () => {
-    app.addToPlaylist(t(1));
-    app.addToPlaylist(t(2));
-    app.addToPlaylist(t(3));
-    app.currentIndex = 1;
-    app.movePlaylistItem(0, 2);
-    expect(app.playlist[app.currentIndex].id).toBe(2);
-    expect(app.currentIndex).toBe(0);
-  });
-
-  it("movePlaylistItem increments currentIndex when a later item moves before it", () => {
-    app.addToPlaylist(t(1));
-    app.addToPlaylist(t(2));
-    app.addToPlaylist(t(3));
-    app.currentIndex = 1;
-    app.movePlaylistItem(2, 0);
-    expect(app.playlist[app.currentIndex].id).toBe(2);
-    expect(app.currentIndex).toBe(2);
   });
 
   it("movePlaylistItem is a no-op when from === to", () => {
@@ -205,10 +157,11 @@ describe("AppState playback control", () => {
     app = makeApp();
   });
 
-  it("playIndex sets src, calls trackPlayed, updates state and document.title", () => {
+  it("playIndex pulls track out of playlist into currentTrack and plays it", () => {
     app.addToPlaylist(t(7, { title: "Song", artist: "Band" }));
     app.playIndex(0);
-    expect(app.currentIndex).toBe(0);
+    expect(app.currentTrack?.id).toBe(7);
+    expect(app.playlist.length).toBe(0);
     expect(app.audio.getAttribute("src")).toBe("media://track/7");
     expect(api.trackPlayed).toHaveBeenCalledWith(7);
     expect(document.title).toBe("Song - Band | DiodeDJ");
@@ -216,56 +169,47 @@ describe("AppState playback control", () => {
 
   it("playIndex out of range is a no-op", () => {
     app.playIndex(0);
-    expect(app.currentIndex).toBe(-1);
+    expect(app.currentTrack).toBeNull();
     expect(api.trackPlayed).not.toHaveBeenCalled();
   });
 
-  it("currentTrack reflects currentIndex", () => {
-    expect(app.currentTrack).toBeNull();
-    app.addToPlaylist(t(1));
-    app.addToPlaylist(t(2));
-    app.currentIndex = 1;
-    expect(app.currentTrack?.id).toBe(2);
+  it("playNow plays directly without enqueuing", () => {
+    app.playNow(t(5));
+    expect(app.currentTrack?.id).toBe(5);
+    expect(app.playlist.length).toBe(0);
   });
 
-  it("next advances when not at end", () => {
+  it("next plays the next queued track", () => {
     app.addToPlaylist(t(1));
     app.addToPlaylist(t(2));
-    app.currentIndex = 0;
     app.next();
-    expect(app.currentIndex).toBe(1);
+    expect(app.currentTrack?.id).toBe(1);
+    expect(app.playlist.map((x) => x.id)).toEqual([2]);
   });
 
-  it("next at end is a no-op", () => {
-    app.addToPlaylist(t(1));
-    app.currentIndex = 0;
+  it("next is a no-op when playlist empty", () => {
+    app.currentTrack = t(99);
     app.next();
-    expect(app.currentIndex).toBe(0);
+    expect(app.currentTrack?.id).toBe(99);
   });
 
-  it("prev within 3s of start jumps to previous track", () => {
-    app.addToPlaylist(t(1));
-    app.addToPlaylist(t(2));
-    app.currentIndex = 1;
-    defineMutableCurrentTime(app.audio, 1);
-    app.prev();
-    expect(app.currentIndex).toBe(0);
-  });
-
-  it("prev after 3s seeks to start of current track", () => {
-    app.addToPlaylist(t(1));
-    app.addToPlaylist(t(2));
-    app.currentIndex = 1;
+  it("prev seeks to start of current track", () => {
+    app.currentTrack = t(1);
     defineMutableCurrentTime(app.audio, 5);
     app.prev();
-    expect(app.currentIndex).toBe(1);
     expect(app.audio.currentTime).toBe(0);
   });
 
-  it("togglePlay starts at index 0 when nothing playing and playlist non-empty", () => {
+  it("prev is a no-op when no current track", () => {
+    defineMutableCurrentTime(app.audio, 5);
+    app.prev();
+    expect(app.audio.currentTime).toBe(5);
+  });
+
+  it("togglePlay starts head of queue when nothing playing and playlist non-empty", () => {
     app.addToPlaylist(t(3));
     app.togglePlay();
-    expect(app.currentIndex).toBe(0);
+    expect(app.currentTrack?.id).toBe(3);
     expect(api.trackPlayed).toHaveBeenCalledWith(3);
   });
 
@@ -281,7 +225,7 @@ describe("AppState playback control", () => {
     app.addToPlaylist(t(9));
     app.toggleAutoPlaylist();
     expect(app.autoPlaylistActive).toBe(true);
-    expect(app.currentIndex).toBe(0);
+    expect(app.currentTrack?.id).toBe(9);
   });
 
   it("toggleAutoPlaylist deactivates without touching playback", () => {
@@ -290,14 +234,14 @@ describe("AppState playback control", () => {
     expect(app.autoPlaylistActive).toBe(false);
   });
 
-  it("stop clears index, autoPlaylist flag, time/duration and title", () => {
+  it("stop clears currentTrack, autoPlaylist flag, time/duration and title", () => {
     app.addToPlaylist(t(5));
     app.playIndex(0);
     app.autoPlaylistActive = true;
     app.currentTime = 12;
     app.duration = 200;
     app.stop();
-    expect(app.currentIndex).toBe(-1);
+    expect(app.currentTrack).toBeNull();
     expect(app.autoPlaylistActive).toBe(false);
     expect(app.currentTime).toBe(0);
     expect(app.duration).toBe(0);
@@ -455,7 +399,6 @@ describe("AppState auto-playlist refill", () => {
   it("does nothing when remaining buffer is already met", async () => {
     app.autoPlaylistActive = true;
     for (let i = 0; i < 10; i++) app.addToPlaylist(t(i));
-    app.currentIndex = 0;
     await app.maybeRefillPlaylist();
     expect(api.generatePlaylist).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary
- Store now-playing track as a separate `currentTrack` state field instead of `currentIndex` into the playlist.
- Playlist becomes an upcoming-queue only — `playIndex`/`next` splice the chosen track out before playing.
- `clearPlaylist()` empties the queue without interrupting playback.

## Notes
- `prev` simplifies to "restart current track"; no history is kept now that played tracks are removed from the queue.
- Tests rewritten to cover the new semantics.

Closes #19
Refs #33

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test -- run` (75 passed)
- [x] Manual: clear playlist mid-playback, confirm audio keeps playing
- [x] Manual: double-click queued track, confirm it plays and disappears from queue

🤖 Generated with [Claude Code](https://claude.com/claude-code)