### PR TITLE
feat: persist window size/position via tauri-plugin-window-state

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -636,6 +636,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-dialog",
+ "tauri-plugin-window-state",
  "tempfile",
  "tokio",
  "walkdir",
@@ -3741,6 +3742,21 @@ dependencies = [
  "thiserror 2.0.18",
  "toml 1.1.2+spec-1.1.0",
  "url",
+]
+
+[[package]]
+name = "tauri-plugin-window-state"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73736611e14142408d15353e21e3cca2f12a3cfb523ad0ce85999b6d2ef1a704"
+dependencies = [
+ "bitflags 2.11.1",
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -16,6 +16,7 @@ tauri-build = { version = "=2.6.0", features = [] }
 [dependencies]
 tauri = { version = "=2.11.0", features = [] }
 tauri-plugin-dialog = "=2.7.1"
+tauri-plugin-window-state = "=2.4.1"
 serde = { version = "=1.0.228", features = ["derive"] }
 serde_json = "=1.0.149"
 rusqlite = { version = "=0.39.0", features = ["bundled"] }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -301,6 +301,15 @@ fn get_scan_status(state: State<'_, AppState>) -> ScanStatus {
 pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_dialog::init())
+        .plugin(
+            tauri_plugin_window_state::Builder::default()
+                .with_state_flags(
+                    tauri_plugin_window_state::StateFlags::SIZE
+                        | tauri_plugin_window_state::StateFlags::POSITION
+                        | tauri_plugin_window_state::StateFlags::MAXIMIZED,
+                )
+                .build(),
+        )
         .setup(|app| {
             let data_dir = app.path().app_data_dir()?;
             std::fs::create_dir_all(&data_dir)?;


### PR DESCRIPTION
## Summary
- Add `tauri-plugin-window-state = "=2.4.1"` (backend-only; no npm package)
- Register plugin with `StateFlags: SIZE | POSITION | MAXIMIZED` — fullscreen excluded so app cannot launch chromeless if quit in fullscreen
- No capability changes (plugin operates Rust-side); no `tauri.conf.json` changes (existing 1280×800 defaults stay as first-launch fallback)

Closes #78

## Design decisions
- **Backend-only**: nothing in the renderer needs programmatic save/restore, so the `@tauri-apps/plugin-window-state` npm package adds no value
- **State file**: lands at plugin default location (`{app_config_dir}/.window-state.json`), not in `app_data_dir`. Plugin Builder API exposes filename override only, not directory. The issue's "verify in `app_data_dir`" criterion is amended
- **No off-screen guard**: plugin restores raw coords. Off-screen edge case (saved on external monitor, relaunched on laptop alone) is unhandled — macOS clamps, Windows users can right-click → Move. Add guard later only if reported
- **Close-handler untouched**: plugin's `CloseRequested` listener runs independently of the existing `flushSave()` → `destroy()` flow

## Test plan
- [x] `cargo build` / `cargo fmt --check` / `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` — 33 backend tests pass
- [x] `pnpm test -- run` — 87 renderer tests pass
- [x] `pnpm lint` / `pnpm typecheck`
- [x] Manual macOS verify: resize/move/maximize → close → relaunch restores geometry
- [x] Manual macOS verify: state file appears at `~/Library/Application Support/com.diodedj.app/.window-state.json`
- [x] Manual macOS verify: fullscreen on close → relaunch does NOT restore fullscreen
- [ ] Linux/Windows: untested at merge; trust upstream plugin

🤖 Generated with [Claude Code](https://claude.com/claude-code)