### PR TITLE
feat(playlist): manual jingle/commercial buttons (#16)

### DIFF
--- a/src/main/db/index.ts
+++ b/src/main/db/index.ts
@@ -185,7 +185,12 @@ export async function incrementPlayCount(id: number): Promise<void> {
 }
 
 export async function getStats(): Promise<LibraryStats> {
-  const result = await sql<LibraryStats>`
+  const totals = await sql<{
+    totalTracks: number;
+    totalArtists: number;
+    totalAlbums: number;
+    totalHours: number;
+  }>`
     SELECT
       COUNT(*) as totalTracks,
       COUNT(DISTINCT artist) as totalArtists,
@@ -193,7 +198,32 @@ export async function getStats(): Promise<LibraryStats> {
       ROUND(SUM(duration) / 3600.0, 1) as totalHours
     FROM tracks
   `.execute(db);
-  return result.rows[0];
+  const counts = await sql<{ content_type: ContentType; count: number }>`
+    SELECT content_type, COUNT(*) as count
+    FROM tracks
+    GROUP BY content_type
+  `.execute(db);
+  const tracksByType: Record<ContentType, number> = {
+    music: 0,
+    commercial: 0,
+    jingle: 0,
+  };
+  for (const row of counts.rows) tracksByType[row.content_type] = row.count;
+  return { ...totals.rows[0], tracksByType };
+}
+
+export async function getBottomNByPlayCount(
+  contentType: ContentType,
+  n: number,
+): Promise<Track[]> {
+  if (n <= 0) return [];
+  return db
+    .selectFrom("tracks")
+    .selectAll()
+    .where("content_type", "=", contentType)
+    .orderBy("play_count", "asc")
+    .limit(n)
+    .execute();
 }
 
 export async function close(): Promise<void> {

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -69,6 +69,10 @@ export function register(mainWindow: BrowserWindow): void {
     return playlist.generate(count);
   });
 
+  handle("pick-filler", async (_event, contentType: ContentType) => {
+    return playlist.pickFiller(contentType);
+  });
+
   handle("get-stats", async () => {
     return db.getStats();
   });

--- a/src/main/playlist.ts
+++ b/src/main/playlist.ts
@@ -1,9 +1,11 @@
 import { Track } from "./db/types";
 import * as db from "./db";
+import { ContentType } from "../types";
 
 // 1 jingle per ~JINGLE_EVERY tracks, 1 commercial per ~COMMERCIAL_EVERY tracks.
 const JINGLE_EVERY = 4;
 const COMMERCIAL_EVERY = 8;
+const FILLER_BUCKET_SIZE = 3;
 
 export async function generate(count: number = 20): Promise<Track[]> {
   if (count <= 0) return [];
@@ -57,6 +59,26 @@ export function interleaveEvenly(
     }
   }
   return result;
+}
+
+// Picks one filler track from the N tracks with the lowest play_count for the
+// given content_type. Selection is uniform-random within that bucket. Dupes
+// across consecutive calls are intentionally allowed — the bucket evolves as
+// play_count increases when tracks actually play.
+export async function pickFiller(
+  contentType: ContentType,
+): Promise<Track | null> {
+  const bucket = await db.getBottomNByPlayCount(
+    contentType,
+    FILLER_BUCKET_SIZE,
+  );
+  return pickRandom(bucket);
+}
+
+// Pure for testing.
+export function pickRandom<T>(items: T[]): T | null {
+  if (items.length === 0) return null;
+  return items[Math.floor(Math.random() * items.length)];
 }
 
 function pickEvenSlots(total: number, count: number): Set<number> {

--- a/src/main/playlist.ts
+++ b/src/main/playlist.ts
@@ -5,7 +5,11 @@ import { ContentType } from "../types";
 // 1 jingle per ~JINGLE_EVERY tracks, 1 commercial per ~COMMERCIAL_EVERY tracks.
 const JINGLE_EVERY = 4;
 const COMMERCIAL_EVERY = 8;
-const FILLER_BUCKET_SIZE = 3;
+
+// Manual filler selection: jingles are picked purely at random (small library,
+// repetition is fine and expected). Commercials draw from the 5 with the
+// lowest play_count to spread plays more evenly while staying random.
+const COMMERCIAL_BUCKET_SIZE = 5;
 
 export async function generate(count: number = 20): Promise<Track[]> {
   if (count <= 0) return [];
@@ -61,18 +65,26 @@ export function interleaveEvenly(
   return result;
 }
 
-// Picks one filler track from the N tracks with the lowest play_count for the
-// given content_type. Selection is uniform-random within that bucket. Dupes
-// across consecutive calls are intentionally allowed — the bucket evolves as
-// play_count increases when tracks actually play.
+// Picks one filler track. Jingles are chosen uniformly at random across the
+// whole library. Commercials are drawn uniform-random from the bottom
+// COMMERCIAL_BUCKET_SIZE by play_count so heavier-played commercials rotate
+// out as their counts grow. Dupes across consecutive calls are intentionally
+// allowed.
 export async function pickFiller(
   contentType: ContentType,
 ): Promise<Track | null> {
-  const bucket = await db.getBottomNByPlayCount(
-    contentType,
-    FILLER_BUCKET_SIZE,
-  );
-  return pickRandom(bucket);
+  if (contentType === "jingle") {
+    const [track] = await db.getRandomTracks(1, "jingle");
+    return track ?? null;
+  }
+  if (contentType === "commercial") {
+    const bucket = await db.getBottomNByPlayCount(
+      "commercial",
+      COMMERCIAL_BUCKET_SIZE,
+    );
+    return pickRandom(bucket);
+  }
+  return null;
 }
 
 // Pure for testing.

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -16,6 +16,8 @@ contextBridge.exposeInMainWorld("api", {
   trackPlayed: (id: number) => ipcRenderer.invoke("track-played", id),
   generatePlaylist: (count: number) =>
     ipcRenderer.invoke("generate-playlist", count),
+  pickFiller: (contentType: string) =>
+    ipcRenderer.invoke("pick-filler", contentType),
   getStats: () => ipcRenderer.invoke("get-stats"),
   getPaths: (type: string) => ipcRenderer.invoke("get-paths", type),
   getAllPaths: () => ipcRenderer.invoke("get-all-paths"),

--- a/src/renderer/components/PlaylistPanel.svelte
+++ b/src/renderer/components/PlaylistPanel.svelte
@@ -62,11 +62,27 @@
         History <span class="pl-tab-count">({app.history.length})</span>
       </button>
     </div>
-    <button
-      id="btn-clear-playlist"
-      title={app.playlistTab === "queue" ? "Clear queue" : "Clear history"}
-      onclick={onClear}>Clear</button
-    >
+    <div id="playlist-actions">
+      {#if app.playlistTab === "queue"}
+        <button
+          class="btn-filler"
+          title="Add a jingle to the queue"
+          disabled={(app.stats?.tracksByType.jingle ?? 0) === 0}
+          onclick={() => app.addFiller("jingle")}>+ Jingle</button
+        >
+        <button
+          class="btn-filler"
+          title="Add a commercial to the queue"
+          disabled={(app.stats?.tracksByType.commercial ?? 0) === 0}
+          onclick={() => app.addFiller("commercial")}>+ Commercial</button
+        >
+      {/if}
+      <button
+        id="btn-clear-playlist"
+        title={app.playlistTab === "queue" ? "Clear queue" : "Clear history"}
+        onclick={onClear}>Clear</button
+      >
+    </div>
   </div>
 
   {#if app.playlistTab === "queue"}

--- a/src/renderer/env.d.ts
+++ b/src/renderer/env.d.ts
@@ -49,6 +49,9 @@ interface ElectronAPI {
   saveSession(state: SessionPersistState): Promise<void>;
   trackPlayed(id: number): Promise<void>;
   generatePlaylist(count: number): Promise<import("../types").Track[]>;
+  pickFiller(
+    contentType: ContentType,
+  ): Promise<import("../types").Track | null>;
   getStats(): Promise<import("../types").LibraryStats>;
   getPaths(type: ContentType): Promise<string[]>;
   getAllPaths(): Promise<Record<ContentType, string[]>>;

--- a/src/renderer/state.svelte.ts
+++ b/src/renderer/state.svelte.ts
@@ -138,6 +138,13 @@ export class AppState {
     this.scheduleSave();
   }
 
+  async addFiller(contentType: ContentType): Promise<void> {
+    const track = await window.api.pickFiller(contentType);
+    if (!track) return;
+    this.playlist.push(track);
+    this.scheduleSave();
+  }
+
   playNow(track: Track): void {
     this.playTrack(track);
   }

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -216,6 +216,12 @@ body {
   font-variant-numeric: tabular-nums;
 }
 
+#playlist-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
 #btn-clear-playlist {
   padding: 3px 10px;
   background: var(--bg-tertiary);
@@ -229,6 +235,26 @@ body {
 #btn-clear-playlist:hover {
   color: #ff4444;
   border-color: #ff4444;
+}
+
+.btn-filler {
+  padding: 3px 10px;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-size: 11px;
+}
+
+.btn-filler:hover:not(:disabled) {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+
+.btn-filler:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
 }
 
 #track-list,

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,6 +28,7 @@ export interface LibraryStats {
   totalArtists: number;
   totalAlbums: number;
   totalHours: number;
+  tracksByType: Record<ContentType, number>;
 }
 
 export interface ScanResult {

--- a/tests/main/playlist.test.ts
+++ b/tests/main/playlist.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from "vitest";
-import { interleaveEvenly } from "../../src/main/playlist";
+import { describe, expect, it, vi } from "vitest";
+import { interleaveEvenly, pickRandom } from "../../src/main/playlist";
 import type { Track } from "../../src/main/db/types";
 
 type Kind = "m" | "j" | "c";
@@ -115,5 +115,34 @@ describe("interleaveEvenly", () => {
     const jingles = Array.from({ length: 3 }, (_, i) => track(i, "j"));
     const out = interleaveEvenly([], jingles, []);
     expect(out.map((t) => t.id)).toEqual([0, 1, 2]);
+  });
+});
+
+describe("pickRandom", () => {
+  it("returns null for empty input", () => {
+    expect(pickRandom([])).toBeNull();
+  });
+
+  it("returns the only item when input is singleton", () => {
+    const items = [track(1, "j")];
+    expect(pickRandom(items)).toBe(items[0]);
+  });
+
+  it("returns the item at the index produced by Math.random", () => {
+    const items = [track(1, "j"), track(2, "j"), track(3, "j")];
+    const spy = vi.spyOn(Math, "random").mockReturnValue(0.5); // floor(0.5*3) = 1
+    try {
+      expect(pickRandom(items)).toBe(items[1]);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("only returns items from the input bucket", () => {
+    const items = [track(1, "j"), track(2, "j"), track(3, "j")];
+    for (let i = 0; i < 50; i++) {
+      const picked = pickRandom(items);
+      expect(items).toContain(picked);
+    }
   });
 });


### PR DESCRIPTION
Closes #16.

## Summary
- Adds `+ Jingle` / `+ Commercial` buttons to the playlist panel header (queue tab only). Clicking appends one track to the end of the queue.
- **Jingles** — picked uniformly at random across the full jingle pool. Jingle libraries are small and repetition is expected, so weighting by `play_count` adds no value.
- **Commercials** — uniform-random pick from the 5 tracks with the lowest `play_count`. Bucket evolves naturally as `play_count` increments on actual playback, so heavy-played commercials rotate out and even distribution is preserved over time.
- Buttons are disabled when the library has zero tracks of that type. `LibraryStats` now exposes `tracksByType: Record<ContentType, number>`.

## Design decisions

**Why split jingle vs commercial selection?** Different goals. Jingles are short station idents, often a handful of files — repetition is fine, randomness alone is enough. Commercials are paid content where even rotation matters (advertisers expect their spots to play roughly evenly). Bottom-N by `play_count` enforces that without going full round-robin.

**Why bottom-5 for commercials, not weighted random?** Pure weighting (`1/(play_count+1)`) has degenerate cases — a single 0-play track dominates forever. Bottom-N + uniform random is predictable, naturally rotates as plays accumulate, and gives an obvious tuning knob. N=5 widens rotation enough that the bucket isn't repetitive while still favoring under-played tracks.

**Why allow duplicates on rapid clicks?** If the user spams `+ Commercial` 6 times and only 5 commercials exist in the bottom bucket, click 6 may repeat. Queue-aware dedup was rejected — it adds complexity (expand bucket on collision, fall back when exhausted) for a niche case.

**Why end of queue, not next-up or smart slot?** Manual override should be simple. The auto-playlist's `interleaveEvenly` handles smart placement when active. Appending is unambiguous.

**Auto-playlist interaction:** Buttons stay enabled during auto-playlist. Manual click appends; auto-refill continues from the new tail. No coupling.

## Test plan
- [x] vitest: new `pickRandom` pure-helper coverage (empty, singleton, mocked Math.random, bucket containment)
- [x] svelte-check + tsc clean
- [x] eslint + prettier clean
- [x] electron-vite build succeeds
- [x] Manual: click `+ Jingle` with empty jingle library → button disabled
- [x] Manual: click `+ Jingle` repeatedly → varied selection across full library, dupes possible
- [x] Manual: click `+ Commercial` repeatedly → favors lower-played commercials, rotation visible after a few plays
- [x] Manual: switch to History tab → filler buttons hidden
- [x] Manual: toggle Auto Playlist on, click `+ Commercial` → commercial appears at end of queue, auto-refill continues

🤖 Generated with [Claude Code](https://claude.com/claude-code)