### PR TITLE
chore(a11y): add ARIA roles and labels for e2e selectors

### DIFF
--- a/src/features/library/LibraryPanel.svelte
+++ b/src/features/library/LibraryPanel.svelte
@@ -20,6 +20,11 @@
     return app.sortDir === "asc" ? " \u25B2" : " \u25BC";
   }
 
+  function ariaSort(column: SortColumn): "ascending" | "descending" | "none" {
+    if (app.sortBy !== column) return "none";
+    return app.sortDir === "asc" ? "ascending" : "descending";
+  }
+
   let searchTimeout: number | undefined;
 
   function onSearchInput(): void {
@@ -50,12 +55,14 @@
 
 <section id="library-panel">
   <div id="library-header">
-    <div id="library-tabs">
+    <div id="library-tabs" role="tablist" aria-label="Library tabs">
       {#each tabs as { type, label } (type)}
         <button
           class="lib-tab"
           class:active={app.activeTab === type}
           data-type={type}
+          role="tab"
+          aria-selected={app.activeTab === type}
           onclick={() => app.setTab(type)}
         >
           {label}
@@ -67,6 +74,7 @@
       id="search-input"
       placeholder="Search tracks..."
       autocomplete="off"
+      aria-label="Search tracks"
       bind:value={app.searchQuery}
       oninput={onSearchInput}
     />
@@ -76,6 +84,8 @@
       <button
         class="track-header {col.cls}"
         class:active={app.sortBy === col.column}
+        role="columnheader"
+        aria-sort={ariaSort(col.column)}
         onclick={() => app.toggleSort(col.column)}
       >
         {col.label}{sortIndicator(col.column)}
@@ -95,6 +105,8 @@
           onmouseenter={(e) => onEnter(track, e)}
           onmouseleave={() => app.clearHover()}
           role="button"
+          aria-label={`Track: ${track.title} by ${track.artist}`}
+          data-track-id={track.id}
           tabindex="0"
         >
           <span class="track-title">{track.title}</span>

--- a/src/features/player/NowPlaying.svelte
+++ b/src/features/player/NowPlaying.svelte
@@ -39,23 +39,40 @@
       <span id="np-artist">{app.currentTrack?.artist ?? ""}</span>
     </div>
     <div id="player-controls">
-      <button id="btn-prev" title="Previous" onclick={() => app.prev()}
-        >&#9198;</button
+      <button
+        id="btn-prev"
+        title="Previous"
+        aria-label="Previous track"
+        onclick={() => app.prev()}>&#9198;</button
       >
-      <button id="btn-play" title="Play" onclick={() => app.togglePlay()}>
+      <button
+        id="btn-play"
+        title={app.isPlaying ? "Pause" : "Play"}
+        aria-label={app.isPlaying ? "Pause" : "Play"}
+        aria-pressed={app.isPlaying}
+        onclick={() => app.togglePlay()}
+      >
         {@html app.isPlaying ? "&#9208;" : "&#9654;"}
       </button>
-      <button id="btn-stop" title="Stop" onclick={() => app.stop()}
-        >&#9632;</button
+      <button
+        id="btn-stop"
+        title="Stop"
+        aria-label="Stop"
+        onclick={() => app.stop()}>&#9632;</button
       >
-      <button id="btn-next" title="Next" onclick={() => app.next()}
-        >&#9197;</button
+      <button
+        id="btn-next"
+        title="Next"
+        aria-label="Next track"
+        onclick={() => app.next()}>&#9197;</button
       >
     </div>
     <button
       id="btn-mode"
       class:active={app.autoAdvance}
       title="Auto/Manual playback mode"
+      aria-label="Toggle playback mode"
+      aria-pressed={app.autoAdvance}
       onclick={() => app.toggleMode()}
     >
       {app.autoAdvance ? "AUTO" : "MANUAL"}

--- a/src/features/settings/SettingsOverlay.svelte
+++ b/src/features/settings/SettingsOverlay.svelte
@@ -114,6 +114,7 @@
         </div>
         <div class="settings-row">
           <button
+            id="btn-scan-now"
             class="btn-scan-now"
             title="Scan all configured paths"
             onclick={onScan}>Scan library</button

--- a/src/features/toolbar/Toolbar.svelte
+++ b/src/features/toolbar/Toolbar.svelte
@@ -26,6 +26,7 @@
       id="btn-generate"
       class:active={app.autoPlaylistActive}
       title="Generate random playlist"
+      aria-pressed={app.autoPlaylistActive}
       onclick={() => app.toggleAutoPlaylist()}
     >
       Auto Playlist


### PR DESCRIPTION
## Summary
- Adds `aria-label`, `role=tablist/tab`, `aria-sort` (via `role=columnheader`), `aria-pressed` on toggle buttons
- Track rows get `aria-label=\"Track: {title} by {artist}\"` + `data-track-id` for stable per-row targeting
- Adds `id=\"btn-scan-now\"` on the scan button so e2e can target it without text-matching

## Why
Prep for the tauri-driver e2e harness in #77 — selectors prefer ARIA over CSS classes. Doubles as a real a11y improvement for screen-reader users.

## Test plan
- [x] `pnpm typecheck` — 185 files, 0 errors, 0 warnings
- [x] `pnpm lint`
- [x] `pnpm test -- run` — 97/97 vitest tests pass
- [ ] Manual sanity-tab through the UI with a screen reader (optional)

Stacked under #77 — the e2e harness PR depends on these labels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)