### PR TITLE
feat(renderer): history tab in the playlist panel

### DIFF
--- a/e2e/playlist.spec.ts
+++ b/e2e/playlist.spec.ts
@@ -19,7 +19,7 @@ test.describe("playlist", () => {
     await rows.nth(1).dblclick();
     await rows.nth(2).dblclick();
     await waitForPlaylistCount(win, 3);
-    await expect(win.locator("#playlist-count")).toHaveText("(3)");
+    await expect(win.locator(".pl-tab").first()).toContainText("(3)");
 
     await win
       .locator("#playlist .playlist-row")
@@ -27,13 +27,67 @@ test.describe("playlist", () => {
       .locator(".btn-remove")
       .click();
     await expect(win.locator("#playlist .playlist-row")).toHaveCount(2);
-    await expect(win.locator("#playlist-count")).toHaveText("(2)");
+    await expect(win.locator(".pl-tab").first()).toContainText("(2)");
 
     await win.click("#btn-clear-playlist");
     await expect(win.locator("#playlist .empty")).toContainText(
       "Playlist empty",
     );
-    await expect(win.locator("#playlist-count")).toHaveText("(0)");
+    await expect(win.locator(".pl-tab").first()).toContainText("(0)");
+  });
+
+  test("history tab lists played tracks newest-first; dblclick re-queues; clear scoped to active tab", async ({
+    launch,
+    library,
+  }) => {
+    const fx = await library({
+      music: [
+        { name: "hist-a", durationSec: 30 },
+        { name: "hist-b", durationSec: 30 },
+        { name: "hist-c", durationSec: 30 },
+      ],
+    });
+    const { win } = await launch({ musicPaths: [fx.musicDir] });
+
+    await clickScan(win);
+    await waitForTrackCount(win, 3);
+    await win.evaluate(() => {
+      (document.getElementById("audio") as HTMLAudioElement).muted = true;
+    });
+
+    const trackRows = win.locator("#track-list .track-row");
+    await trackRows.nth(0).dblclick();
+    await trackRows.nth(1).dblclick();
+    await trackRows.nth(2).dblclick();
+    await waitForPlaylistCount(win, 3);
+
+    await win.locator("#playlist .playlist-row").first().dblclick();
+    await expect(win.locator("#np-title")).toHaveText("hist-a");
+    await win.click("#btn-next");
+    await expect(win.locator("#np-title")).toHaveText("hist-b");
+    await win.click("#btn-next");
+    await expect(win.locator("#np-title")).toHaveText("hist-c");
+
+    const historyTab = win.locator(".pl-tab").nth(1);
+    await expect(historyTab).toContainText("(2)");
+    await historyTab.click();
+
+    const historyRows = win.locator("#history .playlist-row");
+    await expect(historyRows).toHaveCount(2);
+    await expect(historyRows.nth(0)).toContainText("hist-b");
+    await expect(historyRows.nth(1)).toContainText("hist-a");
+
+    await historyRows.nth(0).dblclick();
+    await win.locator(".pl-tab").first().click();
+    await expect(win.locator("#playlist .playlist-row")).toHaveCount(1);
+    await expect(win.locator("#playlist .playlist-row")).toContainText(
+      "hist-b",
+    );
+
+    await win.locator(".pl-tab").nth(1).click();
+    await win.click("#btn-clear-playlist");
+    await expect(win.locator("#history .empty")).toContainText("History empty");
+    await expect(win.locator("#np-title")).toHaveText("hist-c");
   });
 
   test("auto-playlist toggle fills the buffer from the library", async ({

--- a/src/renderer/components/PlaylistPanel.svelte
+++ b/src/renderer/components/PlaylistPanel.svelte
@@ -33,55 +33,110 @@
     if (dragFromIndex === -1 || dragFromIndex === i) return;
     app.movePlaylistItem(dragFromIndex, i);
   }
+
+  function onClear(): void {
+    if (app.playlistTab === "queue") app.clearPlaylist();
+    else app.clearHistory();
+  }
 </script>
 
 <section id="playlist-panel">
   <div id="playlist-header">
-    <h2>
-      Playlist <span id="playlist-count">({app.playlist.length})</span>
-    </h2>
+    <div id="playlist-tabs" role="tablist">
+      <button
+        class="pl-tab"
+        class:active={app.playlistTab === "queue"}
+        role="tab"
+        aria-selected={app.playlistTab === "queue"}
+        onclick={() => (app.playlistTab = "queue")}
+      >
+        Up next <span class="pl-tab-count">({app.playlist.length})</span>
+      </button>
+      <button
+        class="pl-tab"
+        class:active={app.playlistTab === "history"}
+        role="tab"
+        aria-selected={app.playlistTab === "history"}
+        onclick={() => (app.playlistTab = "history")}
+      >
+        History <span class="pl-tab-count">({app.history.length})</span>
+      </button>
+    </div>
     <button
       id="btn-clear-playlist"
-      title="Clear playlist"
-      onclick={() => app.clearPlaylist()}>Clear</button
+      title={app.playlistTab === "queue" ? "Clear queue" : "Clear history"}
+      onclick={onClear}>Clear</button
     >
   </div>
-  <div id="playlist">
-    {#if app.playlist.length === 0}
-      <div class="empty">Playlist empty</div>
-    {:else}
-      {#each app.playlist as track, i (i + "-" + track.id)}
-        <div
-          class="playlist-row"
-          class:dragging={i === dragFromIndex}
-          class:drag-over={i === dragOverIndex && i !== dragFromIndex}
-          draggable="true"
-          data-index={i}
-          ondblclick={() => app.playIndex(i)}
-          ondragstart={() => onDragStart(i)}
-          ondragend={onDragEnd}
-          ondragover={(e) => onDragOver(e, i)}
-          ondragleave={() => onDragLeave(i)}
-          ondrop={(e) => onDrop(e, i)}
-          onmouseenter={(e) => onEnter(track, e)}
-          onmouseleave={() => app.clearHover()}
-          role="listitem"
-        >
-          <span class="pl-drag">&#8942;</span>
-          <span class="pl-num">{i + 1}</span>
-          <span class="pl-title">{track.title}</span>
-          <span class="pl-artist">{track.artist}</span>
-          <span class="pl-duration">{formatTime(track.duration)}</span>
-          <button
-            class="btn-remove"
-            title="Remove"
-            onclick={(e) => {
-              e.stopPropagation();
-              app.removeFromPlaylist(i);
-            }}>&#10005;</button
+
+  {#if app.playlistTab === "queue"}
+    <div id="playlist">
+      {#if app.playlist.length === 0}
+        <div class="empty">Playlist empty</div>
+      {:else}
+        {#each app.playlist as track, i (i + "-" + track.id)}
+          <div
+            class="playlist-row"
+            class:dragging={i === dragFromIndex}
+            class:drag-over={i === dragOverIndex && i !== dragFromIndex}
+            draggable="true"
+            data-index={i}
+            ondblclick={() => app.playIndex(i)}
+            ondragstart={() => onDragStart(i)}
+            ondragend={onDragEnd}
+            ondragover={(e) => onDragOver(e, i)}
+            ondragleave={() => onDragLeave(i)}
+            ondrop={(e) => onDrop(e, i)}
+            onmouseenter={(e) => onEnter(track, e)}
+            onmouseleave={() => app.clearHover()}
+            role="listitem"
           >
-        </div>
-      {/each}
-    {/if}
-  </div>
+            <span class="pl-drag">&#8942;</span>
+            <span class="pl-num">{i + 1}</span>
+            <span class="pl-title">{track.title}</span>
+            <span class="pl-artist">{track.artist}</span>
+            <span class="pl-duration">{formatTime(track.duration)}</span>
+            <button
+              class="btn-remove"
+              title="Remove"
+              onclick={(e) => {
+                e.stopPropagation();
+                app.removeFromPlaylist(i);
+              }}>&#10005;</button
+            >
+          </div>
+        {/each}
+      {/if}
+    </div>
+  {:else}
+    <div id="history">
+      {#if app.historyDisplay.length === 0}
+        <div class="empty">History empty</div>
+      {:else}
+        {#each app.historyDisplay as track, i (i + "-" + track.id)}
+          <div
+            class="playlist-row history-row"
+            data-index={i}
+            ondblclick={() => app.requeueFromHistory(i)}
+            onmouseenter={(e) => onEnter(track, e)}
+            onmouseleave={() => app.clearHover()}
+            role="listitem"
+          >
+            <span class="pl-num">{i + 1}</span>
+            <span class="pl-title">{track.title}</span>
+            <span class="pl-artist">{track.artist}</span>
+            <span class="pl-duration">{formatTime(track.duration)}</span>
+            <button
+              class="btn-remove"
+              title="Remove from history"
+              onclick={(e) => {
+                e.stopPropagation();
+                app.removeFromHistory(i);
+              }}>&#10005;</button
+            >
+          </div>
+        {/each}
+      {/if}
+    </div>
+  {/if}
 </section>

--- a/src/renderer/state.svelte.ts
+++ b/src/renderer/state.svelte.ts
@@ -4,10 +4,14 @@ import logger from "electron-log/renderer";
 export type { Track };
 
 const AUTO_PLAYLIST_BUFFER = 5;
+const HISTORY_CAP = 100;
+
+export type PlaylistTab = "queue" | "history";
 
 export class AppState {
   searchQuery = $state("");
   activeTab = $state<ContentType>("music");
+  playlistTab = $state<PlaylistTab>("queue");
   tracks = $state<Track[]>([]);
   stats = $state<LibraryStats | null>(null);
   paths = $state<Record<ContentType, string[]>>({
@@ -118,8 +122,34 @@ export class AppState {
   }
 
   private playTrack(track: Track): void {
-    if (this.currentTrack) this.history.push(this.currentTrack);
+    if (this.currentTrack) {
+      this.history.push(this.currentTrack);
+      if (this.history.length > HISTORY_CAP) {
+        this.history.splice(0, this.history.length - HISTORY_CAP);
+      }
+    }
     this.setCurrent(track);
+  }
+
+  get historyDisplay(): Track[] {
+    return this.history.slice().reverse();
+  }
+
+  removeFromHistory(displayIndex: number): void {
+    const i = this.history.length - 1 - displayIndex;
+    if (i < 0 || i >= this.history.length) return;
+    this.history.splice(i, 1);
+  }
+
+  clearHistory(): void {
+    this.history.length = 0;
+  }
+
+  requeueFromHistory(displayIndex: number): void {
+    const i = this.history.length - 1 - displayIndex;
+    const track = this.history[i];
+    if (!track) return;
+    this.playlist.push(track);
   }
 
   private setCurrent(track: Track): void {

--- a/src/renderer/state.svelte.ts
+++ b/src/renderer/state.svelte.ts
@@ -178,7 +178,6 @@ export class AppState {
     this.audio.removeAttribute("src");
     this.audio.load();
     this.currentTrack = null;
-    this.history.length = 0;
     this.autoPlaylistActive = false;
     this.currentTime = 0;
     this.duration = 0;

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -168,6 +168,42 @@ body {
   color: var(--text-secondary);
 }
 
+#playlist-tabs {
+  display: flex;
+  gap: 4px;
+  padding: 6px 8px;
+}
+
+.pl-tab {
+  padding: 4px 10px;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 12px;
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.pl-tab:hover {
+  color: var(--text-primary);
+}
+
+.pl-tab.active {
+  background: var(--bg-tertiary);
+  border-color: var(--border);
+  color: var(--text-primary);
+}
+
+.pl-tab-count {
+  margin-left: 4px;
+  font-weight: 400;
+  color: var(--text-secondary);
+  font-variant-numeric: tabular-nums;
+}
+
 #btn-clear-playlist {
   padding: 3px 10px;
   background: var(--bg-tertiary);
@@ -184,10 +220,15 @@ body {
 }
 
 #track-list,
-#playlist {
+#playlist,
+#history {
   flex: 1;
   overflow-y: auto;
   padding: 4px 0;
+}
+
+.history-row {
+  cursor: pointer;
 }
 
 /* --- Track Rows --- */

--- a/tests/renderer/state.test.ts
+++ b/tests/renderer/state.test.ts
@@ -333,7 +333,7 @@ describe("AppState playback control", () => {
     expect(app.autoPlaylistActive).toBe(false);
   });
 
-  it("stop clears currentTrack, history, autoPlaylist flag, time/duration and title", () => {
+  it("stop clears currentTrack, autoPlaylist flag, time/duration and title but preserves history", () => {
     app.addToPlaylist(t(5));
     app.addToPlaylist(t(6));
     app.playIndex(0);
@@ -344,7 +344,7 @@ describe("AppState playback control", () => {
     app.duration = 200;
     app.stop();
     expect(app.currentTrack).toBeNull();
-    expect(app.history.length).toBe(0);
+    expect(app.history.map((x) => x.id)).toEqual([5]);
     expect(app.autoPlaylistActive).toBe(false);
     expect(app.currentTime).toBe(0);
     expect(app.duration).toBe(0);

--- a/tests/renderer/state.test.ts
+++ b/tests/renderer/state.test.ts
@@ -150,6 +150,68 @@ describe("AppState playlist mutations", () => {
   });
 });
 
+describe("AppState history view", () => {
+  let app: AppState;
+  beforeEach(() => {
+    resetApi();
+    app = makeApp();
+  });
+
+  it("playlistTab defaults to queue", () => {
+    expect(app.playlistTab).toBe("queue");
+  });
+
+  it("historyDisplay reverses storage order (newest first)", () => {
+    app.history.push(t(1), t(2), t(3));
+    expect(app.historyDisplay.map((x) => x.id)).toEqual([3, 2, 1]);
+  });
+
+  it("history caps at 100 entries, dropping the oldest", () => {
+    for (let i = 0; i < 100; i++) app.history.push(t(i));
+    app.currentTrack = t(500);
+    app.playNow(t(999));
+    expect(app.history.length).toBe(100);
+    expect(app.history[0].id).toBe(1);
+    expect(app.history[99].id).toBe(500);
+  });
+
+  it("removeFromHistory uses display index (newest first)", () => {
+    app.history.push(t(1), t(2), t(3));
+    app.removeFromHistory(0);
+    expect(app.history.map((x) => x.id)).toEqual([1, 2]);
+    app.removeFromHistory(1);
+    expect(app.history.map((x) => x.id)).toEqual([2]);
+  });
+
+  it("removeFromHistory ignores out-of-range indices", () => {
+    app.history.push(t(1));
+    app.removeFromHistory(5);
+    app.removeFromHistory(-1);
+    expect(app.history.length).toBe(1);
+  });
+
+  it("clearHistory empties history without touching playback", () => {
+    app.history.push(t(1), t(2));
+    app.currentTrack = t(99);
+    app.clearHistory();
+    expect(app.history.length).toBe(0);
+    expect(app.currentTrack?.id).toBe(99);
+  });
+
+  it("requeueFromHistory appends the chosen entry to the playlist tail", () => {
+    app.history.push(t(1), t(2), t(3));
+    app.requeueFromHistory(2);
+    expect(app.playlist.map((x) => x.id)).toEqual([1]);
+    expect(app.history.map((x) => x.id)).toEqual([1, 2, 3]);
+  });
+
+  it("requeueFromHistory is a no-op for invalid indices", () => {
+    app.history.push(t(1));
+    app.requeueFromHistory(5);
+    expect(app.playlist.length).toBe(0);
+  });
+});
+
 describe("AppState playback control", () => {
   let app: AppState;
   beforeEach(() => {


### PR DESCRIPTION
Stacked on top of #45.

## Summary
Adds a second tab in the playlist panel, sharing the same column as "Up next". Implements the [decisions documented on #33](https://github.com/Arskah/diodedj/issues/33#issuecomment-4330277816).

## Behavior
- Pill tabs in header: `[Up next (N)] [History (M)]`
- History rows reuse `.playlist-row` styling, no drag handle
- Newest entry on top (matches `prev` semantics)
- Double-click on a history row re-queues the track to the playlist tail; the entry stays in history
- ✕ removes the entry from history
- Clear button is scoped to the active tab (`Clear queue` / `Clear history`)
- History capped at 100 entries (oldest dropped on overflow)
- In-memory only; survives `stop`, cleared explicitly via the Clear button on the history tab
- Duplicates allowed

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test -- run` (86 passed)
- [x] `pnpm test:e2e` (15 passed, including new history-tab coverage)
- [ ] Manual: play several tracks, switch to History tab, verify newest-first order
- [ ] Manual: double-click a history entry, switch back to Up next, confirm it's re-queued
- [ ] Manual: hit Stop mid-playback, switch to History tab, verify entries are still listed

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)