### PR TITLE
fix(scanner): prune DB rows for files deleted inside library roots

### DIFF
--- a/src/main/db/index.ts
+++ b/src/main/db/index.ts
@@ -176,6 +176,30 @@ export async function removeTracksNotInPaths(paths: string[]): Promise<number> {
   return Number(result.numDeletedRows);
 }
 
+export async function getPathsUnder(root: string): Promise<string[]> {
+  const rows = await db
+    .selectFrom("tracks")
+    .select("path")
+    .where("path", "like", `${root}%`)
+    .execute();
+  return rows.map((r) => r.path);
+}
+
+export async function deleteByPaths(paths: string[]): Promise<number> {
+  if (paths.length === 0) return 0;
+  const CHUNK = 500;
+  let total = 0;
+  for (let i = 0; i < paths.length; i += CHUNK) {
+    const chunk = paths.slice(i, i + CHUNK);
+    const result = await db
+      .deleteFrom("tracks")
+      .where("path", "in", chunk)
+      .executeTakeFirst();
+    total += Number(result.numDeletedRows);
+  }
+  return total;
+}
+
 export async function incrementPlayCount(id: number): Promise<void> {
   await db
     .updateTable("tracks")

--- a/src/main/scanState.ts
+++ b/src/main/scanState.ts
@@ -69,6 +69,7 @@ async function run(signal: AbortSignal): Promise<void> {
   let cumulativeProcessed = 0;
   let cumulativeTotal = 0;
   let cumulativeAdded = 0;
+  const liveByRoot = new Map<string, Set<string>>();
 
   try {
     const allPaths = config.getAllPathsFlat();
@@ -102,6 +103,7 @@ async function run(signal: AbortSignal): Promise<void> {
         cumulativeProcessed += result.total;
         cumulativeTotal += result.total;
         cumulativeAdded += result.added;
+        liveByRoot.set(p, new Set(result.liveFiles ?? []));
         if (signal.aborted) {
           setState({
             status: "canceled",
@@ -113,6 +115,14 @@ async function run(signal: AbortSignal): Promise<void> {
         }
       }
     }
+
+    let pruned = 0;
+    for (const [root, live] of liveByRoot) {
+      const dbPaths = await db.getPathsUnder(root);
+      const stale = dbPaths.filter((dp) => !live.has(dp));
+      if (stale.length) pruned += await db.deleteByPaths(stale);
+    }
+    if (pruned > 0) logger.info(`scan pruned ${pruned} missing files`);
     logger.info(
       `scan complete: ${cumulativeTotal} tracks (${
         cumulativeAdded > 0 ? `${cumulativeAdded} new/updated` : "no changes"

--- a/src/main/scanner.ts
+++ b/src/main/scanner.ts
@@ -17,12 +17,14 @@ export function shouldRescan(
   return Math.floor(existing.mtime) !== Math.floor(fileMtimeMs);
 }
 
+export type InternalScanResult = ScanResult & { liveFiles: string[] };
+
 export async function scanDirectory(
   dirPath: string,
   contentType: ContentType = "music",
   onProgress?: (processed: number, total: number) => void,
   signal?: AbortSignal,
-): Promise<ScanResult> {
+): Promise<InternalScanResult> {
   const mm = await import("music-metadata");
   const files = await findAudioFiles(dirPath);
   let processed = 0;
@@ -70,7 +72,7 @@ export async function scanDirectory(
     if (onProgress) onProgress(processed, files.length);
   }
 
-  return { total: files.length, added };
+  return { total: files.length, added, liveFiles: files };
 }
 
 async function findAudioFiles(dirPath: string): Promise<string[]> {

--- a/tests/main/scanState.test.ts
+++ b/tests/main/scanState.test.ts
@@ -23,8 +23,12 @@ vi.mock("../../src/main/logger", () => ({
     silly: vi.fn(),
   },
 }));
+const getPathsUnder = vi.fn(async (): Promise<string[]> => []);
+const deleteByPaths = vi.fn(async (): Promise<number> => 0);
 vi.mock("../../src/main/db", () => ({
   removeTracksNotInPaths: vi.fn(async () => 0),
+  getPathsUnder: (root: string) => getPathsUnder(root),
+  deleteByPaths: (paths: string[]) => deleteByPaths(paths),
 }));
 vi.mock("../../src/main/config", () => ({
   getAllPathsFlat: () => ["/lib/music"],
@@ -55,6 +59,10 @@ function abortableMock(
 
 beforeEach(() => {
   scanDirectory.mockReset();
+  getPathsUnder.mockReset();
+  getPathsUnder.mockImplementation(async () => []);
+  deleteByPaths.mockReset();
+  deleteByPaths.mockImplementation(async () => 0);
 });
 
 afterEach(async () => {
@@ -128,6 +136,40 @@ describe("scanState", () => {
     const s = scanState.getStatus();
     expect(s.status).toBe("error");
     if (s.status === "error") expect(s.message).toContain("boom");
+  });
+
+  it("prunes DB paths missing from disk after scan completes", async () => {
+    scanDirectory.mockImplementation(async () => ({
+      total: 1,
+      added: 0,
+      liveFiles: ["/lib/music/keep.mp3"],
+    }));
+    getPathsUnder.mockImplementation(async (root: string) =>
+      root === "/lib/music"
+        ? ["/lib/music/keep.mp3", "/lib/music/gone.mp3"]
+        : [],
+    );
+
+    scanState.start();
+    await scanState.waitForIdle();
+
+    expect(deleteByPaths).toHaveBeenCalledWith(["/lib/music/gone.mp3"]);
+  });
+
+  it("does not prune when scan is canceled", async () => {
+    scanDirectory.mockImplementation(async (_p, _t, _op, signal) => {
+      await new Promise<void>((resolve) => {
+        signal?.addEventListener("abort", () => resolve());
+      });
+      return { total: 0, added: 0, liveFiles: [] };
+    });
+    getPathsUnder.mockImplementation(async () => ["/lib/music/anything.mp3"]);
+
+    scanState.start();
+    await new Promise((r) => setTimeout(r, 10));
+    await scanState.cancel();
+
+    expect(deleteByPaths).not.toHaveBeenCalled();
   });
 
   it("emits progress events from scanner callbacks", async () => {

--- a/tests/main/scanState.test.ts
+++ b/tests/main/scanState.test.ts
@@ -23,8 +23,12 @@ vi.mock("../../src/main/logger", () => ({
     silly: vi.fn(),
   },
 }));
-const getPathsUnder = vi.fn(async (): Promise<string[]> => []);
-const deleteByPaths = vi.fn(async (): Promise<number> => 0);
+const getPathsUnder = vi.fn<(root: string) => Promise<string[]>>(
+  async () => [],
+);
+const deleteByPaths = vi.fn<(paths: string[]) => Promise<number>>(
+  async () => 0,
+);
 vi.mock("../../src/main/db", () => ({
   removeTracksNotInPaths: vi.fn(async () => 0),
   getPathsUnder: (root: string) => getPathsUnder(root),


### PR DESCRIPTION
Closes #67

## Summary
- After scan finishes (and was not canceled), diff each library root's live disk files against DB rows under that root and delete the missing ones.
- New `db.getPathsUnder(root)` and `db.deleteByPaths(paths)` (chunked at 500 to stay under SQLite param limit).
- `scanner.scanDirectory` now returns `liveFiles: string[]` so `scanState` can build the per-root live set without re-walking.
- Skip prune entirely on cancel — incomplete walk would otherwise nuke rows under unvisited roots.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test -- run` (124 pass, incl. two new cases: prune happens when DB row missing from disk; no prune on cancel)
- [x] Manual: configure library, scan, delete a file from disk, scan again — row gone, search no longer returns it

🤖 Generated with [Claude Code](https://claude.com/claude-code)