### PR TITLE
fix(playlist): restore drag-and-drop reorder

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -17,7 +17,8 @@
         "width": 1280,
         "height": 800,
         "minWidth": 800,
-        "minHeight": 600
+        "minHeight": 600,
+        "dragDropEnabled": false
       }
     ],
     "security": {

--- a/src/features/playlist/PlaylistPanel.svelte
+++ b/src/features/playlist/PlaylistPanel.svelte
@@ -9,8 +9,12 @@
     app.setHover(track, rect);
   }
 
-  function onDragStart(i: number): void {
+  function onDragStart(e: DragEvent, i: number): void {
     dragFromIndex = i;
+    if (e.dataTransfer) {
+      e.dataTransfer.effectAllowed = "move";
+      e.dataTransfer.setData("text/plain", String(i));
+    }
   }
 
   function onDragEnd(): void {
@@ -98,7 +102,7 @@
             draggable="true"
             data-index={i}
             ondblclick={() => app.playIndex(i)}
-            ondragstart={() => onDragStart(i)}
+            ondragstart={(e) => onDragStart(e, i)}
             ondragend={onDragEnd}
             ondragover={(e) => onDragOver(e, i)}
             ondragleave={() => onDragLeave(i)}

--- a/src/features/playlist/PlaylistPanel.svelte
+++ b/src/features/playlist/PlaylistPanel.svelte
@@ -2,7 +2,7 @@
   import { app, formatTime, type Track } from "../../shared/state.svelte";
 
   let dragFromIndex = $state(-1);
-  let dragOverIndex = $state(-1);
+  let dropTarget = $state(-1);
 
   function onEnter(track: Track, e: MouseEvent): void {
     const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
@@ -19,23 +19,48 @@
 
   function onDragEnd(): void {
     dragFromIndex = -1;
-    dragOverIndex = -1;
+    dropTarget = -1;
   }
 
-  function onDragOver(e: DragEvent, i: number): void {
+  function rowDropTarget(e: DragEvent, i: number): number {
+    const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+    return e.clientY < rect.top + rect.height / 2 ? i : i + 1;
+  }
+
+  function onRowDragOver(e: DragEvent, i: number): void {
     e.preventDefault();
-    dragOverIndex = i;
+    if (e.dataTransfer) e.dataTransfer.dropEffect = "move";
+    dropTarget = rowDropTarget(e, i);
   }
 
-  function onDragLeave(i: number): void {
-    if (dragOverIndex === i) dragOverIndex = -1;
-  }
-
-  function onDrop(e: DragEvent, i: number): void {
+  function onRowDrop(e: DragEvent, i: number): void {
     e.preventDefault();
-    dragOverIndex = -1;
-    if (dragFromIndex === -1 || dragFromIndex === i) return;
-    app.movePlaylistItem(dragFromIndex, i);
+    const target = rowDropTarget(e, i);
+    const from = dragFromIndex;
+    dropTarget = -1;
+    dragFromIndex = -1;
+    if (from === -1) return;
+    const insertAt = target > from ? target - 1 : target;
+    if (insertAt === from) return;
+    app.movePlaylistItem(from, insertAt);
+  }
+
+  function onListDragOver(e: DragEvent): void {
+    e.preventDefault();
+    if (e.dataTransfer) e.dataTransfer.dropEffect = "move";
+    if (dropTarget === -1) dropTarget = app.playlist.length;
+  }
+
+  function onListDrop(e: DragEvent): void {
+    e.preventDefault();
+    const from = dragFromIndex;
+    const target = dropTarget === -1 ? app.playlist.length : dropTarget;
+    dropTarget = -1;
+    dragFromIndex = -1;
+    if (from === -1) return;
+    const insertAt = target > from ? target - 1 : target;
+    if (insertAt === from) return;
+    app.movePlaylistItem(from, insertAt);
   }
 
   function onClear(): void {
@@ -90,7 +115,12 @@
   </div>
 
   {#if app.playlistTab === "queue"}
-    <div id="playlist">
+    <div
+      id="playlist"
+      ondragover={onListDragOver}
+      ondrop={onListDrop}
+      role="list"
+    >
       {#if app.playlist.length === 0}
         <div class="empty">Playlist empty</div>
       {:else}
@@ -98,15 +128,17 @@
           <div
             class="playlist-row"
             class:dragging={i === dragFromIndex}
-            class:drag-over={i === dragOverIndex && i !== dragFromIndex}
+            class:drop-before={dragFromIndex !== -1 && dropTarget === i}
+            class:drop-after={dragFromIndex !== -1 &&
+              dropTarget === i + 1 &&
+              i === app.playlist.length - 1}
             draggable="true"
             data-index={i}
             ondblclick={() => app.playIndex(i)}
             ondragstart={(e) => onDragStart(e, i)}
             ondragend={onDragEnd}
-            ondragover={(e) => onDragOver(e, i)}
-            ondragleave={() => onDragLeave(i)}
-            ondrop={(e) => onDrop(e, i)}
+            ondragover={(e) => onRowDragOver(e, i)}
+            ondrop={(e) => onRowDrop(e, i)}
             onmouseenter={(e) => onEnter(track, e)}
             onmouseleave={() => app.clearHover()}
             role="listitem"

--- a/src/styles.css
+++ b/src/styles.css
@@ -395,8 +395,12 @@ body {
   opacity: 0.4;
 }
 
-.playlist-row.drag-over {
-  border-top: 2px solid var(--accent);
+.playlist-row.drop-before {
+  box-shadow: inset 0 2px 0 0 var(--accent);
+}
+
+.playlist-row.drop-after {
+  box-shadow: inset 0 -2px 0 0 var(--accent);
 }
 
 .pl-num {


### PR DESCRIPTION
## Summary
- Disable Tauri window `dragDropEnabled` so the OS-level file drop handler stops intercepting HTML5 drag events inside the webview.
- Set `dataTransfer.effectAllowed` + `setData` in `dragstart` so WebKit (macOS) initiates the drag.

## Test plan
- [x] `pnpm dev`, drag a row in the Up-next queue, verify reorder.
- [x] Drag onto same index — no-op.
- [x] Drag last → first and first → last.
- [x] `pnpm typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)