### PR TITLE
feat(ui): reserve traffic light space, move search to library header

### DIFF
--- a/src/main/mainWindow.ts
+++ b/src/main/mainWindow.ts
@@ -8,7 +8,7 @@ import windowStateKeeper from "electron-window-state";
 
 const TITLEBAR_BG = "#1a1a2e";
 const TITLEBAR_SYMBOL = "#e8e8e8";
-const TITLEBAR_HEIGHT = 50;
+const TITLEBAR_HEIGHT = 38;
 const LINUX_FALLBACK_BG = "#0f0f1a";
 
 export function createMainWindow(): BrowserWindow {
@@ -25,7 +25,7 @@ export function createMainWindow(): BrowserWindow {
     process.platform === "darwin"
       ? {
           titleBarStyle: "hiddenInset",
-          trafficLightPosition: { x: 12, y: 18 },
+          trafficLightPosition: { x: 12, y: 12 },
           vibrancy: "under-window",
           visualEffectState: "active",
         }

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -1,8 +1,7 @@
 import { contextBridge, ipcRenderer } from "electron";
 
-document.documentElement.dataset["platform"] = process.platform;
-
 contextBridge.exposeInMainWorld("api", {
+  platform: process.platform,
   search: (query: string, contentType?: string) =>
     ipcRenderer.invoke("search", query, contentType),
   getTrack: (id: number) => ipcRenderer.invoke("get-track", id),

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -1,5 +1,7 @@
 import { contextBridge, ipcRenderer } from "electron";
 
+document.documentElement.dataset["platform"] = process.platform;
+
 contextBridge.exposeInMainWorld("api", {
   search: (query: string, contentType?: string) =>
     ipcRenderer.invoke("search", query, contentType),

--- a/src/renderer/components/LibraryPanel.svelte
+++ b/src/renderer/components/LibraryPanel.svelte
@@ -8,6 +8,13 @@
     { type: "jingle", label: "Jingles" },
   ];
 
+  let searchTimeout: number | undefined;
+
+  function onSearchInput(): void {
+    clearTimeout(searchTimeout);
+    searchTimeout = window.setTimeout(() => app.search(), 250);
+  }
+
   function playNow(track: Track, e: MouseEvent): void {
     e.stopPropagation();
     app.playNow(track);
@@ -25,17 +32,27 @@
 </script>
 
 <section id="library-panel">
-  <div id="library-tabs">
-    {#each tabs as { type, label } (type)}
-      <button
-        class="lib-tab"
-        class:active={app.activeTab === type}
-        data-type={type}
-        onclick={() => app.setTab(type)}
-      >
-        {label}
-      </button>
-    {/each}
+  <div id="library-header">
+    <div id="library-tabs">
+      {#each tabs as { type, label } (type)}
+        <button
+          class="lib-tab"
+          class:active={app.activeTab === type}
+          data-type={type}
+          onclick={() => app.setTab(type)}
+        >
+          {label}
+        </button>
+      {/each}
+    </div>
+    <input
+      type="text"
+      id="search-input"
+      placeholder="Search tracks..."
+      autocomplete="off"
+      bind:value={app.searchQuery}
+      oninput={onSearchInput}
+    />
   </div>
   <div id="track-list">
     {#if app.tracks.length === 0}

--- a/src/renderer/components/Toolbar.svelte
+++ b/src/renderer/components/Toolbar.svelte
@@ -1,13 +1,6 @@
 <script lang="ts">
   import { app } from "../state.svelte";
 
-  let searchTimeout: number | undefined;
-
-  function onInput(): void {
-    clearTimeout(searchTimeout);
-    searchTimeout = window.setTimeout(() => app.search(), 250);
-  }
-
   async function openPaths(): Promise<void> {
     await app.loadPaths();
     app.pathsOpen = true;
@@ -15,17 +8,14 @@
 </script>
 
 <header id="toolbar">
-  <div id="search-area">
-    <input
-      type="text"
-      id="search-input"
-      placeholder="Search tracks..."
-      autocomplete="off"
-      bind:value={app.searchQuery}
-      oninput={onInput}
-    />
-  </div>
+  <div id="toolbar-spacer"></div>
   <div id="toolbar-actions">
+    <span id="library-stats">
+      {#if app.stats && app.stats.totalTracks > 0}
+        {app.stats.totalTracks} tracks | {app.stats.totalArtists} artists | {app
+          .stats.totalHours}h
+      {/if}
+    </span>
     <button id="btn-paths" title="Manage library paths" onclick={openPaths}
       >Paths</button
     >
@@ -42,11 +32,5 @@
     >
       Auto Playlist
     </button>
-    <span id="library-stats">
-      {#if app.stats && app.stats.totalTracks > 0}
-        {app.stats.totalTracks} tracks | {app.stats.totalArtists} artists | {app
-          .stats.totalHours}h
-      {/if}
-    </span>
   </div>
 </header>

--- a/src/renderer/env.d.ts
+++ b/src/renderer/env.d.ts
@@ -8,6 +8,7 @@ declare module "*.svelte" {
 type ContentType = "music" | "commercial" | "jingle";
 
 interface ElectronAPI {
+  platform: NodeJS.Platform;
   search(
     query: string,
     contentType?: ContentType,

--- a/src/renderer/main.ts
+++ b/src/renderer/main.ts
@@ -3,6 +3,8 @@ import App from "./App.svelte";
 import { app } from "./state.svelte";
 import "./styles.css";
 
+document.documentElement.dataset["platform"] = window.api.platform;
+
 mount(App, { target: document.getElementById("app")! });
 
 void app.search();

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -36,31 +36,19 @@ body {
 #toolbar {
   display: flex;
   align-items: center;
-  gap: 12px;
-  padding: 10px 16px;
+  height: 38px;
+  padding: 0 12px;
   background: var(--bg-secondary);
   border-bottom: 1px solid var(--border);
   -webkit-app-region: drag;
 }
 
-#search-area {
+:root[data-platform="darwin"] #toolbar {
+  padding-left: 78px;
+}
+
+#toolbar-spacer {
   flex: 1;
-  -webkit-app-region: no-drag;
-}
-
-#search-input {
-  width: 100%;
-  padding: 8px 14px;
-  background: var(--bg-primary);
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  color: var(--text-primary);
-  font-size: 14px;
-  outline: none;
-}
-
-#search-input:focus {
-  border-color: var(--accent);
 }
 
 #toolbar-actions {
@@ -71,13 +59,13 @@ body {
 }
 
 #toolbar-actions button {
-  padding: 8px 14px;
+  padding: 5px 12px;
   background: var(--bg-tertiary);
   border: 1px solid var(--border);
   border-radius: 6px;
   color: var(--text-primary);
   cursor: pointer;
-  font-size: 13px;
+  font-size: 12px;
   white-space: nowrap;
 }
 
@@ -121,14 +109,38 @@ body {
   flex: 2;
 }
 
-#library-tabs {
+#library-header {
   display: flex;
+  align-items: stretch;
   background: var(--bg-secondary);
   border-bottom: 1px solid var(--border);
+  gap: 12px;
+  padding-right: 12px;
+}
+
+#library-tabs {
+  display: flex;
+  flex-shrink: 0;
+}
+
+#library-header #search-input {
+  flex: 1;
+  min-width: 0;
+  align-self: center;
+  padding: 6px 12px;
+  background: var(--bg-primary);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--text-primary);
+  font-size: 13px;
+  outline: none;
+}
+
+#library-header #search-input:focus {
+  border-color: var(--accent);
 }
 
 .lib-tab {
-  flex: 1;
   padding: 10px 16px;
   font-size: 12px;
   font-weight: 600;

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -3,7 +3,7 @@
     "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "Bundler",
-    "lib": ["ES2022"],
+    "lib": ["ES2022", "DOM"],
     "types": ["node", "electron-vite/node"],
     "strict": true,
     "esModuleInterop": true,

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -3,7 +3,7 @@
     "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "Bundler",
-    "lib": ["ES2022", "DOM"],
+    "lib": ["ES2022"],
     "types": ["node", "electron-vite/node"],
     "strict": true,
     "esModuleInterop": true,


### PR DESCRIPTION
Stacked on #50.

## Summary
- Slim toolbar 50→38px; reserve 78px left padding on macOS for traffic lights via `:root[data-platform="darwin"]` (set on `<html>` by preload).
- Re-tune `trafficLightPosition.y` to 12 and `titleBarOverlay.height` to 38 to match new toolbar.
- Move `#search-input` out of the toolbar into the library panel header, inline with the content-type tabs (Music / Commercials / Jingles).

## Why move search?
Search is library-scoped (filters tracks within the active content-type tab), so collocating it with the results it filters matches its actual reach. Toolbar becomes pure chrome — traffic lights left, action buttons right — instead of fighting the search input for the center.

## Trade-off
If global search across non-library scopes is ever planned, revisit. For now, search has always been library-only.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test -- run` (87 passing — selector `#search-input` preserved, e2e selectors unaffected)
- [x] macOS launch: traffic lights centered on slim toolbar, no overlap with action buttons; search input usable in library header
- [ ] Windows 11 / Linux: titlebar overlay matches new 38px height; search renders inline with tabs
- [x] `pnpm test:e2e` (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)