### PR TITLE
fix: fairer commercial selection in auto-playlist

### DIFF
--- a/src-tauri/src/library/db.rs
+++ b/src-tauri/src/library/db.rs
@@ -478,6 +478,16 @@ mod tests {
         .unwrap();
     }
 
+    fn insert_with_play_count(db: &Db, path: &str, content_type: &str, play_count: i64) {
+        let conn = db.conn.lock();
+        conn.execute(
+            "INSERT INTO tracks (path, content_type, title, artist, album, duration, play_count) \
+             VALUES (?, ?, 't', 'a', 'al', 100.0, ?)",
+            params![path, content_type, play_count],
+        )
+        .unwrap();
+    }
+
     #[test]
     fn migrate_sets_user_version() {
         let db = Db::open_in_memory().unwrap();
@@ -557,6 +567,49 @@ mod tests {
         assert_eq!(r.len(), 2);
         assert_eq!(r[0].id, 2);
         assert_eq!(r[1].id, 1);
+    }
+
+    #[test]
+    fn pick_random_from_bottom_only_returns_low_play_count_rows() {
+        let db = Db::open_in_memory().unwrap();
+        // 3 hot, 5 cold commercials. Bucket = 5 → only cold should ever be picked.
+        for i in 0..3 {
+            insert_with_play_count(&db, &format!("/hot{i}.mp3"), "commercial", 100);
+        }
+        for i in 0..5 {
+            insert_with_play_count(&db, &format!("/cold{i}.mp3"), "commercial", 0);
+        }
+        for _ in 0..50 {
+            let picked = db.pick_random_from_bottom("commercial", 2, 5).unwrap();
+            assert_eq!(picked.len(), 2);
+            for t in picked {
+                assert_eq!(t.play_count, 0, "hot track leaked into bottom-N pick");
+            }
+        }
+    }
+
+    #[test]
+    fn pick_random_from_bottom_breaks_ties_randomly() {
+        // All 8 rows tied at play_count = 0. Bucket = 4. Over many picks we
+        // should observe more than just the first 4 rows by ROWID — i.e. tie
+        // ordering is not deterministic.
+        let db = Db::open_in_memory().unwrap();
+        for i in 0..8 {
+            insert_with_play_count(&db, &format!("/c{i}.mp3"), "commercial", 0);
+        }
+        let mut seen = std::collections::HashSet::new();
+        for _ in 0..200 {
+            let picked = db.pick_random_from_bottom("commercial", 1, 4).unwrap();
+            seen.insert(picked[0].id);
+            if seen.len() > 4 {
+                break;
+            }
+        }
+        assert!(
+            seen.len() > 4,
+            "tie ordering deterministic: only saw ids {:?}",
+            seen
+        );
     }
 
     #[test]

--- a/src-tauri/src/library/db.rs
+++ b/src-tauri/src/library/db.rs
@@ -331,24 +331,24 @@ impl Db {
     pub fn pick_random_from_bottom(
         &self,
         content_type: &str,
+        count: i64,
         bucket_size: i64,
-    ) -> Result<Option<Track>> {
-        if bucket_size <= 0 {
-            return Ok(None);
+    ) -> Result<Vec<Track>> {
+        if bucket_size <= 0 || count <= 0 {
+            return Ok(vec![]);
         }
         let conn = self.conn.lock();
         let mut stmt = conn.prepare(
             "WITH bucket AS ( \
                 SELECT * FROM tracks WHERE content_type = ? \
                 ORDER BY play_count ASC LIMIT ? \
-            ) SELECT * FROM bucket ORDER BY RANDOM() LIMIT 1",
+            ) SELECT * FROM bucket ORDER BY RANDOM() LIMIT ?",
         )?;
-        let mut rows =
-            stmt.query_map(rusqlite::params![content_type, bucket_size], row_to_track)?;
-        match rows.next() {
-            Some(r) => r.map(Some).map_err(Into::into),
-            None => Ok(None),
-        }
+        let rows = stmt.query_map(
+            rusqlite::params![content_type, bucket_size, count],
+            row_to_track,
+        )?;
+        rows.collect::<rusqlite::Result<_>>().map_err(Into::into)
     }
 
     pub fn get_stats(&self) -> Result<LibraryStats> {

--- a/src-tauri/src/library/db.rs
+++ b/src-tauri/src/library/db.rs
@@ -341,7 +341,7 @@ impl Db {
         let mut stmt = conn.prepare(
             "WITH bucket AS ( \
                 SELECT * FROM tracks WHERE content_type = ? \
-                ORDER BY play_count ASC LIMIT ? \
+                ORDER BY play_count ASC, RANDOM() LIMIT ? \
             ) SELECT * FROM bucket ORDER BY RANDOM() LIMIT ?",
         )?;
         let rows = stmt.query_map(

--- a/src-tauri/src/playlist.rs
+++ b/src-tauri/src/playlist.rs
@@ -17,7 +17,7 @@ pub fn generate(db: &Db, count: i64) -> Result<Vec<Track>> {
 
     let music = db.get_random_tracks("music", music_count)?;
     let jingles = db.get_random_tracks("jingle", jingle_count)?;
-    let commercials = db.get_random_tracks("commercial", commercial_count)?;
+    let commercials = db.pick_random_from_bottom("commercial", commercial_count, COMMERCIAL_BUCKET_SIZE)?;
 
     Ok(interleave_evenly(music, jingles, commercials))
 }
@@ -25,7 +25,7 @@ pub fn generate(db: &Db, count: i64) -> Result<Vec<Track>> {
 pub fn pick_filler(db: &Db, content_type: &str) -> Result<Option<Track>> {
     match content_type {
         "jingle" => Ok(db.get_random_tracks("jingle", 1)?.pop()),
-        "commercial" => db.pick_random_from_bottom("commercial", COMMERCIAL_BUCKET_SIZE),
+        "commercial" => Ok(db.pick_random_from_bottom("commercial", 1, COMMERCIAL_BUCKET_SIZE)?.pop()),
         _ => Ok(None),
     }
 }

--- a/src-tauri/src/playlist.rs
+++ b/src-tauri/src/playlist.rs
@@ -5,7 +5,12 @@ use crate::library::db::{Db, Track};
 
 const JINGLE_EVERY: i64 = 4;
 const COMMERCIAL_EVERY: i64 = 8;
-const COMMERCIAL_BUCKET_SIZE: i64 = 5;
+const COMMERCIAL_BUCKET_MULTIPLIER: i64 = 3;
+const COMMERCIAL_BUCKET_MIN: i64 = 10;
+
+fn commercial_bucket_size(count: i64) -> i64 {
+    (count * COMMERCIAL_BUCKET_MULTIPLIER).max(COMMERCIAL_BUCKET_MIN)
+}
 
 pub fn generate(db: &Db, count: i64) -> Result<Vec<Track>> {
     if count <= 0 {
@@ -17,7 +22,11 @@ pub fn generate(db: &Db, count: i64) -> Result<Vec<Track>> {
 
     let music = db.get_random_tracks("music", music_count)?;
     let jingles = db.get_random_tracks("jingle", jingle_count)?;
-    let commercials = db.pick_random_from_bottom("commercial", commercial_count, COMMERCIAL_BUCKET_SIZE)?;
+    let commercials = db.pick_random_from_bottom(
+        "commercial",
+        commercial_count,
+        commercial_bucket_size(commercial_count),
+    )?;
 
     Ok(interleave_evenly(music, jingles, commercials))
 }
@@ -25,7 +34,9 @@ pub fn generate(db: &Db, count: i64) -> Result<Vec<Track>> {
 pub fn pick_filler(db: &Db, content_type: &str) -> Result<Option<Track>> {
     match content_type {
         "jingle" => Ok(db.get_random_tracks("jingle", 1)?.pop()),
-        "commercial" => Ok(db.pick_random_from_bottom("commercial", 1, COMMERCIAL_BUCKET_SIZE)?.pop()),
+        "commercial" => Ok(db
+            .pick_random_from_bottom("commercial", 1, commercial_bucket_size(1))?
+            .pop()),
         _ => Ok(None),
     }
 }


### PR DESCRIPTION
## Summary

Auto-playlist commercial picker had four fairness/correctness bugs. This PR fixes them and adds regression tests.

### Bugs fixed

1. **Commercials were picked uniformly at random** (`ea34282`). `generate()` used `get_random_tracks("commercial", ...)` which is `ORDER BY RANDOM()` over the full table, ignoring `play_count`. Frequently played commercials kept getting picked. Switched to `pick_random_from_bottom` so picks are biased toward the least-played rows.

2. **Tie ordering was deterministic** (`071028a`). The bottom-N CTE used `ORDER BY play_count ASC` with no secondary key, so SQLite broke ties by ROWID. On a fresh library (every `play_count = 0`) only the first N inserted commercials were ever picked. Now `ORDER BY play_count ASC, RANDOM()`.

3. **Silent truncation when count > bucket** (`c6aa862`). `COMMERCIAL_BUCKET_SIZE = 5` capped the outer `LIMIT`, so an 80-track playlist asking for 10 commercials only got 5. Replaced with `commercial_bucket_size(count) = max(count * 3, 10)` — bucket always at least as wide as the request, with a min floor that gives `pick_filler` (count=1) meaningful randomness.

4. **No coverage** (`a8487c9`). Added two tests:
   - `pick_random_from_bottom_only_returns_low_play_count_rows` — bucket fence holds across 50 samples.
   - `pick_random_from_bottom_breaks_ties_randomly` — 8 tied rows, bucket 4: 200 single picks must surface more than 4 distinct ids.

## Test plan

- [x] `cargo test --manifest-path src-tauri/Cargo.toml` (33 passed)
- [x] `cargo clippy --all-targets -- -D warnings` (clean)
- [x] `cargo fmt --check` (clean)
- [x] `pnpm test -- run` (87 passed)
- [ ] Smoke: generate an 80-track auto-playlist on a real library and confirm 10 commercials appear and rotate over repeated generations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)