### PR TITLE
feat(playlist): mix jingles and commercials into auto playlist

### DIFF
--- a/src/main/playlist.ts
+++ b/src/main/playlist.ts
@@ -1,6 +1,70 @@
 import { Track } from "./db/types";
 import * as db from "./db";
 
-export function generate(count: number = 20): Promise<Track[]> {
-  return db.getRandomTracks(count);
+// 1 jingle per ~JINGLE_EVERY tracks, 1 commercial per ~COMMERCIAL_EVERY tracks.
+const JINGLE_EVERY = 4;
+const COMMERCIAL_EVERY = 8;
+
+export async function generate(count: number = 20): Promise<Track[]> {
+  if (count <= 0) return [];
+  const jingleCount = Math.floor(count / JINGLE_EVERY);
+  const commercialCount = Math.floor(count / COMMERCIAL_EVERY);
+  const musicCount = Math.max(0, count - jingleCount - commercialCount);
+
+  const [music, jingles, commercials] = await Promise.all([
+    db.getRandomTracks(musicCount, "music"),
+    jingleCount > 0
+      ? db.getRandomTracks(jingleCount, "jingle")
+      : Promise.resolve<Track[]>([]),
+    commercialCount > 0
+      ? db.getRandomTracks(commercialCount, "commercial")
+      : Promise.resolve<Track[]>([]),
+  ]);
+
+  return interleaveEvenly(music, jingles, commercials);
+}
+
+// Distributes `jingles` and `commercials` evenly across the music tracks so
+// non-music slots are spaced as uniformly as possible. Pure for testing.
+export function interleaveEvenly(
+  music: Track[],
+  jingles: Track[],
+  commercials: Track[],
+): Track[] {
+  const total = music.length + jingles.length + commercials.length;
+  if (total === 0) return [];
+
+  const jSlots = pickEvenSlots(total, jingles.length);
+  const remaining: number[] = [];
+  for (let i = 0; i < total; i++) {
+    if (!jSlots.has(i)) remaining.push(i);
+  }
+  const cIndices = pickEvenSlots(remaining.length, commercials.length);
+  const cSlots = new Set<number>();
+  cIndices.forEach((idx) => cSlots.add(remaining[idx]));
+
+  const result: Track[] = new Array(total);
+  let mi = 0;
+  let ji = 0;
+  let ci = 0;
+  for (let i = 0; i < total; i++) {
+    if (jSlots.has(i)) {
+      result[i] = jingles[ji++];
+    } else if (cSlots.has(i)) {
+      result[i] = commercials[ci++];
+    } else {
+      result[i] = music[mi++];
+    }
+  }
+  return result;
+}
+
+function pickEvenSlots(total: number, count: number): Set<number> {
+  const slots = new Set<number>();
+  if (count <= 0 || total <= 0) return slots;
+  const step = total / count;
+  for (let i = 0; i < count; i++) {
+    slots.add(Math.floor(i * step + step / 2));
+  }
+  return slots;
 }

--- a/tests/main/playlist.test.ts
+++ b/tests/main/playlist.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+import { interleaveEvenly } from "../../src/main/playlist";
+import type { Track } from "../../src/main/db/types";
+
+type Kind = "m" | "j" | "c";
+
+function track(id: number, kind: Kind): Track {
+  const map = { m: "music", j: "jingle", c: "commercial" } as const;
+  return {
+    id,
+    path: `/${id}`,
+    content_type: map[kind],
+    title: `${kind}${id}`,
+    artist: "",
+    album: "",
+    genre: null,
+    year: null,
+    duration: 0,
+    bpm: null,
+    sample_rate: null,
+    bitrate: null,
+    format: "mp3",
+    play_count: 0,
+    added_at: "",
+  };
+}
+
+function kindsOf(tracks: Track[]): Kind[] {
+  return tracks.map((t) =>
+    t.content_type === "music" ? "m" : t.content_type === "jingle" ? "j" : "c",
+  );
+}
+
+function maxGap(kinds: Kind[], target: Kind): number {
+  const positions = kinds
+    .map((k, i) => (k === target ? i : -1))
+    .filter((i) => i !== -1);
+  if (positions.length < 2) return positions.length === 1 ? kinds.length : 0;
+  let max = 0;
+  for (let i = 1; i < positions.length; i++) {
+    max = Math.max(max, positions[i] - positions[i - 1]);
+  }
+  return max;
+}
+
+describe("interleaveEvenly", () => {
+  it("returns empty when all pools are empty", () => {
+    expect(interleaveEvenly([], [], [])).toEqual([]);
+  });
+
+  it("preserves total count and pool contents", () => {
+    const music = Array.from({ length: 13 }, (_, i) => track(i, "m"));
+    const jingles = Array.from({ length: 5 }, (_, i) => track(100 + i, "j"));
+    const commercials = Array.from({ length: 2 }, (_, i) =>
+      track(200 + i, "c"),
+    );
+
+    const out = interleaveEvenly(music, jingles, commercials);
+    expect(out).toHaveLength(20);
+
+    const ids = new Set(out.map((t) => t.id));
+    [...music, ...jingles, ...commercials].forEach((t) =>
+      expect(ids.has(t.id)).toBe(true),
+    );
+  });
+
+  it("preserves order within each pool", () => {
+    const music = Array.from({ length: 13 }, (_, i) => track(i, "m"));
+    const jingles = Array.from({ length: 5 }, (_, i) => track(100 + i, "j"));
+    const commercials = Array.from({ length: 2 }, (_, i) =>
+      track(200 + i, "c"),
+    );
+
+    const out = interleaveEvenly(music, jingles, commercials);
+    const ofKind = (k: Kind): number[] =>
+      out.filter((t) => kindsOf([t])[0] === k).map((t) => t.id);
+
+    expect(ofKind("m")).toEqual(music.map((t) => t.id));
+    expect(ofKind("j")).toEqual(jingles.map((t) => t.id));
+    expect(ofKind("c")).toEqual(commercials.map((t) => t.id));
+  });
+
+  it("spreads jingles roughly evenly across the playlist", () => {
+    const music = Array.from({ length: 15 }, (_, i) => track(i, "m"));
+    const jingles = Array.from({ length: 5 }, (_, i) => track(100 + i, "j"));
+    const out = interleaveEvenly(music, jingles, []);
+    const kinds = kindsOf(out);
+
+    // For 5 jingles in 20 slots, ideal step is 4. Allow some slack.
+    expect(maxGap(kinds, "j")).toBeLessThanOrEqual(5);
+  });
+
+  it("spreads commercials evenly", () => {
+    const music = Array.from({ length: 13 }, (_, i) => track(i, "m"));
+    const jingles = Array.from({ length: 5 }, (_, i) => track(100 + i, "j"));
+    const commercials = Array.from({ length: 2 }, (_, i) =>
+      track(200 + i, "c"),
+    );
+    const out = interleaveEvenly(music, jingles, commercials);
+    const kinds = kindsOf(out);
+
+    // 2 commercials in 20 slots — ideal gap ~10. Allow generous slack.
+    expect(maxGap(kinds, "c")).toBeLessThanOrEqual(14);
+    expect(maxGap(kinds, "c")).toBeGreaterThanOrEqual(6);
+  });
+
+  it("handles only-music input", () => {
+    const music = Array.from({ length: 5 }, (_, i) => track(i, "m"));
+    const out = interleaveEvenly(music, [], []);
+    expect(out.map((t) => t.id)).toEqual([0, 1, 2, 3, 4]);
+  });
+
+  it("handles only-jingles input", () => {
+    const jingles = Array.from({ length: 3 }, (_, i) => track(i, "j"));
+    const out = interleaveEvenly([], jingles, []);
+    expect(out.map((t) => t.id)).toEqual([0, 1, 2]);
+  });
+});


### PR DESCRIPTION
## Summary
- Auto playlist now blends music with jingles and commercials at fixed ratios (1 jingle per 4 slots, 1 commercial per 8 slots).
- Non-music slots are spaced evenly via a pure `interleaveEvenly` helper, so jingles/commercials are spread across the buffer rather than clustering.
- Falls back gracefully when the jingle or commercial pool is empty (e.g. no paths configured) — `getRandomTracks` simply returns nothing for that bucket.

Closes #17

## Test plan
- [x] `pnpm test -- run` (new `tests/main/playlist.test.ts` covers empty pools, count/content preservation, per-pool ordering, and even spacing for jingles + commercials)
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] Manual: scan a library with all three content types configured, toggle auto-playlist, verify jingles and commercials appear regularly through the queue

🤖 Generated with [Claude Code](https://claude.com/claude-code)