### PR TITLE
feat(scanner): incremental scan via mtime + preserve play_count

### DIFF
--- a/src/main/db/index.ts
+++ b/src/main/db/index.ts
@@ -5,17 +5,20 @@ import { Kysely, SqliteDialect, Migrator, Migration, sql } from "kysely";
 import { ContentType, LibraryStats, SortColumn, SortDir } from "../../types";
 import { Database, Track, TrackInsert } from "./types";
 import * as initial from "./migrations/001_initial";
+import * as trackMtime from "./migrations/002_track_mtime";
 
 const migrations: Record<string, Migration> = {
   "001_initial": initial,
+  "002_track_mtime": trackMtime,
 };
 
 let db: Kysely<Database>;
 let sqlite: BetterSqlite3.Database;
 
-export async function init(): Promise<Kysely<Database>> {
-  const dbPath = path.join(app.getPath("userData"), "diodedj.db");
-  sqlite = new BetterSqlite3(dbPath);
+export async function init(dbPath?: string): Promise<Kysely<Database>> {
+  const resolvedPath =
+    dbPath ?? path.join(app.getPath("userData"), "diodedj.db");
+  sqlite = new BetterSqlite3(resolvedPath);
   sqlite.pragma("journal_mode = WAL");
 
   db = new Kysely<Database>({
@@ -130,7 +133,34 @@ export async function getRandomTracks(
 }
 
 export async function insertTrack(track: TrackInsert): Promise<void> {
-  await db.replaceInto("tracks").values(track).execute();
+  await db
+    .insertInto("tracks")
+    .values(track)
+    .onConflict((oc) =>
+      oc.column("path").doUpdateSet({
+        content_type: track.content_type,
+        title: track.title,
+        artist: track.artist,
+        album: track.album,
+        genre: track.genre,
+        year: track.year,
+        duration: track.duration,
+        bpm: track.bpm,
+        sample_rate: track.sample_rate,
+        bitrate: track.bitrate,
+        format: track.format,
+        mtime: track.mtime,
+      }),
+    )
+    .execute();
+}
+
+export async function getTrackByPath(p: string): Promise<Track | undefined> {
+  return db
+    .selectFrom("tracks")
+    .selectAll()
+    .where("path", "=", p)
+    .executeTakeFirst();
 }
 
 export async function removeTracksNotInPaths(paths: string[]): Promise<number> {

--- a/src/main/db/migrations/002_track_mtime.ts
+++ b/src/main/db/migrations/002_track_mtime.ts
@@ -1,0 +1,9 @@
+import { Kysely, sql } from "kysely";
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`ALTER TABLE tracks ADD COLUMN mtime INTEGER`.execute(db);
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`ALTER TABLE tracks DROP COLUMN mtime`.execute(db);
+}

--- a/src/main/db/types.ts
+++ b/src/main/db/types.ts
@@ -17,6 +17,7 @@ export interface TracksTable {
   format: string;
   play_count: Generated<number>;
   added_at: Generated<string>;
+  mtime: number | null;
 }
 
 export interface Database {

--- a/src/main/scanner.ts
+++ b/src/main/scanner.ts
@@ -2,9 +2,20 @@ import fs from "fs";
 import path from "path";
 import { ContentType, ScanResult } from "../types";
 import * as db from "./db";
-import { TrackInsert } from "./db/types";
+import { Track, TrackInsert } from "./db/types";
 import { AUDIO_EXTENSIONS } from "./audio-formats";
 import { logger } from "./logger";
+
+export function shouldRescan(
+  existing: Track | undefined,
+  fileMtimeMs: number,
+  contentType: ContentType,
+): boolean {
+  if (!existing) return true;
+  if (existing.mtime == null) return true;
+  if (existing.content_type !== contentType) return true;
+  return Math.floor(existing.mtime) !== Math.floor(fileMtimeMs);
+}
 
 export async function scanDirectory(
   dirPath: string,
@@ -18,6 +29,16 @@ export async function scanDirectory(
 
   for (const filePath of files) {
     try {
+      const stat = await fs.promises.stat(filePath);
+      const mtimeMs = Math.floor(stat.mtimeMs);
+      const existing = await db.getTrackByPath(filePath);
+
+      if (!shouldRescan(existing, mtimeMs, contentType)) {
+        processed++;
+        if (onProgress) onProgress(processed, files.length);
+        continue;
+      }
+
       const metadata = await mm.parseFile(filePath);
       const { common, format } = metadata;
 
@@ -34,6 +55,7 @@ export async function scanDirectory(
         sample_rate: format.sampleRate || null,
         bitrate: format.bitrate || null,
         format: path.extname(filePath).slice(1).toLowerCase(),
+        mtime: mtimeMs,
       };
 
       await db.insertTrack(track);

--- a/tests/main/playlist.test.ts
+++ b/tests/main/playlist.test.ts
@@ -22,6 +22,7 @@ function track(id: number, kind: Kind): Track {
     format: "mp3",
     play_count: 0,
     added_at: "",
+    mtime: null,
   };
 }
 

--- a/tests/main/scanner.test.ts
+++ b/tests/main/scanner.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { shouldRescan } from "../../src/main/scanner";
+import type { Track } from "../../src/main/db/types";
+
+function makeTrack(partial: Partial<Track>): Track {
+  return {
+    id: 1,
+    path: "/x",
+    content_type: "music",
+    title: "t",
+    artist: "a",
+    album: "al",
+    genre: null,
+    year: null,
+    duration: 0,
+    bpm: null,
+    sample_rate: null,
+    bitrate: null,
+    format: "mp3",
+    play_count: 0,
+    added_at: "",
+    mtime: null,
+    ...partial,
+  };
+}
+
+describe("shouldRescan", () => {
+  it("returns true when no existing track", () => {
+    expect(shouldRescan(undefined, 100, "music")).toBe(true);
+  });
+
+  it("returns true when existing has null mtime", () => {
+    expect(shouldRescan(makeTrack({ mtime: null }), 100, "music")).toBe(true);
+  });
+
+  it("returns true when content_type differs", () => {
+    expect(
+      shouldRescan(
+        makeTrack({ mtime: 100, content_type: "music" }),
+        100,
+        "jingle",
+      ),
+    ).toBe(true);
+  });
+
+  it("returns true when mtime differs", () => {
+    expect(
+      shouldRescan(
+        makeTrack({ mtime: 100, content_type: "music" }),
+        200,
+        "music",
+      ),
+    ).toBe(true);
+  });
+
+  it("returns false when mtime + content_type match", () => {
+    expect(
+      shouldRescan(
+        makeTrack({ mtime: 100, content_type: "music" }),
+        100,
+        "music",
+      ),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
Foundation PR for #18 (background scan). Stacks under follow-up PR that moves scanning off the UI thread.

## Summary

- New migration `002_track_mtime` adds `tracks.mtime INTEGER`
- `db.init()` accepts optional `dbPath` (default unchanged) so tests can use `:memory:`
- `insertTrack` switches from `REPLACE INTO` to `INSERT ... ON CONFLICT(path) DO UPDATE SET ...` updating metadata + mtime, preserving `play_count`, `added_at`, and `id`
- New `db.getTrackByPath()` for the scanner skip-lookup
- Scanner stats each file, queries existing track by path, and skips reparse when path + mtime + `content_type` all match. Otherwise reparses and upserts.
- Pure `shouldRescan(existing, fileMtime, contentType)` helper extracted for unit testing

## Why

Two motivations beyond pure speedup of repeat scans:

1. The previous `REPLACE INTO` reset `play_count` to 0 every rescan — silently wiping play history. The upsert fixes this.
2. The follow-up background-scan PR will let users keep using the app during scans, which makes auto-rescanning more attractive. Skipping unchanged files keeps that cheap.

## Out of scope (separate issues)

- Pruning DB rows for files deleted on disk inside library roots — `removeTracksNotInPaths` only filters by path prefix, not actual existence. Separate bug.
- Filesystem watching.
- Auto-scan on launch.

## Test plan

- [x] `pnpm test` — 109 passing, 5 new `shouldRescan` unit tests
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm format:check`
- [x] Manual: scan a library twice, confirm second scan reports `added: 0` and play counts persist across rescan
- [ ] Manual: touch one file's mtime, rescan, confirm only that one is reparsed

## Note on test coverage

DB integration tests for the scanner (round-tripping through real SQLite) are intentionally not in this PR. `better-sqlite3` is built for Electron's Node ABI by `electron-builder install-app-deps` in postinstall; under the host Node it errors with `NODE_MODULE_VERSION` mismatch. Adding a rebuild step gates `pnpm test` on a yak-shave that breaks the dev app afterwards.

End-to-end coverage of the full scan path will come via Playwright in the background-scan PR (where the integration is tested through a real built Electron).

🤖 Generated with [Claude Code](https://claude.com/claude-code)