### PR TITLE
feat(library): sortable columns in track search

### DIFF
--- a/e2e/library.spec.ts
+++ b/e2e/library.spec.ts
@@ -98,6 +98,59 @@ test.describe("library", () => {
     await expect(win.locator("#track-list")).toContainText("stinger");
   });
 
+  test("sort by title cycles asc → desc and reorders the list", async ({
+    launch,
+    library,
+  }) => {
+    const fx = await library({
+      music: [{ name: "charlie" }, { name: "alpha" }, { name: "bravo" }],
+    });
+    const { win } = await launch({ musicPaths: [fx.musicDir] });
+
+    await clickScan(win);
+    await waitForTrackCount(win, 3);
+
+    const titleHeader = win.locator("#track-headers .track-header.track-title");
+
+    await titleHeader.click();
+    await expect(titleHeader).toHaveClass(/active/);
+    await expect(titleHeader).toContainText("\u25B2");
+    await expect
+      .poll(() => win.locator("#track-list .track-title").allTextContents())
+      .toEqual(["alpha", "bravo", "charlie"]);
+
+    await titleHeader.click();
+    await expect(titleHeader).toContainText("\u25BC");
+    await expect
+      .poll(() => win.locator("#track-list .track-title").allTextContents())
+      .toEqual(["charlie", "bravo", "alpha"]);
+  });
+
+  test("switching sort column resets direction to ascending", async ({
+    launch,
+    library,
+  }) => {
+    const fx = await library({
+      music: [{ name: "zeta" }, { name: "kilo" }, { name: "alpha" }],
+    });
+    const { win } = await launch({ musicPaths: [fx.musicDir] });
+
+    await clickScan(win);
+    await waitForTrackCount(win, 3);
+
+    const titleHeader = win.locator("#track-headers .track-header.track-title");
+    const playsHeader = win.locator("#track-headers .track-header.track-plays");
+
+    await titleHeader.click();
+    await titleHeader.click();
+    await expect(titleHeader).toContainText("\u25BC");
+
+    await playsHeader.click();
+    await expect(playsHeader).toHaveClass(/active/);
+    await expect(playsHeader).toContainText("\u25B2");
+    await expect(titleHeader).not.toHaveClass(/active/);
+  });
+
   test("scan after removing a path prunes orphaned tracks", async ({
     launch,
     library,

--- a/src/main/db/index.ts
+++ b/src/main/db/index.ts
@@ -2,7 +2,7 @@ import BetterSqlite3 from "better-sqlite3";
 import path from "path";
 import { app } from "electron";
 import { Kysely, SqliteDialect, Migrator, Migration, sql } from "kysely";
-import { ContentType, LibraryStats } from "../../types";
+import { ContentType, LibraryStats, SortColumn, SortDir } from "../../types";
 import { Database, Track, TrackInsert } from "./types";
 import * as initial from "./migrations/001_initial";
 
@@ -39,41 +39,57 @@ export async function init(): Promise<Kysely<Database>> {
   return db;
 }
 
+const SORT_COLUMNS: Record<SortColumn, string> = {
+  title: "title",
+  artist: "artist",
+  album: "album",
+  play_count: "play_count",
+};
+
+function orderClause(sortBy?: SortColumn, sortDir?: SortDir): string {
+  if (!sortBy || !(sortBy in SORT_COLUMNS)) return "";
+  const col = SORT_COLUMNS[sortBy];
+  const dir = sortDir === "desc" ? "DESC" : "ASC";
+  const collate = sortBy === "play_count" ? "" : "COLLATE NOCASE ";
+  return `${col} ${collate}${dir}`;
+}
+
 export async function search(
   query: string,
   contentType?: ContentType,
+  sortBy?: SortColumn,
+  sortDir?: SortDir,
 ): Promise<Track[]> {
+  const order = orderClause(sortBy, sortDir);
   if (!query?.trim()) {
-    let q = db
-      .selectFrom("tracks")
-      .selectAll()
-      .orderBy("artist")
-      .orderBy("album")
-      .orderBy("title")
-      .limit(200);
-    if (contentType) {
-      q = q.where("content_type", "=", contentType);
+    let q = db.selectFrom("tracks").selectAll();
+    if (contentType) q = q.where("content_type", "=", contentType);
+    if (order) {
+      q = q.orderBy(sql.raw(order));
+    } else {
+      q = q.orderBy("artist").orderBy("album").orderBy("title");
     }
-    return await q.execute();
+    return await q.limit(200).execute();
   }
   const ftsQuery = query
     .trim()
     .split(/\s+/)
     .map((t) => `"${t}"*`)
     .join(" ");
+  const orderSql = order ? sql.raw(order) : sql.raw("rank");
   const result = contentType
     ? await sql<Track>`
         SELECT tracks.* FROM tracks_fts
         JOIN tracks ON tracks.id = tracks_fts.rowid
         WHERE tracks_fts MATCH ${ftsQuery} AND tracks.content_type = ${contentType}
-        ORDER BY rank
+        ORDER BY ${orderSql}
         LIMIT 200
       `.execute(db)
     : await sql<Track>`
         SELECT tracks.* FROM tracks_fts
         JOIN tracks ON tracks.id = tracks_fts.rowid
         WHERE tracks_fts MATCH ${ftsQuery}
-        ORDER BY rank
+        ORDER BY ${orderSql}
         LIMIT 200
       `.execute(db);
   return result.rows;

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -1,5 +1,5 @@
 import { BrowserWindow, ipcMain, dialog, IpcMainInvokeEvent } from "electron";
-import { ContentType } from "../types";
+import { ContentType, SortColumn, SortDir } from "../types";
 import * as db from "./db";
 import * as config from "./config";
 import * as scanner from "./scanner";
@@ -22,9 +22,18 @@ function handle(channel: string, handler: Handler): void {
 }
 
 export function register(mainWindow: BrowserWindow): void {
-  handle("search", async (_event, query: string, contentType?: ContentType) => {
-    return db.search(query, contentType);
-  });
+  handle(
+    "search",
+    async (
+      _event,
+      query: string,
+      contentType?: ContentType,
+      sortBy?: SortColumn,
+      sortDir?: SortDir,
+    ) => {
+      return db.search(query, contentType, sortBy, sortDir);
+    },
+  );
 
   handle("get-track", async (_event, id: number) => {
     return db.getTrack(id);

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -2,8 +2,12 @@ import { contextBridge, ipcRenderer } from "electron";
 
 contextBridge.exposeInMainWorld("api", {
   platform: process.platform,
-  search: (query: string, contentType?: string) =>
-    ipcRenderer.invoke("search", query, contentType),
+  search: (
+    query: string,
+    contentType?: string,
+    sortBy?: string,
+    sortDir?: string,
+  ) => ipcRenderer.invoke("search", query, contentType, sortBy, sortDir),
   getTrack: (id: number) => ipcRenderer.invoke("get-track", id),
   trackPlayed: (id: number) => ipcRenderer.invoke("track-played", id),
   generatePlaylist: (count: number) =>

--- a/src/renderer/components/LibraryPanel.svelte
+++ b/src/renderer/components/LibraryPanel.svelte
@@ -1,12 +1,24 @@
 <script lang="ts">
   import { app, formatTime, type Track } from "../state.svelte";
-  import type { ContentType } from "../../types";
+  import type { ContentType, SortColumn } from "../../types";
 
   const tabs: { type: ContentType; label: string }[] = [
     { type: "music", label: "Music" },
     { type: "commercial", label: "Commercials" },
     { type: "jingle", label: "Jingles" },
   ];
+
+  const sortableCols: { column: SortColumn; label: string; cls: string }[] = [
+    { column: "title", label: "Title", cls: "track-title" },
+    { column: "artist", label: "Artist", cls: "track-artist" },
+    { column: "album", label: "Album", cls: "track-album" },
+    { column: "play_count", label: "Plays", cls: "track-plays" },
+  ];
+
+  function sortIndicator(column: SortColumn): string {
+    if (app.sortBy !== column) return "";
+    return app.sortDir === "asc" ? " \u25B2" : " \u25BC";
+  }
 
   let searchTimeout: number | undefined;
 
@@ -53,6 +65,19 @@
       bind:value={app.searchQuery}
       oninput={onSearchInput}
     />
+  </div>
+  <div id="track-headers">
+    {#each sortableCols as col (col.column)}
+      <button
+        class="track-header {col.cls}"
+        class:active={app.sortBy === col.column}
+        onclick={() => app.toggleSort(col.column)}
+      >
+        {col.label}{sortIndicator(col.column)}
+      </button>
+    {/each}
+    <span class="track-header track-duration">Time</span>
+    <span class="track-header-spacer"></span>
   </div>
   <div id="track-list">
     {#if app.tracks.length === 0}

--- a/src/renderer/env.d.ts
+++ b/src/renderer/env.d.ts
@@ -6,12 +6,16 @@ declare module "*.svelte" {
 }
 
 type ContentType = "music" | "commercial" | "jingle";
+type SortColumn = "title" | "artist" | "album" | "play_count";
+type SortDir = "asc" | "desc";
 
 interface ElectronAPI {
   platform: NodeJS.Platform;
   search(
     query: string,
     contentType?: ContentType,
+    sortBy?: SortColumn,
+    sortDir?: SortDir,
   ): Promise<import("../types").Track[]>;
   getTrack(id: number): Promise<import("../types").Track>;
   trackPlayed(id: number): Promise<void>;

--- a/src/renderer/state.svelte.ts
+++ b/src/renderer/state.svelte.ts
@@ -1,4 +1,10 @@
-import type { ContentType, LibraryStats, Track } from "../types";
+import type {
+  ContentType,
+  LibraryStats,
+  SortColumn,
+  SortDir,
+  Track,
+} from "../types";
 import logger from "electron-log/renderer";
 
 export type { Track };
@@ -15,6 +21,8 @@ export class AppState {
   searchQuery = $state("");
   activeTab = $state<ContentType>("music");
   playlistTab = $state<PlaylistTab>("queue");
+  sortBy = $state<SortColumn | null>(null);
+  sortDir = $state<SortDir>("asc");
   tracks = $state<Track[]>([]);
   stats = $state<LibraryStats | null>(null);
   paths = $state<Record<ContentType, string[]>>({
@@ -88,11 +96,26 @@ export class AppState {
   }
 
   async search(): Promise<void> {
-    this.tracks = await window.api.search(this.searchQuery, this.activeTab);
+    this.tracks = await window.api.search(
+      this.searchQuery,
+      this.activeTab,
+      this.sortBy ?? undefined,
+      this.sortDir,
+    );
   }
 
   setTab(tab: ContentType): void {
     this.activeTab = tab;
+    void this.search();
+  }
+
+  toggleSort(column: SortColumn): void {
+    if (this.sortBy === column) {
+      this.sortDir = this.sortDir === "asc" ? "desc" : "asc";
+    } else {
+      this.sortBy = column;
+      this.sortDir = "asc";
+    }
     void this.search();
   }
 

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -239,6 +239,52 @@ body {
   padding: 4px 0;
 }
 
+#track-headers {
+  display: flex;
+  align-items: center;
+  padding: 6px 16px;
+  gap: 12px;
+  background: var(--bg-secondary);
+  border-bottom: 1px solid var(--border);
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--text-secondary);
+}
+
+.track-header {
+  background: none;
+  border: none;
+  color: inherit;
+  font: inherit;
+  text-transform: inherit;
+  letter-spacing: inherit;
+  cursor: pointer;
+  text-align: left;
+  padding: 2px 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.track-header:hover {
+  color: var(--text-primary);
+}
+
+.track-header.active {
+  color: var(--accent);
+}
+
+#track-headers .track-plays {
+  text-align: right;
+}
+
+.track-header-spacer {
+  width: 64px;
+  flex-shrink: 0;
+}
+
 .history-row {
   cursor: pointer;
 }
@@ -291,7 +337,7 @@ body {
 }
 
 .track-plays {
-  width: 35px;
+  width: 55px;
   text-align: right;
   color: var(--text-secondary);
   font-size: 11px;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,13 @@
 export type ContentType = "music" | "commercial" | "jingle";
 
+export type SortColumn = "title" | "artist" | "album" | "play_count";
+export type SortDir = "asc" | "desc";
+
+export interface SortOption {
+  column: SortColumn;
+  dir: SortDir;
+}
+
 export interface Track {
   id: number;
   title: string;

--- a/tests/renderer/state.test.ts
+++ b/tests/renderer/state.test.ts
@@ -424,14 +424,33 @@ describe("AppState library + paths", () => {
     app.searchQuery = "foo";
     app.activeTab = "music";
     await app.search();
-    expect(api.search).toHaveBeenCalledWith("foo", "music");
+    expect(api.search).toHaveBeenCalledWith("foo", "music", undefined, "asc");
     expect(app.tracks.length).toBe(2);
   });
 
   it("setTab updates activeTab and triggers a search for it", () => {
     app.setTab("jingle");
     expect(app.activeTab).toBe("jingle");
-    expect(api.search).toHaveBeenCalledWith("", "jingle");
+    expect(api.search).toHaveBeenCalledWith("", "jingle", undefined, "asc");
+  });
+
+  it("toggleSort sets column ascending then flips direction on second click", async () => {
+    await app.toggleSort("title");
+    expect(app.sortBy).toBe("title");
+    expect(app.sortDir).toBe("asc");
+    expect(api.search).toHaveBeenLastCalledWith("", "music", "title", "asc");
+    await app.toggleSort("title");
+    expect(app.sortDir).toBe("desc");
+    expect(api.search).toHaveBeenLastCalledWith("", "music", "title", "desc");
+  });
+
+  it("toggleSort to a different column resets direction to asc", async () => {
+    app.sortBy = "artist";
+    app.sortDir = "desc";
+    await app.toggleSort("album");
+    expect(app.sortBy).toBe("album");
+    expect(app.sortDir).toBe("asc");
+    expect(api.search).toHaveBeenLastCalledWith("", "music", "album", "asc");
   });
 
   it("loadStats stores response", async () => {


### PR DESCRIPTION
Closes #34.

## Summary
- Click column headers (Title / Artist / Album / Plays) to sort the library list. Same column toggles asc ↔ desc; switching column resets to asc.
- `db.search` accepts optional `sortBy` + `sortDir`; whitelisted columns; `COLLATE NOCASE` for text columns. Default ordering preserved when no column selected.
- Plays column widened (35 → 55px) to fit the sort indicator.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test -- run` (89 passed, includes new `toggleSort` cases)
- [x] `pnpm exec playwright test --grep sort` (2 passed: title asc/desc reorder + column-switch reset)

🤖 Generated with [Claude Code](https://claude.com/claude-code)