### PR TITLE
feat(session): persist playlist and history across restarts

### DIFF
--- a/src/main/db/index.ts
+++ b/src/main/db/index.ts
@@ -103,6 +103,19 @@ export async function getTrack(id: number): Promise<Track | undefined> {
     .executeTakeFirst();
 }
 
+export async function getTracksByIds(ids: number[]): Promise<Track[]> {
+  if (ids.length === 0) return [];
+  const rows = await db
+    .selectFrom("tracks")
+    .selectAll()
+    .where("id", "in", ids)
+    .execute();
+  const byId = new Map(rows.map((r) => [r.id, r]));
+  return ids
+    .map((id) => byId.get(id))
+    .filter((t): t is Track => t !== undefined);
+}
+
 export async function getRandomTracks(
   count: number,
   contentType: ContentType = "music",

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -4,6 +4,7 @@ import * as db from "./db";
 import * as config from "./config";
 import * as scanner from "./scanner";
 import * as playlist from "./playlist";
+import * as session from "./session";
 import { logger } from "./logger";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -37,6 +38,27 @@ export function register(mainWindow: BrowserWindow): void {
 
   handle("get-track", async (_event, id: number) => {
     return db.getTrack(id);
+  });
+
+  handle("get-tracks-by-ids", async (_event, ids: number[]) => {
+    return db.getTracksByIds(ids);
+  });
+
+  handle("load-session", async () => {
+    const state = session.load();
+    const ids = Array.from(
+      new Set([
+        ...state.playlistIds,
+        ...state.historyIds,
+        ...(state.currentTrackId !== null ? [state.currentTrackId] : []),
+      ]),
+    );
+    const tracks = await db.getTracksByIds(ids);
+    return { state, tracks };
+  });
+
+  handle("save-session", (_event, state: session.SessionState) => {
+    session.save(state);
   });
 
   handle("track-played", async (_event, id: number) => {

--- a/src/main/session.ts
+++ b/src/main/session.ts
@@ -1,0 +1,46 @@
+import fs from "fs";
+import path from "path";
+import { app } from "electron";
+
+export interface SessionState {
+  playlistIds: number[];
+  historyIds: number[];
+  currentTrackId: number | null;
+  currentTime: number;
+  autoPlaylistActive: boolean;
+  autoAdvance: boolean;
+  volume: number;
+}
+
+const defaults: SessionState = {
+  playlistIds: [],
+  historyIds: [],
+  currentTrackId: null,
+  currentTime: 0,
+  autoPlaylistActive: false,
+  autoAdvance: true,
+  volume: 1,
+};
+
+let sessionPath: string;
+
+function resolvePath(): string {
+  if (!sessionPath) {
+    sessionPath = path.join(app.getPath("userData"), "session.json");
+  }
+  return sessionPath;
+}
+
+export function load(): SessionState {
+  try {
+    const raw = fs.readFileSync(resolvePath(), "utf-8");
+    const parsed = JSON.parse(raw) as Partial<SessionState>;
+    return { ...defaults, ...parsed };
+  } catch {
+    return { ...defaults };
+  }
+}
+
+export function save(state: SessionState): void {
+  fs.writeFileSync(resolvePath(), JSON.stringify(state, null, 2));
+}

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -9,6 +9,10 @@ contextBridge.exposeInMainWorld("api", {
     sortDir?: string,
   ) => ipcRenderer.invoke("search", query, contentType, sortBy, sortDir),
   getTrack: (id: number) => ipcRenderer.invoke("get-track", id),
+  getTracksByIds: (ids: number[]) =>
+    ipcRenderer.invoke("get-tracks-by-ids", ids),
+  loadSession: () => ipcRenderer.invoke("load-session"),
+  saveSession: (state: unknown) => ipcRenderer.invoke("save-session", state),
   trackPlayed: (id: number) => ipcRenderer.invoke("track-played", id),
   generatePlaylist: (count: number) =>
     ipcRenderer.invoke("generate-playlist", count),

--- a/src/renderer/env.d.ts
+++ b/src/renderer/env.d.ts
@@ -9,6 +9,21 @@ type ContentType = "music" | "commercial" | "jingle";
 type SortColumn = "title" | "artist" | "album" | "play_count";
 type SortDir = "asc" | "desc";
 
+interface SessionPersistState {
+  playlistIds: number[];
+  historyIds: number[];
+  currentTrackId: number | null;
+  currentTime: number;
+  autoPlaylistActive: boolean;
+  autoAdvance: boolean;
+  volume: number;
+}
+
+interface SessionLoadResult {
+  state: SessionPersistState;
+  tracks: import("../types").Track[];
+}
+
 interface ElectronAPI {
   platform: NodeJS.Platform;
   search(
@@ -18,6 +33,9 @@ interface ElectronAPI {
     sortDir?: SortDir,
   ): Promise<import("../types").Track[]>;
   getTrack(id: number): Promise<import("../types").Track>;
+  getTracksByIds(ids: number[]): Promise<import("../types").Track[]>;
+  loadSession(): Promise<SessionLoadResult>;
+  saveSession(state: SessionPersistState): Promise<void>;
   trackPlayed(id: number): Promise<void>;
   generatePlaylist(count: number): Promise<import("../types").Track[]>;
   getStats(): Promise<import("../types").LibraryStats>;

--- a/src/renderer/main.ts
+++ b/src/renderer/main.ts
@@ -9,3 +9,6 @@ mount(App, { target: document.getElementById("app")! });
 
 void app.search();
 void app.loadStats();
+void app.loadSession();
+
+window.addEventListener("beforeunload", () => app.flushSave());

--- a/src/renderer/state.svelte.ts
+++ b/src/renderer/state.svelte.ts
@@ -14,6 +14,7 @@ const AUTO_PLAYLIST_BUFFER = 20;
 // Threshold at which the auto playlist will be refilled. Should be lower than AUTO_PLAYLIST_BUFFER to avoid excessive refilling.
 const AUTO_PLAYLIST_THRESHOLD = 5;
 const HISTORY_CAP = 100;
+const SESSION_SAVE_DEBOUNCE_MS = 750;
 
 export type PlaylistTab = "queue" | "history";
 
@@ -51,6 +52,9 @@ export class AppState {
 
   audio: HTMLAudioElement;
 
+  private saveTimer: ReturnType<typeof setTimeout> | null = null;
+  private sessionLoaded = false;
+
   constructor() {
     this.audio = new Audio();
     this.audio.id = "audio";
@@ -67,6 +71,7 @@ export class AppState {
         isFinite(this.audio.duration) && this.audio.duration > 0
           ? this.audio.duration
           : (this.currentTrack?.duration ?? 0);
+      this.scheduleSave();
     });
     this.audio.addEventListener("ended", () => {
       void this.handleEnded();
@@ -93,6 +98,7 @@ export class AppState {
   setVolume(v: number): void {
     this.volume = v;
     this.audio.volume = v;
+    this.scheduleSave();
   }
 
   async search(): Promise<void> {
@@ -121,6 +127,7 @@ export class AppState {
 
   addToPlaylist(track: Track): void {
     this.playlist.push(track);
+    this.scheduleSave();
   }
 
   playNow(track: Track): void {
@@ -129,16 +136,19 @@ export class AppState {
 
   removeFromPlaylist(index: number): void {
     this.playlist.splice(index, 1);
+    this.scheduleSave();
   }
 
   movePlaylistItem(from: number, to: number): void {
     if (from === to) return;
     const [item] = this.playlist.splice(from, 1);
     this.playlist.splice(to, 0, item);
+    this.scheduleSave();
   }
 
   clearPlaylist(): void {
     this.playlist.length = 0;
+    this.scheduleSave();
   }
 
   playIndex(index: number): void {
@@ -163,16 +173,19 @@ export class AppState {
     if (this.history.length > HISTORY_CAP) {
       this.history.splice(0, this.history.length - HISTORY_CAP);
     }
+    this.scheduleSave();
   }
 
   removeFromHistory(displayIndex: number): void {
     const i = this.history.length - 1 - displayIndex;
     if (i < 0 || i >= this.history.length) return;
     this.history.splice(i, 1);
+    this.scheduleSave();
   }
 
   clearHistory(): void {
     this.history.length = 0;
+    this.scheduleSave();
   }
 
   requeueFromHistory(displayIndex: number): void {
@@ -180,6 +193,7 @@ export class AppState {
     const track = this.history[i];
     if (!track) return;
     this.playlist.push(track);
+    this.scheduleSave();
   }
 
   private setCurrent(track: Track): void {
@@ -189,6 +203,7 @@ export class AppState {
     void window.api.trackPlayed(track.id);
     document.title = `${track.title} - ${track.artist} | DiodeDJ`;
     void this.maybeRefillPlaylist();
+    this.scheduleSave();
   }
 
   togglePlay(): void {
@@ -213,6 +228,7 @@ export class AppState {
     this.currentTime = 0;
     this.duration = 0;
     document.title = "DiodeDJ";
+    this.scheduleSave();
   }
 
   next(): void {
@@ -239,6 +255,7 @@ export class AppState {
 
   toggleMode(): void {
     this.autoAdvance = !this.autoAdvance;
+    this.scheduleSave();
   }
 
   async toggleAutoPlaylist(): Promise<void> {
@@ -249,6 +266,7 @@ export class AppState {
         this.playIndex(0);
       }
     }
+    this.scheduleSave();
   }
 
   async maybeRefillPlaylist(): Promise<void> {
@@ -257,6 +275,7 @@ export class AppState {
       const count = AUTO_PLAYLIST_BUFFER - this.playlist.length;
       const tracks = await window.api.generatePlaylist(count);
       this.playlist.push(...tracks);
+      this.scheduleSave();
     }
   }
 
@@ -282,6 +301,84 @@ export class AppState {
 
   async loadStats(): Promise<void> {
     this.stats = await window.api.getStats();
+  }
+
+  async loadSession(): Promise<void> {
+    let result;
+    try {
+      result = await window.api.loadSession();
+    } catch (err) {
+      logger.error("Session load failed:", err);
+      this.sessionLoaded = true;
+      return;
+    }
+    const { state, tracks } = result;
+    const byId = new Map(tracks.map((t) => [t.id, t]));
+    const resolve = (ids: number[]): Track[] =>
+      ids.map((id) => byId.get(id)).filter((t): t is Track => t !== undefined);
+
+    this.playlist = resolve(state.playlistIds);
+    this.history = resolve(state.historyIds);
+    this.autoPlaylistActive = state.autoPlaylistActive;
+    this.autoAdvance = state.autoAdvance;
+    this.setVolume(state.volume);
+
+    const restored =
+      state.currentTrackId !== null ? byId.get(state.currentTrackId) : null;
+    if (restored) {
+      this.currentTrack = restored;
+      this.audio.src = window.api.getMediaUrl(restored.id);
+      this.duration = restored.duration ?? 0;
+      const seek = state.currentTime;
+      if (seek > 0) {
+        this.currentTime = seek;
+        const onMeta = (): void => {
+          try {
+            this.audio.currentTime = seek;
+          } catch (err) {
+            logger.error("Resume seek failed:", err);
+          }
+          this.audio.removeEventListener("loadedmetadata", onMeta);
+        };
+        this.audio.addEventListener("loadedmetadata", onMeta);
+      }
+      document.title = `${restored.title} - ${restored.artist} | DiodeDJ`;
+    }
+
+    this.sessionLoaded = true;
+  }
+
+  private scheduleSave(): void {
+    if (!this.sessionLoaded) return;
+    if (this.saveTimer) clearTimeout(this.saveTimer);
+    this.saveTimer = setTimeout(() => {
+      this.saveTimer = null;
+      void this.persistSession();
+    }, SESSION_SAVE_DEBOUNCE_MS);
+  }
+
+  flushSave(): void {
+    if (this.saveTimer) {
+      clearTimeout(this.saveTimer);
+      this.saveTimer = null;
+    }
+    void this.persistSession();
+  }
+
+  private async persistSession(): Promise<void> {
+    try {
+      await window.api.saveSession({
+        playlistIds: this.playlist.map((t) => t.id),
+        historyIds: this.history.map((t) => t.id),
+        currentTrackId: this.currentTrack?.id ?? null,
+        currentTime: this.currentTime,
+        autoPlaylistActive: this.autoPlaylistActive,
+        autoAdvance: this.autoAdvance,
+        volume: this.volume,
+      });
+    } catch (err) {
+      logger.error("Session save failed:", err);
+    }
   }
 
   async loadPaths(): Promise<void> {

--- a/tests/renderer/state.test.ts
+++ b/tests/renderer/state.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("electron-log/renderer", () => ({
   default: {
@@ -15,6 +15,9 @@ const { api } = vi.hoisted(() => {
   const api = {
     search: vi.fn(),
     getTrack: vi.fn(),
+    getTracksByIds: vi.fn(),
+    loadSession: vi.fn(),
+    saveSession: vi.fn(),
     trackPlayed: vi.fn(),
     generatePlaylist: vi.fn(),
     getStats: vi.fn(),
@@ -65,6 +68,20 @@ function resetApi(): void {
   api.addPath.mockResolvedValue(null);
   api.removePath.mockResolvedValue(true);
   api.scanLibrary.mockResolvedValue({ total: 0, added: 0 });
+  api.getTracksByIds.mockResolvedValue([]);
+  api.loadSession.mockResolvedValue({
+    state: {
+      playlistIds: [],
+      historyIds: [],
+      currentTrackId: null,
+      currentTime: 0,
+      autoPlaylistActive: false,
+      autoAdvance: true,
+      volume: 1,
+    },
+    tracks: [],
+  });
+  api.saveSession.mockResolvedValue(undefined);
 }
 
 function makeApp(): AppState {
@@ -551,5 +568,100 @@ describe("AppState auto-playlist refill", () => {
     initialTracks.forEach((track) => app.addToPlaylist(track));
     await app.maybeRefillPlaylist();
     expect(api.generatePlaylist).not.toHaveBeenCalled();
+  });
+});
+
+describe("AppState session persistence", () => {
+  let app: AppState;
+
+  beforeEach(() => {
+    resetApi();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("loadSession hydrates playlist, history, current track and flags", async () => {
+    api.loadSession.mockResolvedValueOnce({
+      state: {
+        playlistIds: [2, 3],
+        historyIds: [1],
+        currentTrackId: 2,
+        currentTime: 12.5,
+        autoPlaylistActive: true,
+        autoAdvance: false,
+        volume: 0.6,
+      },
+      tracks: [t(1), t(2), t(3)],
+    });
+
+    app = makeApp();
+    await app.loadSession();
+
+    expect(app.playlist.map((x) => x.id)).toEqual([2, 3]);
+    expect(app.history.map((x) => x.id)).toEqual([1]);
+    expect(app.currentTrack?.id).toBe(2);
+    expect(app.autoPlaylistActive).toBe(true);
+    expect(app.autoAdvance).toBe(false);
+    expect(app.volume).toBe(0.6);
+    expect(app.currentTime).toBe(12.5);
+    expect(app.audio.getAttribute("src")).toBe("media://track/2");
+    expect(document.title).toBe("t2 - a2 | DiodeDJ");
+  });
+
+  it("loadSession drops missing track ids", async () => {
+    api.loadSession.mockResolvedValueOnce({
+      state: {
+        playlistIds: [1, 99, 2],
+        historyIds: [42],
+        currentTrackId: 7,
+        currentTime: 0,
+        autoPlaylistActive: false,
+        autoAdvance: true,
+        volume: 1,
+      },
+      tracks: [t(1), t(2)],
+    });
+
+    app = makeApp();
+    await app.loadSession();
+
+    expect(app.playlist.map((x) => x.id)).toEqual([1, 2]);
+    expect(app.history).toEqual([]);
+    expect(app.currentTrack).toBeNull();
+  });
+
+  it("does not save before session is loaded", () => {
+    app = makeApp();
+    app.addToPlaylist(t(1));
+    vi.runAllTimers();
+    expect(api.saveSession).not.toHaveBeenCalled();
+  });
+
+  it("debounced save fires after mutations once session is loaded", async () => {
+    app = makeApp();
+    await app.loadSession();
+    app.addToPlaylist(t(1));
+    app.addToPlaylist(t(2));
+    expect(api.saveSession).not.toHaveBeenCalled();
+    vi.runAllTimers();
+    expect(api.saveSession).toHaveBeenCalledTimes(1);
+    const arg = api.saveSession.mock.calls[0][0];
+    expect(arg.playlistIds).toEqual([1, 2]);
+    expect(arg.currentTrackId).toBeNull();
+    expect(arg.autoAdvance).toBe(true);
+    expect(arg.volume).toBe(1);
+  });
+
+  it("flushSave persists immediately and cancels pending timer", async () => {
+    app = makeApp();
+    await app.loadSession();
+    app.addToPlaylist(t(5));
+    app.flushSave();
+    expect(api.saveSession).toHaveBeenCalledTimes(1);
+    vi.runAllTimers();
+    expect(api.saveSession).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Summary
- Persists playlist, history, current track + position, auto flags, volume to `userData/session.json`. Closes #26.
- Renderer hydrates session on startup (paused at saved position); debounced save on mutations + `timeupdate`; flush on `beforeunload`.
- Tracks stored as ids; `db.getTracksByIds` resolves on load and drops missing ids.

## Test plan
- [x] `pnpm typecheck` clean
- [x] `pnpm test -- run` (94 pass, 5 new session tests)
- [x] `pnpm lint` + `pnpm format:check` clean
- [x] Manual: queue tracks, play one partway, quit, relaunch — playlist + history + paused current track restored at saved position
- [x] Manual: delete a queued track from library then rescan + relaunch — missing ids dropped silently

🤖 Generated with [Claude Code](https://claude.com/claude-code)