### PR TITLE
ci: add missing permissions for lint job

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,6 +3,9 @@ name: Lint
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint


### PR DESCRIPTION
Potential fix for [https://github.com/Arskah/diodedj/security/code-scanning/1](https://github.com/Arskah/diodedj/security/code-scanning/1)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is restricted regardless of repository/org defaults.  
Best fix here: set workflow-level permissions to `contents: read` near the top of `.github/workflows/lint.yml` (after `on:` and before `jobs:`), since all jobs in this file are lint/read-only tasks and do not need write scopes. This preserves current functionality while documenting and enforcing least privilege.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
