### PR TITLE
feat(audio): cue deck backend (cue deck step 2/4)

### DIFF
--- a/src-tauri/src/audio/devices.rs
+++ b/src-tauri/src/audio/devices.rs
@@ -1,6 +1,8 @@
 use cpal::traits::{DeviceTrait, HostTrait};
 use serde::{Deserialize, Serialize};
 
+use crate::persist::config::DeviceRef;
+
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct DeviceInfo {
@@ -33,6 +35,46 @@ pub fn list_output_devices() -> Vec<DeviceInfo> {
         .collect()
 }
 
+/// Resolve a saved `DeviceRef` to a current `cpal::Device`. Exact-match by
+/// name first, fall back to matching by description so a renamed device
+/// (e.g. "Headphones (USB Audio)" → "Headphones (USB Audio Pro)") still
+/// resolves while `description` remains stable.
+pub fn resolve_device(reference: &DeviceRef) -> Option<cpal::Device> {
+    let host = cpal::default_host();
+    let mut found_by_name: Option<cpal::Device> = None;
+    let mut found_by_desc: Option<cpal::Device> = None;
+    let devices = host.output_devices().ok()?;
+    for d in devices {
+        let Ok(name) = d.name() else { continue };
+        if name == reference.name {
+            found_by_name = Some(d);
+            break;
+        }
+        if found_by_desc.is_none() && name == reference.description {
+            found_by_desc = Some(d);
+        }
+    }
+    found_by_name.or(found_by_desc)
+}
+
+/// Resolve `main_device` config — falls back to the system default
+/// device when the reference is `None` or no match exists.
+pub fn resolve_main_device(reference: Option<&DeviceRef>) -> Option<cpal::Device> {
+    match reference {
+        None => None, // None signals "use rodio's open_default_stream"
+        Some(r) => match resolve_device(r) {
+            Some(d) => Some(d),
+            None => {
+                log::warn!(
+                    "main device '{}' not found among current outputs; falling back to default",
+                    r.description
+                );
+                None
+            }
+        },
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -42,5 +84,31 @@ mod tests {
         // host.output_devices() may fail or return zero devices in CI sandboxes;
         // success criterion is "no panic, returns Vec".
         let _ = list_output_devices();
+    }
+
+    #[test]
+    fn resolve_unknown_device_returns_none() {
+        let reference = DeviceRef {
+            name: "definitely-not-a-real-device-xyz123".to_string(),
+            description: "definitely-not-a-real-device-xyz123".to_string(),
+        };
+        assert!(resolve_device(&reference).is_none());
+    }
+
+    #[test]
+    fn resolve_main_device_with_none_returns_none() {
+        // None reference means "use system default" — caller passes the
+        // resolved Option<Device> into rodio, which treats None as default.
+        assert!(resolve_main_device(None).is_none());
+    }
+
+    #[test]
+    fn resolve_main_device_with_unknown_falls_back_to_none() {
+        let reference = DeviceRef {
+            name: "ghost-device".to_string(),
+            description: "ghost-device".to_string(),
+        };
+        // Unknown device → caller falls back to default (None).
+        assert!(resolve_main_device(Some(&reference)).is_none());
     }
 }

--- a/src-tauri/src/audio/player.rs
+++ b/src-tauri/src/audio/player.rs
@@ -23,17 +23,38 @@ pub enum Cmd {
     SetVolume(f32),
 }
 
+struct Topics {
+    time: String,
+    duration: String,
+    pause_state: String,
+    ended: String,
+    error: String,
+}
+
+impl Topics {
+    fn new(prefix: &str) -> Self {
+        Self {
+            time: format!("{prefix}:time"),
+            duration: format!("{prefix}:duration"),
+            pause_state: format!("{prefix}:pause-state"),
+            ended: format!("{prefix}:ended"),
+            error: format!("{prefix}:error"),
+        }
+    }
+}
+
 pub struct PlayerHandle {
     tx: Sender<Cmd>,
 }
 
 impl PlayerHandle {
-    pub fn spawn(app: AppHandle) -> Self {
+    pub fn spawn(app: AppHandle, device: Option<cpal::Device>, event_prefix: &'static str) -> Self {
         let (tx, rx) = channel();
+        let topics = Topics::new(event_prefix);
         thread::spawn(move || {
-            if let Err(e) = run(app.clone(), rx) {
-                log::error!("player thread exited: {}", e);
-                let _ = app.emit("player:error", e.to_string());
+            if let Err(e) = run(app.clone(), rx, device, &topics) {
+                log::error!("[{}] player thread exited: {}", event_prefix, e);
+                let _ = app.emit(&topics.error, e.to_string());
             }
         });
         Self { tx }
@@ -52,9 +73,23 @@ struct State {
     volume: f32,
 }
 
-fn run(app: AppHandle, rx: std::sync::mpsc::Receiver<Cmd>) -> Result<()> {
-    let stream: OutputStream =
-        OutputStreamBuilder::open_default_stream().context("open default audio stream")?;
+fn open_stream(device: Option<cpal::Device>) -> Result<OutputStream> {
+    match device {
+        Some(d) => OutputStreamBuilder::from_device(d)
+            .context("from_device")?
+            .open_stream()
+            .context("open_stream"),
+        None => OutputStreamBuilder::open_default_stream().context("open default audio stream"),
+    }
+}
+
+fn run(
+    app: AppHandle,
+    rx: std::sync::mpsc::Receiver<Cmd>,
+    device: Option<cpal::Device>,
+    topics: &Topics,
+) -> Result<()> {
+    let stream = open_stream(device)?;
     let mut sink = Sink::connect_new(stream.mixer());
     let mut last_time_emit = Instant::now()
         .checked_sub(TIME_EMIT_INTERVAL)
@@ -70,7 +105,7 @@ fn run(app: AppHandle, rx: std::sync::mpsc::Receiver<Cmd>) -> Result<()> {
     loop {
         loop {
             match rx.try_recv() {
-                Ok(cmd) => apply(&app, &stream, &mut sink, &mut state, cmd),
+                Ok(cmd) => apply(&app, &stream, &mut sink, &mut state, topics, cmd),
                 Err(std::sync::mpsc::TryRecvError::Empty) => break,
                 Err(std::sync::mpsc::TryRecvError::Disconnected) => return Ok(()),
             }
@@ -79,20 +114,27 @@ fn run(app: AppHandle, rx: std::sync::mpsc::Receiver<Cmd>) -> Result<()> {
         if state.active && last_time_emit.elapsed() >= TIME_EMIT_INTERVAL {
             last_time_emit = Instant::now();
             let pos = state.seek_offset + sink.get_pos().as_secs_f64();
-            let _ = app.emit("player:time", pos);
+            let _ = app.emit(&topics.time, pos);
         }
 
         if state.active && sink.empty() {
             state.active = false;
-            let _ = app.emit("player:pause-state", true);
-            let _ = app.emit("player:ended", ());
+            let _ = app.emit(&topics.pause_state, true);
+            let _ = app.emit(&topics.ended, ());
         }
 
         thread::sleep(TICK_INTERVAL);
     }
 }
 
-fn apply(app: &AppHandle, stream: &OutputStream, sink: &mut Sink, state: &mut State, cmd: Cmd) {
+fn apply(
+    app: &AppHandle,
+    stream: &OutputStream,
+    sink: &mut Sink,
+    state: &mut State,
+    topics: &Topics,
+    cmd: Cmd,
+) {
     match cmd {
         Cmd::Load { path, duration } => {
             sink.stop();
@@ -108,28 +150,28 @@ fn apply(app: &AppHandle, stream: &OutputStream, sink: &mut Sink, state: &mut St
                     state.current_duration = final_duration;
                     state.seek_offset = 0.0;
                     if let Some(d) = final_duration {
-                        let _ = app.emit("player:duration", d);
+                        let _ = app.emit(&topics.duration, d);
                     }
-                    let _ = app.emit("player:pause-state", false);
+                    let _ = app.emit(&topics.pause_state, false);
                 }
                 Err(e) => {
                     log::error!("player: decode {} failed: {}", path.display(), e);
-                    let _ = app.emit("player:error", format!("decode failed: {}", e));
+                    let _ = app.emit(&topics.error, format!("decode failed: {}", e));
                     state.active = false;
                     state.current_path = None;
                     state.current_duration = None;
                     state.seek_offset = 0.0;
-                    let _ = app.emit("player:pause-state", true);
+                    let _ = app.emit(&topics.pause_state, true);
                 }
             }
         }
         Cmd::Play => {
             sink.play();
-            let _ = app.emit("player:pause-state", false);
+            let _ = app.emit(&topics.pause_state, false);
         }
         Cmd::Pause => {
             sink.pause();
-            let _ = app.emit("player:pause-state", true);
+            let _ = app.emit(&topics.pause_state, true);
         }
         Cmd::Stop => {
             sink.stop();
@@ -139,7 +181,7 @@ fn apply(app: &AppHandle, stream: &OutputStream, sink: &mut Sink, state: &mut St
             state.current_path = None;
             state.current_duration = None;
             state.seek_offset = 0.0;
-            let _ = app.emit("player:pause-state", true);
+            let _ = app.emit(&topics.pause_state, true);
         }
         Cmd::Seek(s) => {
             let target = s.max(0.0);
@@ -183,7 +225,7 @@ fn apply(app: &AppHandle, stream: &OutputStream, sink: &mut Sink, state: &mut St
                 }
                 Err(e) => {
                     log::error!("player: reload-on-seek failed: {}", e);
-                    let _ = app.emit("player:error", format!("seek failed: {}", e));
+                    let _ = app.emit(&topics.error, format!("seek failed: {}", e));
                     state.active = false;
                 }
             }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,3 +1,4 @@
+use parking_lot::Mutex;
 use serde::Serialize;
 use std::collections::HashSet;
 use std::sync::Arc;
@@ -8,7 +9,7 @@ mod library;
 mod persist;
 mod playlist;
 
-use audio::devices::{list_output_devices, DeviceInfo};
+use audio::devices::{list_output_devices, resolve_device, resolve_main_device, DeviceInfo};
 use audio::player::{Cmd, PlayerHandle};
 use library::db::{Db, LibraryStats, Track};
 use library::scan_state::{ScanState, ScanStatus, StartResult};
@@ -21,6 +22,8 @@ pub struct AppState {
     session: Arc<Session>,
     scan: Arc<ScanState>,
     player: Arc<PlayerHandle>,
+    cue: Arc<Mutex<Option<PlayerHandle>>>,
+    app_handle: AppHandle,
 }
 
 #[derive(Serialize)]
@@ -185,7 +188,9 @@ fn get_main_device(state: State<'_, AppState>) -> Option<DeviceRef> {
 
 #[tauri::command(rename_all = "camelCase")]
 fn set_main_device(state: State<'_, AppState>, device: Option<DeviceRef>) -> Result<(), String> {
-    state.config.set_main_device(device).map_err(err)
+    state.config.set_main_device(device).map_err(err)?;
+    log::info!("main device updated; restart required to apply");
+    Ok(())
 }
 
 #[tauri::command(rename_all = "camelCase")]
@@ -195,7 +200,86 @@ fn get_cue_device(state: State<'_, AppState>) -> Option<DeviceRef> {
 
 #[tauri::command(rename_all = "camelCase")]
 fn set_cue_device(state: State<'_, AppState>, device: Option<DeviceRef>) -> Result<(), String> {
-    state.config.set_cue_device(device).map_err(err)
+    state.config.set_cue_device(device).map_err(err)?;
+    // Invalidate cached cue handle so the next cue_* command spawns
+    // against the new device. Dropping the Sender stops the worker thread.
+    *state.cue.lock() = None;
+    Ok(())
+}
+
+/// Ensure a cue `PlayerHandle` exists for the configured cue device.
+/// Lazy-spawned on first cue command. Errors if no cue device is set
+/// or the saved device cannot be resolved.
+fn with_cue<F>(state: &State<'_, AppState>, f: F) -> Result<(), String>
+where
+    F: FnOnce(&PlayerHandle),
+{
+    let mut guard = state.cue.lock();
+    if guard.is_none() {
+        let cue_ref = state
+            .config
+            .get_cue_device()
+            .ok_or_else(|| "no cue device configured; pick one in Settings → Audio".to_string())?;
+        let device = resolve_device(&cue_ref).ok_or_else(|| {
+            format!(
+                "cue device '{}' not found among current outputs",
+                cue_ref.description
+            )
+        })?;
+        *guard = Some(PlayerHandle::spawn(
+            state.app_handle.clone(),
+            Some(device),
+            "cue",
+        ));
+    }
+    if let Some(handle) = guard.as_ref() {
+        f(handle);
+    }
+    Ok(())
+}
+
+#[tauri::command(rename_all = "camelCase")]
+fn cue_load(state: State<'_, AppState>, id: i64) -> Result<(), String> {
+    let track = state
+        .db
+        .get_media_track(id)
+        .map_err(err)?
+        .ok_or_else(|| "track not found".to_string())?;
+    with_cue(&state, |h| {
+        h.send(Cmd::Load {
+            path: std::path::PathBuf::from(track.path),
+            duration: if track.duration > 0.0 {
+                Some(track.duration)
+            } else {
+                None
+            },
+        });
+    })
+}
+
+#[tauri::command(rename_all = "camelCase")]
+fn cue_play(state: State<'_, AppState>) -> Result<(), String> {
+    with_cue(&state, |h| h.send(Cmd::Play))
+}
+
+#[tauri::command(rename_all = "camelCase")]
+fn cue_pause(state: State<'_, AppState>) -> Result<(), String> {
+    with_cue(&state, |h| h.send(Cmd::Pause))
+}
+
+#[tauri::command(rename_all = "camelCase")]
+fn cue_stop(state: State<'_, AppState>) -> Result<(), String> {
+    with_cue(&state, |h| h.send(Cmd::Stop))
+}
+
+#[tauri::command(rename_all = "camelCase")]
+fn cue_seek(state: State<'_, AppState>, seconds: f64) -> Result<(), String> {
+    with_cue(&state, |h| h.send(Cmd::Seek(seconds)))
+}
+
+#[tauri::command(rename_all = "camelCase")]
+fn cue_set_volume(state: State<'_, AppState>, volume: f32) -> Result<(), String> {
+    with_cue(&state, |h| h.send(Cmd::SetVolume(volume)))
 }
 
 #[tauri::command(rename_all = "camelCase")]
@@ -223,13 +307,16 @@ pub fn run() {
             let db = Db::open(&data_dir.join("diodedj.db"))?;
             let config = Config::open(&data_dir)?;
             let session = Session::open(&data_dir);
-            let player = PlayerHandle::spawn(app.handle().clone());
+            let main_device = resolve_main_device(config.get_main_device().as_ref());
+            let player = PlayerHandle::spawn(app.handle().clone(), main_device, "player");
             app.manage(AppState {
                 db: Arc::new(db),
                 config: Arc::new(config),
                 session: Arc::new(session),
                 scan: Arc::new(ScanState::default()),
                 player: Arc::new(player),
+                cue: Arc::new(Mutex::new(None)),
+                app_handle: app.handle().clone(),
             });
             Ok(())
         })
@@ -255,6 +342,12 @@ pub fn run() {
             set_main_device,
             get_cue_device,
             set_cue_device,
+            cue_load,
+            cue_play,
+            cue_pause,
+            cue_stop,
+            cue_seek,
+            cue_set_volume,
             player_load,
             player_play,
             player_pause,

--- a/src/features/player/nativeBackend.test.ts
+++ b/src/features/player/nativeBackend.test.ts
@@ -1,0 +1,127 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { invoke, listen } = vi.hoisted(() => ({
+  invoke: vi.fn(),
+  listen: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({ invoke }));
+vi.mock("@tauri-apps/api/event", () => ({ listen }));
+
+import { NativeBackend } from "./nativeBackend";
+import type { PlayerEvent } from "./backend";
+
+interface ListenCallback {
+  (e: { payload: unknown }): void;
+}
+const listeners: Record<string, ListenCallback> = {};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  for (const key of Object.keys(listeners)) delete listeners[key];
+  listen.mockImplementation((topic: string, cb: ListenCallback) => {
+    listeners[topic] = cb;
+    return Promise.resolve(() => {
+      delete listeners[topic];
+    });
+  });
+  invoke.mockResolvedValue(undefined);
+});
+
+describe("NativeBackend (deckId='player' default)", () => {
+  it("subscribes to player:* event topics on construction", async () => {
+    const b = new NativeBackend();
+    await b.load(1); // awaits ready
+    const topics = listen.mock.calls.map((c) => c[0]);
+    expect(topics).toEqual(
+      expect.arrayContaining([
+        "player:time",
+        "player:duration",
+        "player:pause-state",
+        "player:ended",
+        "player:error",
+      ]),
+    );
+  });
+
+  it("invokes player_* commands", async () => {
+    const b = new NativeBackend();
+    await b.load(7);
+    expect(invoke).toHaveBeenCalledWith("player_load", { id: 7 });
+    await b.play();
+    expect(invoke).toHaveBeenCalledWith("player_play");
+    await b.pause();
+    expect(invoke).toHaveBeenCalledWith("player_pause");
+    await b.stop();
+    expect(invoke).toHaveBeenCalledWith("player_stop");
+    await b.seek(3.5);
+    expect(invoke).toHaveBeenCalledWith("player_seek", { seconds: 3.5 });
+    await b.setVolume(0.7);
+    expect(invoke).toHaveBeenCalledWith("player_set_volume", { volume: 0.7 });
+  });
+
+  it("forwards player:time events to handlers", async () => {
+    const b = new NativeBackend();
+    const events: PlayerEvent[] = [];
+    b.on((e) => events.push(e));
+    await b.load(1); // ensure ready
+    listeners["player:time"]({ payload: 12.5 });
+    listeners["player:duration"]({ payload: 200 });
+    listeners["player:pause-state"]({ payload: true });
+    listeners["player:ended"]({ payload: null });
+    listeners["player:error"]({ payload: "boom" });
+    expect(events).toEqual([
+      { type: "time", seconds: 12.5 },
+      { type: "duration", seconds: 200 },
+      { type: "pause-state", paused: true },
+      { type: "ended" },
+      { type: "error", message: "boom" },
+    ]);
+  });
+});
+
+describe("NativeBackend (deckId='cue')", () => {
+  it("subscribes to cue:* event topics", async () => {
+    const b = new NativeBackend("cue");
+    await b.load(1);
+    const topics = listen.mock.calls.map((c) => c[0]);
+    expect(topics).toEqual(
+      expect.arrayContaining([
+        "cue:time",
+        "cue:duration",
+        "cue:pause-state",
+        "cue:ended",
+        "cue:error",
+      ]),
+    );
+  });
+
+  it("invokes cue_* commands", async () => {
+    const b = new NativeBackend("cue");
+    await b.load(42);
+    expect(invoke).toHaveBeenCalledWith("cue_load", { id: 42 });
+    await b.play();
+    expect(invoke).toHaveBeenCalledWith("cue_play");
+    await b.seek(8);
+    expect(invoke).toHaveBeenCalledWith("cue_seek", { seconds: 8 });
+    await b.setVolume(0.3);
+    expect(invoke).toHaveBeenCalledWith("cue_set_volume", { volume: 0.3 });
+  });
+
+  it("forwards cue:* events to handlers", async () => {
+    const b = new NativeBackend("cue");
+    const events: PlayerEvent[] = [];
+    b.on((e) => events.push(e));
+    await b.load(1);
+    listeners["cue:time"]({ payload: 5 });
+    expect(events).toEqual([{ type: "time", seconds: 5 }]);
+  });
+
+  it("dispose unsubscribes all listeners", async () => {
+    const b = new NativeBackend("cue");
+    await b.load(1);
+    expect(listeners["cue:time"]).toBeDefined();
+    await b.dispose();
+    expect(listeners["cue:time"]).toBeUndefined();
+  });
+});

--- a/src/features/player/nativeBackend.ts
+++ b/src/features/player/nativeBackend.ts
@@ -2,28 +2,36 @@ import { invoke } from "@tauri-apps/api/core";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import type { PlayerBackend, PlayerEvent, PlayerEventHandler } from "./backend";
 
+/**
+ * Identifier shared by Tauri command names and event topics for a given deck.
+ * Main deck uses `player` (`player_load`, `player:time`, ...), cue deck uses
+ * `cue` (`cue_load`, `cue:time`, ...).
+ */
+export type DeckId = "player" | "cue";
+
 export class NativeBackend implements PlayerBackend {
   private handlers = new Set<PlayerEventHandler>();
   private unlisteners: UnlistenFn[] = [];
   private ready: Promise<void>;
 
-  constructor() {
+  constructor(private deckId: DeckId = "player") {
     this.ready = this.subscribe();
   }
 
   private async subscribe(): Promise<void> {
+    const p = this.deckId;
     const subs = await Promise.all([
-      listen<number>("player:time", (e) =>
+      listen<number>(`${p}:time`, (e) =>
         this.emit({ type: "time", seconds: e.payload }),
       ),
-      listen<number>("player:duration", (e) =>
+      listen<number>(`${p}:duration`, (e) =>
         this.emit({ type: "duration", seconds: e.payload }),
       ),
-      listen<boolean>("player:pause-state", (e) =>
+      listen<boolean>(`${p}:pause-state`, (e) =>
         this.emit({ type: "pause-state", paused: e.payload }),
       ),
-      listen<null>("player:ended", () => this.emit({ type: "ended" })),
-      listen<string>("player:error", (e) =>
+      listen<null>(`${p}:ended`, () => this.emit({ type: "ended" })),
+      listen<string>(`${p}:error`, (e) =>
         this.emit({ type: "error", message: e.payload }),
       ),
     ]);
@@ -32,27 +40,27 @@ export class NativeBackend implements PlayerBackend {
 
   async load(trackId: number): Promise<void> {
     await this.ready;
-    await invoke<void>("player_load", { id: trackId });
+    await invoke<void>(`${this.deckId}_load`, { id: trackId });
   }
 
   play(): Promise<void> {
-    return invoke<void>("player_play");
+    return invoke<void>(`${this.deckId}_play`);
   }
 
   pause(): Promise<void> {
-    return invoke<void>("player_pause");
+    return invoke<void>(`${this.deckId}_pause`);
   }
 
   stop(): Promise<void> {
-    return invoke<void>("player_stop");
+    return invoke<void>(`${this.deckId}_stop`);
   }
 
   seek(seconds: number): Promise<void> {
-    return invoke<void>("player_seek", { seconds });
+    return invoke<void>(`${this.deckId}_seek`, { seconds });
   }
 
   setVolume(volume: number): Promise<void> {
-    return invoke<void>("player_set_volume", { volume });
+    return invoke<void>(`${this.deckId}_set_volume`, { volume });
   }
 
   on(handler: PlayerEventHandler): () => void {


### PR DESCRIPTION
## Summary
Step 2/4 of #81. **Backend only** — second `PlayerHandle` for the cue device, `cue_*` Tauri commands + `cue:*` events, lazy-spawn on first cue command. No UI yet — the renderer's `state.svelte.ts` + components land in step 3.

> **Stacked**: this PR bases on `feat/audio-devices` (step 1, #89). Review/merge that one first.

## Changes
### Backend
- **`audio/player.rs`** — `PlayerHandle::spawn` now takes `Option<cpal::Device>` + `event_prefix: &'static str`. A `Topics` struct caches `{prefix}:time/duration/pause-state/ended/error` so two threads can run side-by-side without colliding.
- **`audio/devices.rs`**:
  - `resolve_device(&DeviceRef)` — exact-match by `name`, fallback to `description` so renamed devices still resolve.
  - `resolve_main_device(Option<&DeviceRef>)` — falls back to the system default when no reference or no match (logs warning).
- **`lib.rs`**:
  - `AppState` gains `cue: Arc<Mutex<Option<PlayerHandle>>>` + `app_handle: AppHandle` (stashed for lazy spawn).
  - `setup()` resolves saved `main_device` + spawns main player against it.
  - `with_cue()` helper locks the cue mutex, spawns handle if absent, sends `Cmd`.
  - New commands: `cue_load`, `cue_play`, `cue_pause`, `cue_stop`, `cue_seek`, `cue_set_volume` — all `Result<(), String>` so the renderer surfaces "no cue device configured" / "cue device not found".
  - `set_main_device`: persists; logs *"restart required"* (hot-swap of main player deferred).
  - `set_cue_device`: persists + invalidates cached cue handle (drops sender → cue thread exits → next `cue_*` spawns fresh).

### Frontend
- **`features/player/nativeBackend.ts`** — `NativeBackend` takes optional `DeckId` (`"player" | "cue"`, default `"player"`). One class drives both decks; command names + event topics derive from the deck id.
- **`features/player/nativeBackend.test.ts`** — 7 new tests covering both decks: invokes, event subscriptions, payload mapping, dispose.

## Tests
- **Cargo**: **30** tests (was 27 in step 1; +3: `resolve_unknown_device_returns_none`, `resolve_main_device_with_none_returns_none`, `resolve_main_device_with_unknown_falls_back_to_none`).
- **Vitest**: **69** tests (was 62; +7 in `nativeBackend.test.ts`).

## Deferred to step 3
- `state.svelte.ts` integration (cue track / position / playback state).
- `SessionState.cue_volume` field — without UI, no caller needs it yet; lands alongside the cue volume slider.
- `SettingsOverlay` + cue panel UI + `→ main` promotion + hotkeys + library headphones button.

## Test plan
- [x] `cargo test` (30 tests)
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo build` (debug)
- [x] `pnpm typecheck`
- [x] `pnpm test -- run` (69 tests)
- [x] `pnpm lint`
- [x] `pnpm vite build`
- [ ] Manual smoke (deferred — needs UI from step 3 to drive cue commands)

Refs #81.

🤖 Generated with [Claude Code](https://claude.com/claude-code)