### PR TITLE
feat(main): modern native window chrome

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   "dependencies": {
     "better-sqlite3": "12.9.0",
     "electron-log": "5.4.3",
+    "electron-window-state": "5.0.3",
     "ffmpeg-static": "5.3.0",
     "kysely": "0.28.16",
     "ms": "2.1.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       electron-log:
         specifier: 5.4.3
         version: 5.4.3
+      electron-window-state:
+        specifier: 5.0.3
+        version: 5.0.3
       ffmpeg-static:
         specifier: 5.3.0
         version: 5.3.0
@@ -1548,6 +1551,10 @@ packages:
     peerDependenciesMeta:
       '@swc/core':
         optional: true
+
+  electron-window-state@5.0.3:
+    resolution: {integrity: sha512-1mNTwCfkolXl3kMf50yW3vE2lZj0y92P/HYWFBrb+v2S/pCka5mdwN3cagKm458A7NjndSwijynXgcLWRodsVg==}
+    engines: {node: '>=8.0.0'}
 
   electron-winstaller@5.4.0:
     resolution: {integrity: sha512-bO3y10YikuUwUuDUQRM4KfwNkKhnpVO7IPdbsrejwN9/AABJzzTQ4GeHwyzNSrVO+tEH3/Np255a3sVZpZDjvg==}
@@ -4545,6 +4552,11 @@ snapshots:
       vite: 8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
+
+  electron-window-state@5.0.3:
+    dependencies:
+      jsonfile: 4.0.0
+      mkdirp: 0.5.6
 
   electron-winstaller@5.4.0:
     dependencies:

--- a/src/main/mainWindow.ts
+++ b/src/main/mainWindow.ts
@@ -1,24 +1,72 @@
-import { app, BrowserWindow } from "electron";
+import {
+  app,
+  BrowserWindow,
+  type BrowserWindowConstructorOptions,
+} from "electron";
 import path from "path";
+import windowStateKeeper from "electron-window-state";
+
+const TITLEBAR_BG = "#1a1a2e";
+const TITLEBAR_SYMBOL = "#e8e8e8";
+const TITLEBAR_HEIGHT = 50;
+const LINUX_FALLBACK_BG = "#0f0f1a";
 
 export function createMainWindow(): BrowserWindow {
   if (!app.isReady()) {
     throw new Error("createMainWindow must be called after app is ready");
   }
 
+  const state = windowStateKeeper({
+    defaultWidth: 1200,
+    defaultHeight: 800,
+  });
+
+  const platformOpts: BrowserWindowConstructorOptions =
+    process.platform === "darwin"
+      ? {
+          titleBarStyle: "hiddenInset",
+          trafficLightPosition: { x: 12, y: 18 },
+          vibrancy: "under-window",
+          visualEffectState: "active",
+        }
+      : process.platform === "win32"
+        ? {
+            titleBarOverlay: {
+              color: TITLEBAR_BG,
+              symbolColor: TITLEBAR_SYMBOL,
+              height: TITLEBAR_HEIGHT,
+            },
+            backgroundMaterial: "mica",
+          }
+        : {
+            titleBarOverlay: {
+              color: TITLEBAR_BG,
+              symbolColor: TITLEBAR_SYMBOL,
+              height: TITLEBAR_HEIGHT,
+            },
+            backgroundColor: LINUX_FALLBACK_BG,
+          };
+
   const mainWindow = new BrowserWindow({
-    width: 1200,
-    height: 800,
+    x: state.x,
+    y: state.y,
+    width: state.width,
+    height: state.height,
     minWidth: 800,
     minHeight: 600,
     title: "DiodeDJ",
-    backgroundColor: "#0f0f1a",
+    show: false,
+    paintWhenInitiallyHidden: true,
+    ...platformOpts,
     webPreferences: {
       preload: path.join(__dirname, "../preload/preload.js"),
       contextIsolation: true,
       nodeIntegration: false,
     },
   });
+
+  state.manage(mainWindow);
+  mainWindow.once("ready-to-show", () => mainWindow.show());
 
   const devUrl = process.env["ELECTRON_RENDERER_URL"];
   if (devUrl) {


### PR DESCRIPTION
Closes #49

## Summary
- Per-platform titlebar: `hiddenInset` + tuned `trafficLightPosition` (mac), `titleBarOverlay` (win/linux).
- Native background material: `vibrancy: 'under-window'` + `visualEffectState: 'active'` (mac), `backgroundMaterial: 'mica'` (win), solid fallback (linux).
- `show: false` + `paintWhenInitiallyHidden: true`, reveal on `ready-to-show` to avoid first-paint flash.
- `electron-window-state` (5.0.3, pinned) for size/position/maximized persistence across launches.

## Known follow-up (out of scope)
Vibrancy/mica are dormant until the renderer drops its solid `body` background. Tracked separately — this PR is main-process only by design.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test -- run` (87 passing)
- [x] macOS launch: traffic lights aligned with toolbar, no first-paint flash, size/pos persists across restarts
- [ ] Windows 11 launch: native min/max/close in titlebar overlay, mica visible, state persists
- [ ] Linux launch: titlebar overlay buttons render, solid bg, state persists
- [x] Multi-monitor: disconnect external display, relaunch — window restored on primary
- [x] `pnpm test:e2e` (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)