### PR TITLE
refactor(player): introduce PlayerBackend abstraction

### DIFF
--- a/src/renderer/player/backend.ts
+++ b/src/renderer/player/backend.ts
@@ -1,0 +1,19 @@
+export type PlayerEvent =
+  | { type: "time"; seconds: number }
+  | { type: "duration"; seconds: number }
+  | { type: "pause-state"; paused: boolean }
+  | { type: "ended" }
+  | { type: "error"; message: string };
+
+export type PlayerEventHandler = (event: PlayerEvent) => void;
+
+export interface PlayerBackend {
+  load(url: string): Promise<void>;
+  play(): Promise<void>;
+  pause(): Promise<void>;
+  stop(): Promise<void>;
+  seek(seconds: number): Promise<void>;
+  setVolume(volume: number): Promise<void>;
+  on(handler: PlayerEventHandler): () => void;
+  dispose(): Promise<void>;
+}

--- a/src/renderer/player/htmlAudioBackend.ts
+++ b/src/renderer/player/htmlAudioBackend.ts
@@ -1,0 +1,100 @@
+import type { PlayerBackend, PlayerEvent, PlayerEventHandler } from "./backend";
+
+export class HtmlAudioBackend implements PlayerBackend {
+  private audio: HTMLAudioElement;
+  private handlers = new Set<PlayerEventHandler>();
+
+  constructor() {
+    this.audio = new Audio();
+    this.audio.addEventListener("play", () => {
+      this.emit({ type: "pause-state", paused: false });
+    });
+    this.audio.addEventListener("pause", () => {
+      this.emit({ type: "pause-state", paused: true });
+    });
+    this.audio.addEventListener("timeupdate", () => {
+      this.emit({ type: "time", seconds: this.audio.currentTime });
+      const d = this.audio.duration;
+      if (isFinite(d) && d > 0) {
+        this.emit({ type: "duration", seconds: d });
+      }
+    });
+    this.audio.addEventListener("durationchange", () => {
+      const d = this.audio.duration;
+      if (isFinite(d) && d > 0) {
+        this.emit({ type: "duration", seconds: d });
+      }
+    });
+    this.audio.addEventListener("ended", () => {
+      this.emit({ type: "ended" });
+    });
+    this.audio.addEventListener("error", () => {
+      const err = this.audio.error;
+      this.emit({
+        type: "error",
+        message: err?.message ?? `code ${err?.code ?? "unknown"}`,
+      });
+    });
+  }
+
+  load(url: string): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const onLoaded = (): void => {
+        cleanup();
+        resolve();
+      };
+      const onError = (): void => {
+        cleanup();
+        reject(new Error(this.audio.error?.message ?? "audio element error"));
+      };
+      const cleanup = (): void => {
+        this.audio.removeEventListener("loadedmetadata", onLoaded);
+        this.audio.removeEventListener("error", onError);
+      };
+      this.audio.addEventListener("loadedmetadata", onLoaded);
+      this.audio.addEventListener("error", onError);
+      this.audio.src = url;
+      this.audio.load();
+    });
+  }
+
+  async play(): Promise<void> {
+    await this.audio.play();
+  }
+
+  async pause(): Promise<void> {
+    this.audio.pause();
+  }
+
+  async stop(): Promise<void> {
+    this.audio.pause();
+    this.audio.removeAttribute("src");
+    this.audio.load();
+  }
+
+  async seek(seconds: number): Promise<void> {
+    this.audio.currentTime = seconds;
+  }
+
+  async setVolume(volume: number): Promise<void> {
+    this.audio.volume = volume;
+  }
+
+  on(handler: PlayerEventHandler): () => void {
+    this.handlers.add(handler);
+    return () => {
+      this.handlers.delete(handler);
+    };
+  }
+
+  async dispose(): Promise<void> {
+    this.audio.pause();
+    this.audio.removeAttribute("src");
+    this.audio.load();
+    this.handlers.clear();
+  }
+
+  private emit(event: PlayerEvent): void {
+    for (const h of this.handlers) h(event);
+  }
+}

--- a/src/renderer/player/htmlAudioBackend.ts
+++ b/src/renderer/player/htmlAudioBackend.ts
@@ -6,6 +6,8 @@ export class HtmlAudioBackend implements PlayerBackend {
 
   constructor() {
     this.audio = new Audio();
+    this.audio.id = "audio";
+    document.body.appendChild(this.audio);
     this.audio.addEventListener("play", () => {
       this.emit({ type: "pause-state", paused: false });
     });

--- a/src/renderer/state.svelte.ts
+++ b/src/renderer/state.svelte.ts
@@ -6,6 +6,8 @@ import type {
   Track,
 } from "../types";
 import logger from "electron-log/renderer";
+import type { PlayerBackend } from "./player/backend";
+import { HtmlAudioBackend } from "./player/htmlAudioBackend";
 
 export type { Track };
 
@@ -48,39 +50,33 @@ export class AppState {
   hoverX = $state(0);
   hoverY = $state(0);
 
-  audio: HTMLAudioElement;
+  backend: PlayerBackend;
 
   private saveTimer: ReturnType<typeof setTimeout> | null = null;
   private sessionLoaded = false;
 
-  constructor() {
-    this.audio = new Audio();
-    this.audio.id = "audio";
-    document.body.appendChild(this.audio);
-    this.audio.addEventListener("play", () => {
-      this.isPlaying = true;
-    });
-    this.audio.addEventListener("pause", () => {
-      this.isPlaying = false;
-    });
-    this.audio.addEventListener("timeupdate", () => {
-      this.currentTime = this.audio.currentTime;
-      this.duration =
-        isFinite(this.audio.duration) && this.audio.duration > 0
-          ? this.audio.duration
-          : (this.currentTrack?.duration ?? 0);
-      this.scheduleSave();
-    });
-    this.audio.addEventListener("ended", () => {
-      void this.handleEnded();
-    });
-    this.audio.addEventListener("error", () => {
-      const err = this.audio.error;
-      logger.error("Audio error:", {
-        code: err?.code,
-        message: err?.message,
-        src: this.audio.currentSrc,
-      });
+  constructor(backend?: PlayerBackend) {
+    this.backend = backend ?? new HtmlAudioBackend();
+
+    this.backend.on((event) => {
+      switch (event.type) {
+        case "pause-state":
+          this.isPlaying = !event.paused;
+          break;
+        case "time":
+          this.currentTime = event.seconds;
+          this.scheduleSave();
+          break;
+        case "duration":
+          this.duration = event.seconds;
+          break;
+        case "ended":
+          void this.handleEnded();
+          break;
+        case "error":
+          logger.error("Audio error:", event.message);
+          break;
+      }
     });
 
     window.api.onScanProgress(({ processed, total }) => {
@@ -105,7 +101,7 @@ export class AppState {
 
   setVolume(v: number): void {
     this.volume = v;
-    this.audio.volume = v;
+    void this.backend.setVolume(v);
     this.scheduleSave();
   }
 
@@ -213,12 +209,22 @@ export class AppState {
 
   private setCurrent(track: Track): void {
     this.currentTrack = track;
-    this.audio.src = window.api.getMediaUrl(track.id);
-    void this.audio.play();
+    this.duration = track.duration ?? 0;
+    this.currentTime = 0;
+    void this.loadAndPlay(track);
     void window.api.trackPlayed(track.id);
     document.title = `${track.title} - ${track.artist} | DiodeDJ`;
     void this.maybeRefillPlaylist();
     this.scheduleSave();
+  }
+
+  private async loadAndPlay(track: Track): Promise<void> {
+    try {
+      await this.backend.load(window.api.getMediaUrl(track.id));
+      await this.backend.play();
+    } catch (err) {
+      logger.error("Load/play failed:", err);
+    }
   }
 
   togglePlay(): void {
@@ -226,22 +232,23 @@ export class AppState {
       if (this.playlist.length > 0) this.playIndex(0);
       return;
     }
-    if (this.audio.paused) {
-      this.audio.play().catch((err) => logger.error("Resume failed:", err));
+    if (this.isPlaying) {
+      void this.backend.pause();
     } else {
-      this.audio.pause();
+      void this.backend
+        .play()
+        .catch((err) => logger.error("Resume failed:", err));
     }
   }
 
   stop(): void {
     if (this.currentTrack) this.appendHistory(this.currentTrack);
-    this.audio.pause();
-    this.audio.removeAttribute("src");
-    this.audio.load();
+    void this.backend.stop();
     this.currentTrack = null;
     this.autoPlaylistActive = false;
     this.currentTime = 0;
     this.duration = 0;
+    this.isPlaying = false;
     document.title = "DiodeDJ";
     this.scheduleSave();
   }
@@ -251,17 +258,22 @@ export class AppState {
   }
 
   prev(): void {
-    if (this.currentTrack && this.audio.currentTime > 3) {
-      this.audio.currentTime = 0;
+    if (this.currentTrack && this.currentTime > 3) {
+      this.currentTime = 0;
+      void this.backend.seek(0);
       return;
     }
     const previous = this.history[this.history.length - 1];
     if (!previous) {
-      if (this.currentTrack) this.audio.currentTime = 0;
+      if (this.currentTrack) {
+        this.currentTime = 0;
+        void this.backend.seek(0);
+      }
       return;
     }
     if (this.currentTrack?.id === previous.id) {
-      this.audio.currentTime = 0;
+      this.currentTime = 0;
+      void this.backend.seek(0);
       return;
     }
     if (this.currentTrack) this.playlist.unshift(this.currentTrack);
@@ -307,11 +319,11 @@ export class AppState {
   seekToPct(pct: number): void {
     if (!this.duration) return;
     const clamped = Math.min(1, Math.max(0, pct));
-    try {
-      this.audio.currentTime = clamped * this.duration;
-    } catch (err) {
+    const seconds = clamped * this.duration;
+    this.currentTime = seconds;
+    void this.backend.seek(seconds).catch((err) => {
       logger.error("Seek failed:", err);
-    }
+    });
   }
 
   async loadStats(): Promise<void> {
@@ -342,25 +354,26 @@ export class AppState {
       state.currentTrackId !== null ? byId.get(state.currentTrackId) : null;
     if (restored) {
       this.currentTrack = restored;
-      this.audio.src = window.api.getMediaUrl(restored.id);
       this.duration = restored.duration ?? 0;
-      const seek = state.currentTime;
-      if (seek > 0) {
-        this.currentTime = seek;
-        const onMeta = (): void => {
-          try {
-            this.audio.currentTime = seek;
-          } catch (err) {
-            logger.error("Resume seek failed:", err);
-          }
-          this.audio.removeEventListener("loadedmetadata", onMeta);
-        };
-        this.audio.addEventListener("loadedmetadata", onMeta);
+      if (state.currentTime > 0) {
+        this.currentTime = state.currentTime;
       }
+      void this.loadWithSeek(restored, state.currentTime);
       document.title = `${restored.title} - ${restored.artist} | DiodeDJ`;
     }
 
     this.sessionLoaded = true;
+  }
+
+  private async loadWithSeek(track: Track, seek: number): Promise<void> {
+    try {
+      await this.backend.load(window.api.getMediaUrl(track.id));
+      if (seek > 0) {
+        await this.backend.seek(seek);
+      }
+    } catch (err) {
+      logger.error("Resume load failed:", err);
+    }
   }
 
   private scheduleSave(): void {

--- a/tests/renderer/mockBackend.ts
+++ b/tests/renderer/mockBackend.ts
@@ -1,0 +1,94 @@
+import type {
+  PlayerBackend,
+  PlayerEvent,
+  PlayerEventHandler,
+} from "../../src/renderer/player/backend";
+
+export class MockBackend implements PlayerBackend {
+  loadedUrls: string[] = [];
+  seekCalls: number[] = [];
+  volume = 1;
+  playCalls = 0;
+  pauseCalls = 0;
+  stopCalls = 0;
+  disposeCalls = 0;
+  loadShouldReject = false;
+  playShouldReject = false;
+  seekShouldReject = false;
+
+  private handlers = new Set<PlayerEventHandler>();
+
+  async load(url: string): Promise<void> {
+    this.loadedUrls.push(url);
+    if (this.loadShouldReject) throw new Error("load failed");
+  }
+
+  async play(): Promise<void> {
+    this.playCalls++;
+    if (this.playShouldReject) throw new Error("play failed");
+    this.emit({ type: "pause-state", paused: false });
+  }
+
+  async pause(): Promise<void> {
+    this.pauseCalls++;
+    this.emit({ type: "pause-state", paused: true });
+  }
+
+  async stop(): Promise<void> {
+    this.stopCalls++;
+    this.emit({ type: "pause-state", paused: true });
+  }
+
+  async seek(seconds: number): Promise<void> {
+    this.seekCalls.push(seconds);
+    if (this.seekShouldReject) throw new Error("seek failed");
+  }
+
+  async setVolume(volume: number): Promise<void> {
+    this.volume = volume;
+  }
+
+  on(handler: PlayerEventHandler): () => void {
+    this.handlers.add(handler);
+    return () => {
+      this.handlers.delete(handler);
+    };
+  }
+
+  async dispose(): Promise<void> {
+    this.disposeCalls++;
+    this.handlers.clear();
+  }
+
+  emitTime(seconds: number): void {
+    this.emit({ type: "time", seconds });
+  }
+
+  emitDuration(seconds: number): void {
+    this.emit({ type: "duration", seconds });
+  }
+
+  emitPauseState(paused: boolean): void {
+    this.emit({ type: "pause-state", paused });
+  }
+
+  emitEnded(): void {
+    this.emit({ type: "ended" });
+  }
+
+  emitError(message: string): void {
+    this.emit({ type: "error", message });
+  }
+
+  get lastLoadedUrl(): string | undefined {
+    return this.loadedUrls[this.loadedUrls.length - 1];
+  }
+
+  get lastSeek(): number | undefined {
+    return this.seekCalls[this.seekCalls.length - 1];
+  }
+
+  private emit(event: PlayerEvent): void {
+    for (const h of this.handlers) h(event);
+  }
+}

--- a/tests/renderer/state.test.ts
+++ b/tests/renderer/state.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MockBackend } from "./mockBackend";
 
 vi.mock("electron-log/renderer", () => ({
   default: {
@@ -89,25 +90,21 @@ function resetApi(): void {
   api.saveSession.mockResolvedValue(undefined);
 }
 
-function makeApp(): AppState {
-  document.body.innerHTML = "";
-  document.title = "DiodeDJ";
-  const app = new AppState();
-  vi.spyOn(app.audio, "play").mockResolvedValue();
-  vi.spyOn(app.audio, "pause").mockImplementation(() => {});
-  vi.spyOn(app.audio, "load").mockImplementation(() => {});
-  return app;
+interface TestApp {
+  app: AppState;
+  mock: MockBackend;
 }
 
-function defineMutableCurrentTime(
-  audio: HTMLAudioElement,
-  value: number,
-): void {
-  Object.defineProperty(audio, "currentTime", {
-    value,
-    writable: true,
-    configurable: true,
-  });
+function makeApp(): TestApp {
+  document.body.innerHTML = "";
+  document.title = "DiodeDJ";
+  const mock = new MockBackend();
+  const app = new AppState(mock);
+  return { app, mock };
+}
+
+async function flushAsync(): Promise<void> {
+  for (let i = 0; i < 5; i++) await Promise.resolve();
 }
 
 describe("formatTime", () => {
@@ -128,7 +125,7 @@ describe("AppState playlist mutations", () => {
   let app: AppState;
   beforeEach(() => {
     resetApi();
-    app = makeApp();
+    app = makeApp().app;
   });
 
   it("addToPlaylist appends tracks", () => {
@@ -176,7 +173,7 @@ describe("AppState history view", () => {
   let app: AppState;
   beforeEach(() => {
     resetApi();
-    app = makeApp();
+    app = makeApp().app;
   });
 
   it("playlistTab defaults to queue", () => {
@@ -236,9 +233,10 @@ describe("AppState history view", () => {
 
 describe("AppState playback control", () => {
   let app: AppState;
+  let mock: MockBackend;
   beforeEach(() => {
     resetApi();
-    app = makeApp();
+    ({ app, mock } = makeApp());
   });
 
   it("playIndex pulls track out of playlist into currentTrack and plays it", () => {
@@ -246,7 +244,7 @@ describe("AppState playback control", () => {
     app.playIndex(0);
     expect(app.currentTrack?.id).toBe(7);
     expect(app.playlist.length).toBe(0);
-    expect(app.audio.getAttribute("src")).toBe("media://track/7");
+    expect(mock.lastLoadedUrl).toBe("media://track/7");
     expect(api.trackPlayed).toHaveBeenCalledWith(7);
     expect(document.title).toBe("Song - Band | DiodeDJ");
   });
@@ -292,9 +290,10 @@ describe("AppState playback control", () => {
 
   it("prev after 3s seeks to start of current track", () => {
     app.currentTrack = t(1);
-    defineMutableCurrentTime(app.audio, 5);
+    app.currentTime = 5;
     app.prev();
-    expect(app.audio.currentTime).toBe(0);
+    expect(app.currentTime).toBe(0);
+    expect(mock.lastSeek).toBe(0);
     expect(app.currentTrack?.id).toBe(1);
   });
 
@@ -305,7 +304,7 @@ describe("AppState playback control", () => {
     app.playIndex(0);
     expect(app.currentTrack?.id).toBe(2);
     expect(app.history.map((x) => x.id)).toEqual([1]);
-    defineMutableCurrentTime(app.audio, 1);
+    app.currentTime = 1;
     app.prev();
     expect(app.currentTrack?.id).toBe(1);
     expect(app.history.map((x) => x.id)).toEqual([1]);
@@ -317,30 +316,32 @@ describe("AppState playback control", () => {
     app.addToPlaylist(t(2));
     app.playIndex(0);
     app.playIndex(0);
-    defineMutableCurrentTime(app.audio, 1);
+    app.currentTime = 1;
     app.prev();
     expect(app.currentTrack?.id).toBe(1);
     expect(app.playlist.map((x) => x.id)).toEqual([2]);
-    defineMutableCurrentTime(app.audio, 1);
+    app.currentTime = 1;
     app.prev();
     expect(app.currentTrack?.id).toBe(1);
     expect(app.history.map((x) => x.id)).toEqual([1]);
     expect(app.playlist.map((x) => x.id)).toEqual([2]);
-    expect(app.audio.currentTime).toBe(0);
+    expect(app.currentTime).toBe(0);
   });
 
   it("prev within 3s with empty history just restarts current", () => {
     app.currentTrack = t(1);
-    defineMutableCurrentTime(app.audio, 1);
+    app.currentTime = 1;
     app.prev();
-    expect(app.audio.currentTime).toBe(0);
+    expect(app.currentTime).toBe(0);
+    expect(mock.lastSeek).toBe(0);
     expect(app.currentTrack?.id).toBe(1);
   });
 
   it("prev is a no-op when no current track and empty history", () => {
-    defineMutableCurrentTime(app.audio, 5);
+    app.currentTime = 5;
     app.prev();
-    expect(app.audio.currentTime).toBe(5);
+    expect(app.currentTime).toBe(5);
+    expect(mock.seekCalls.length).toBe(0);
     expect(app.currentTrack).toBeNull();
   });
 
@@ -388,30 +389,35 @@ describe("AppState playback control", () => {
     expect(app.currentTime).toBe(0);
     expect(app.duration).toBe(0);
     expect(document.title).toBe("DiodeDJ");
+    expect(mock.stopCalls).toBeGreaterThan(0);
   });
 
-  it("setVolume updates state and audio element", () => {
+  it("setVolume updates state and backend", () => {
     app.setVolume(0.4);
     expect(app.volume).toBe(0.4);
-    expect(app.audio.volume).toBe(0.4);
+    expect(mock.volume).toBe(0.4);
   });
 
-  it("seekToPct clamps and applies to audio.currentTime", () => {
+  it("seekToPct clamps and applies via backend", () => {
     app.duration = 100;
-    defineMutableCurrentTime(app.audio, 0);
+    app.currentTime = 0;
     app.seekToPct(0.5);
-    expect(app.audio.currentTime).toBe(50);
+    expect(app.currentTime).toBe(50);
+    expect(mock.lastSeek).toBe(50);
     app.seekToPct(2);
-    expect(app.audio.currentTime).toBe(100);
+    expect(app.currentTime).toBe(100);
+    expect(mock.lastSeek).toBe(100);
     app.seekToPct(-1);
-    expect(app.audio.currentTime).toBe(0);
+    expect(app.currentTime).toBe(0);
+    expect(mock.lastSeek).toBe(0);
   });
 
   it("seekToPct is a no-op when duration is zero", () => {
     app.duration = 0;
-    defineMutableCurrentTime(app.audio, 7);
+    app.currentTime = 7;
     app.seekToPct(0.5);
-    expect(app.audio.currentTime).toBe(7);
+    expect(app.currentTime).toBe(7);
+    expect(mock.seekCalls.length).toBe(0);
   });
 
   it("progressPct reflects currentTime/duration ratio", () => {
@@ -420,6 +426,52 @@ describe("AppState playback control", () => {
     expect(app.progressPct).toBe(25);
     app.duration = 0;
     expect(app.progressPct).toBe(0);
+  });
+});
+
+describe("AppState backend events", () => {
+  let app: AppState;
+  let mock: MockBackend;
+  beforeEach(() => {
+    resetApi();
+    ({ app, mock } = makeApp());
+  });
+
+  it("time event mirrors to currentTime", () => {
+    mock.emitTime(42);
+    expect(app.currentTime).toBe(42);
+  });
+
+  it("duration event mirrors to duration", () => {
+    mock.emitDuration(180);
+    expect(app.duration).toBe(180);
+  });
+
+  it("pause-state event mirrors to isPlaying (inverse)", () => {
+    mock.emitPauseState(false);
+    expect(app.isPlaying).toBe(true);
+    mock.emitPauseState(true);
+    expect(app.isPlaying).toBe(false);
+  });
+
+  it("ended event triggers auto-advance when enabled", async () => {
+    app.addToPlaylist(t(1));
+    app.addToPlaylist(t(2));
+    app.playIndex(0);
+    expect(app.currentTrack?.id).toBe(1);
+    mock.emitEnded();
+    await flushAsync();
+    expect(app.currentTrack?.id).toBe(2);
+  });
+
+  it("ended event stops playback when autoAdvance is false", async () => {
+    app.addToPlaylist(t(1));
+    app.addToPlaylist(t(2));
+    app.playIndex(0);
+    app.autoAdvance = false;
+    mock.emitEnded();
+    await flushAsync();
+    expect(app.currentTrack).toBeNull();
   });
 });
 
@@ -439,7 +491,7 @@ describe("AppState library + paths", () => {
       commercial: [],
       jingle: [],
     });
-    app = makeApp();
+    app = makeApp().app;
   });
 
   it("search forwards query + tab and stores results", async () => {
@@ -554,7 +606,7 @@ describe("AppState auto-playlist refill", () => {
   beforeEach(() => {
     resetApi();
     api.generatePlaylist.mockResolvedValue(generateTracks(0, bufferSize));
-    app = makeApp();
+    app = makeApp().app;
   });
 
   it("does nothing when auto-playlist is inactive", async () => {
@@ -596,6 +648,7 @@ describe("AppState auto-playlist refill", () => {
 
 describe("AppState session persistence", () => {
   let app: AppState;
+  let mock: MockBackend;
 
   beforeEach(() => {
     resetApi();
@@ -620,7 +673,7 @@ describe("AppState session persistence", () => {
       tracks: [t(1), t(2), t(3)],
     });
 
-    app = makeApp();
+    ({ app, mock } = makeApp());
     await app.loadSession();
 
     expect(app.playlist.map((x) => x.id)).toEqual([2, 3]);
@@ -630,7 +683,7 @@ describe("AppState session persistence", () => {
     expect(app.autoAdvance).toBe(false);
     expect(app.volume).toBe(0.6);
     expect(app.currentTime).toBe(12.5);
-    expect(app.audio.getAttribute("src")).toBe("media://track/2");
+    expect(mock.lastLoadedUrl).toBe("media://track/2");
     expect(document.title).toBe("t2 - a2 | DiodeDJ");
   });
 
@@ -648,7 +701,7 @@ describe("AppState session persistence", () => {
       tracks: [t(1), t(2)],
     });
 
-    app = makeApp();
+    ({ app, mock } = makeApp());
     await app.loadSession();
 
     expect(app.playlist.map((x) => x.id)).toEqual([1, 2]);
@@ -657,14 +710,14 @@ describe("AppState session persistence", () => {
   });
 
   it("does not save before session is loaded", () => {
-    app = makeApp();
+    ({ app, mock } = makeApp());
     app.addToPlaylist(t(1));
     vi.runAllTimers();
     expect(api.saveSession).not.toHaveBeenCalled();
   });
 
   it("debounced save fires after mutations once session is loaded", async () => {
-    app = makeApp();
+    ({ app, mock } = makeApp());
     await app.loadSession();
     app.addToPlaylist(t(1));
     app.addToPlaylist(t(2));
@@ -679,7 +732,7 @@ describe("AppState session persistence", () => {
   });
 
   it("flushSave persists immediately and cancels pending timer", async () => {
-    app = makeApp();
+    ({ app, mock } = makeApp());
     await app.loadSession();
     app.addToPlaylist(t(5));
     app.flushSave();


### PR DESCRIPTION
## Summary

Step 1 of the SP3 ship plan in [docs/audio-backend-and-cue-deck.md](./docs/audio-backend-and-cue-deck.md) toward closing #43.

- Adds `PlayerBackend` interface (`src/renderer/player/backend.ts`) with async `load`/`play`/`pause`/`stop`/`seek`/`setVolume`/`dispose` and a `PlayerEvent` emitter contract. Shape is IPC-compatible so PR-2's mpv-via-IPC impl is drop-in.
- Adds `HtmlAudioBackend` wrapping the existing `<audio>` element, preserving the exact behavior `AppState` had before (including the `removeAttribute("src") + load()` clear-on-stop dance noted in CLAUDE.md).
- Refactors `AppState` to drive the backend instead of an `HTMLAudioElement` it owned directly. Constructor takes an optional backend (`new AppState(backend)`), defaulting to `new HtmlAudioBackend()` — no behavior change for the running app.
- Tests gain a `MockBackend` fixture; assertions that previously poked the audio element now go through the backend's recorded calls and emitted events.

No mpv / cue-deck work yet — those land in PR-2 and PR-3 respectively.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test -- run` — 129 passed
- [x] `pnpm build`
- [ ] Manual smoke: `pnpm dev`, verify play/pause/seek/volume/next/prev/stop/auto-advance still behave identically

🤖 Generated with [Claude Code](https://claude.com/claude-code)