### PR TITLE
test(e2e): Docker harness for local Linux e2e on macOS

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.git
+node_modules
+dist
+src-tauri/target
+e2e-results
+.vscode
+.idea
+*.log

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 coverage/
 node_modules/
+.pnpm-store/
 dist/
 *.db
 *.tgz

--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -1,4 +1,5 @@
-FROM node:24-trixie
+# ── base ───────────────────────────────────────────────────────────────
+FROM node:24-trixie AS base
 
 ENV DEBIAN_FRONTEND=noninteractive \
     LANG=C.UTF-8 \
@@ -8,9 +9,6 @@ ENV DEBIAN_FRONTEND=noninteractive \
     RUST_VERSION=1.95.0 \
     TAURI_DRIVER_VERSION=2.0.6
 
-# Build deps (libwebkit2gtk-4.1-dev etc) + runtime deps (webkit2gtk-driver,
-# pulseaudio, xvfb) collapsed into one layer so the image works for both
-# `tauri build` and `pnpm e2e` against the produced binary.
 RUN apt-get update && apt-get install -y --no-install-recommends \
       ca-certificates curl git xz-utils unzip jq pkg-config build-essential file \
       libwebkit2gtk-4.1-dev \
@@ -29,10 +27,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       xauth \
     && rm -rf /var/lib/apt/lists/*
 
-# pnpm via corepack (ships with node images).
-RUN corepack enable && corepack prepare pnpm@latest --activate
+RUN corepack enable
 
-# Rust pinned to .tool-versions.
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
       | sh -s -- -y --default-toolchain ${RUST_VERSION} --profile minimal \
     && rustup component add rustfmt clippy
@@ -44,6 +40,37 @@ RUN printf 'pcm.!default { type pulse }\nctl.!default { type pulse }\n' \
       > /etc/asound.conf
 
 WORKDIR /work
+
+
+# ── pnpm-deps ──────────────────────────────────────────────────────────
+# HUSKY=0 skips the `prepare: husky` hook (no .git in build context).
+# strict-dep-builds=false silences ERR_PNPM_IGNORED_BUILDS for
+# edgedriver/geckodriver — only esbuild's postinstall is needed.
+FROM base AS pnpm-deps
+COPY package.json pnpm-lock.yaml ./
+RUN HUSKY=0 pnpm install --frozen-lockfile --config.strict-dep-builds=false
+
+
+# ── cargo-deps ─────────────────────────────────────────────────────────
+# Warms the cargo registry only. Stub src/ satisfies manifest validation
+# without pulling real source into this stage's cache key. tauri-build
+# requires the renderer dist + full source so compilation is deferred to
+# the runtime stage against the e2e-target volume.
+FROM base AS cargo-deps
+COPY src-tauri/Cargo.toml src-tauri/Cargo.lock src-tauri/
+RUN mkdir -p src-tauri/src \
+    && : > src-tauri/src/lib.rs \
+    && echo 'fn main() {}' > src-tauri/src/main.rs \
+    && cd src-tauri && cargo fetch
+
+
+# ── runtime ────────────────────────────────────────────────────────────
+FROM base AS runtime
+
+COPY --from=pnpm-deps /work/node_modules ./node_modules
+COPY --from=cargo-deps /usr/local/cargo/registry /usr/local/cargo/registry
+
+COPY . /work
 
 COPY scripts/docker-e2e-entrypoint.sh /usr/local/bin/run-e2e.sh
 RUN chmod +x /usr/local/bin/run-e2e.sh

--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -7,7 +7,8 @@ ENV DEBIAN_FRONTEND=noninteractive \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
     RUST_VERSION=1.95.0 \
-    TAURI_DRIVER_VERSION=2.0.6
+    TAURI_DRIVER_VERSION=2.0.6 \
+    COREPACK_ENABLE_DOWNLOAD_PROMPT=0
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
       ca-certificates curl git xz-utils unzip jq pkg-config build-essential file \

--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -1,0 +1,51 @@
+FROM node:24-trixie
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    LANG=C.UTF-8 \
+    RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    PATH=/usr/local/cargo/bin:$PATH \
+    RUST_VERSION=1.95.0 \
+    TAURI_DRIVER_VERSION=2.0.6
+
+# Build deps (libwebkit2gtk-4.1-dev etc) + runtime deps (webkit2gtk-driver,
+# pulseaudio, xvfb) collapsed into one layer so the image works for both
+# `tauri build` and `pnpm e2e` against the produced binary.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      ca-certificates curl git xz-utils unzip jq pkg-config build-essential file \
+      libwebkit2gtk-4.1-dev \
+      libgtk-3-dev \
+      libayatana-appindicator3-dev \
+      librsvg2-dev \
+      libssl-dev \
+      libasound2-dev \
+      libayatana-appindicator3-1 \
+      librsvg2-2 \
+      libasound2-plugins \
+      pulseaudio \
+      pulseaudio-utils \
+      webkit2gtk-driver \
+      xvfb \
+      xauth \
+    && rm -rf /var/lib/apt/lists/*
+
+# pnpm via corepack (ships with node images).
+RUN corepack enable && corepack prepare pnpm@latest --activate
+
+# Rust pinned to .tool-versions.
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+      | sh -s -- -y --default-toolchain ${RUST_VERSION} --profile minimal \
+    && rustup component add rustfmt clippy
+
+RUN cargo install tauri-driver --version ${TAURI_DRIVER_VERSION} --locked
+
+# ALSA → PulseAudio bridge so rodio/cpal's ALSA backend finds a sink.
+RUN printf 'pcm.!default { type pulse }\nctl.!default { type pulse }\n' \
+      > /etc/asound.conf
+
+WORKDIR /work
+
+COPY scripts/docker-e2e-entrypoint.sh /usr/local/bin/run-e2e.sh
+RUN chmod +x /usr/local/bin/run-e2e.sh
+
+CMD ["/usr/local/bin/run-e2e.sh"]

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -1,0 +1,33 @@
+# Local Linux e2e harness. Source is baked into the image at build time —
+# nothing from the host is bind-mounted into /work, so the container runs
+# exactly like CI. Only failure artifacts escape via the e2e-results bind.
+#
+# Usage:
+#   docker compose -f docker-compose.e2e.yml run --build --rm e2e
+#
+# `--build` re-COPYs the working tree into the image. Named volumes keep
+# pnpm/cargo caches + cargo target dir across runs so incremental builds
+# stay fast.
+
+services:
+  e2e:
+    build:
+      context: .
+      dockerfile: Dockerfile.e2e
+    image: diodedj-e2e:local
+    init: true
+    shm_size: "2gb"
+    working_dir: /work
+    environment:
+      E2E_BINARY: release
+      RUST_LOG: debug
+      RUST_BACKTRACE: "1"
+    volumes:
+      - ./e2e-results:/work/e2e-results
+      # node_modules + cargo registry are baked into the image via layered
+      # COPY + install; only the cargo target dir needs cross-run state for
+      # incremental compile.
+      - e2e-target:/work/src-tauri/target
+
+volumes:
+  e2e-target:

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -10,7 +10,8 @@ End-to-end tests for DiodeDJ via `tauri-driver` + WebdriverIO.
 2. Run inside the Linux container shipped at `docker-compose.e2e.yml`:
 
    ```bash
-   docker compose -f docker-compose.e2e.yml run --build --rm e2e
+   pnpm e2e:docker
+   # equivalent to: docker compose -f docker-compose.e2e.yml run --build --rm e2e
    ```
 
    Source is COPY'd into the image at build time — no bind mount of the working tree — so the run matches CI. `--build` re-COPYs after edits. Named volumes persist node_modules, the cargo target dir, and the pnpm/cargo download caches across runs, so incremental builds stay fast. Failure artifacts surface in `./e2e-results/`.

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -7,7 +7,13 @@ End-to-end tests for DiodeDJ via `tauri-driver` + WebdriverIO.
 **Linux only.** macOS WKWebView ships no WebDriver implementation, and Tauri's `tauri-driver` does not support darwin. Mac developers have two options:
 
 1. Push the branch and watch CI (5 min feedback loop).
-2. Run inside a Linux container. See issue #130 for the planned OrbStack / Lima setup script.
+2. Run inside the Linux container shipped at `docker-compose.e2e.yml`:
+
+   ```bash
+   docker compose -f docker-compose.e2e.yml run --build --rm e2e
+   ```
+
+   Source is COPY'd into the image at build time — no bind mount of the working tree — so the run matches CI. `--build` re-COPYs after edits. Named volumes persist node_modules, the cargo target dir, and the pnpm/cargo download caches across runs, so incremental builds stay fast. Failure artifacts surface in `./e2e-results/`.
 
 ## One-time local setup (Linux)
 

--- a/e2e/wdio.conf.ts
+++ b/e2e/wdio.conf.ts
@@ -31,6 +31,53 @@ fs.mkdirSync(E2E_APP_DATA_DIR, { recursive: true });
 
 let tauriDriver: ChildProcess | null = null;
 
+const tailedLogs = new Set<string>();
+
+function tailFile(file: string): void {
+  if (tailedLogs.has(file)) return;
+  tailedLogs.add(file);
+  const prefix = `[app:${path.basename(file)}] `;
+  let position = 0;
+  let pending = false;
+  const stream = () => {
+    if (pending) return;
+    pending = true;
+    fs.stat(file, (err, st) => {
+      if (err || st.size <= position) {
+        pending = false;
+        return;
+      }
+      const rs = fs.createReadStream(file, { start: position, end: st.size });
+      let buf = "";
+      rs.on("data", (chunk) => {
+        buf += chunk.toString();
+        const lines = buf.split("\n");
+        buf = lines.pop() ?? "";
+        for (const line of lines) process.stdout.write(prefix + line + "\n");
+      });
+      rs.on("end", () => {
+        if (buf) process.stdout.write(prefix + buf);
+        position = st.size;
+        pending = false;
+      });
+    });
+  };
+  fs.watchFile(file, { interval: 250 }, stream);
+  stream();
+}
+
+function tailAppLogs(logsDir: string): void {
+  fs.mkdirSync(logsDir, { recursive: true });
+  for (const f of fs.readdirSync(logsDir)) {
+    if (f.endsWith(".log")) tailFile(path.join(logsDir, f));
+  }
+  fs.watch(logsDir, (_event, filename) => {
+    if (filename && filename.endsWith(".log")) {
+      tailFile(path.join(logsDir, filename));
+    }
+  });
+}
+
 export const config: WebdriverIO.Config = {
   runner: "local",
   hostname: "127.0.0.1",
@@ -90,6 +137,12 @@ export const config: WebdriverIO.Config = {
     // `docker run` output and CI job logs without unzipping artifacts.
     tauriDriver.stdout?.pipe(process.stdout);
     tauriDriver.stderr?.pipe(process.stderr);
+
+    // Tail the app's tauri-plugin-log file sink to stdout. The plugin's
+    // Stdout target is swallowed because tauri-driver doesn't forward the
+    // app's stdio. The LogDir target writes `${E2E_APP_DATA_DIR}/logs/*.log`,
+    // which we follow as soon as it appears.
+    tailAppLogs(path.join(E2E_APP_DATA_DIR, "logs"));
   },
 
   afterSession: () => {

--- a/e2e/wdio.conf.ts
+++ b/e2e/wdio.conf.ts
@@ -86,10 +86,6 @@ export const config: WebdriverIO.Config = {
     const logStream = fs.createWriteStream(logPath, { flags: "a" });
     tauriDriver.stdout?.pipe(logStream);
     tauriDriver.stderr?.pipe(logStream);
-    // Also tee to host stdout/stderr so logs surface live in
-    // `docker run` output and CI job logs without unzipping artifacts.
-    tauriDriver.stdout?.pipe(process.stdout);
-    tauriDriver.stderr?.pipe(process.stderr);
   },
 
   afterSession: () => {

--- a/e2e/wdio.conf.ts
+++ b/e2e/wdio.conf.ts
@@ -31,53 +31,6 @@ fs.mkdirSync(E2E_APP_DATA_DIR, { recursive: true });
 
 let tauriDriver: ChildProcess | null = null;
 
-const tailedLogs = new Set<string>();
-
-function tailFile(file: string): void {
-  if (tailedLogs.has(file)) return;
-  tailedLogs.add(file);
-  const prefix = `[app:${path.basename(file)}] `;
-  let position = 0;
-  let pending = false;
-  const stream = () => {
-    if (pending) return;
-    pending = true;
-    fs.stat(file, (err, st) => {
-      if (err || st.size <= position) {
-        pending = false;
-        return;
-      }
-      const rs = fs.createReadStream(file, { start: position, end: st.size });
-      let buf = "";
-      rs.on("data", (chunk) => {
-        buf += chunk.toString();
-        const lines = buf.split("\n");
-        buf = lines.pop() ?? "";
-        for (const line of lines) process.stdout.write(prefix + line + "\n");
-      });
-      rs.on("end", () => {
-        if (buf) process.stdout.write(prefix + buf);
-        position = st.size;
-        pending = false;
-      });
-    });
-  };
-  fs.watchFile(file, { interval: 250 }, stream);
-  stream();
-}
-
-function tailAppLogs(logsDir: string): void {
-  fs.mkdirSync(logsDir, { recursive: true });
-  for (const f of fs.readdirSync(logsDir)) {
-    if (f.endsWith(".log")) tailFile(path.join(logsDir, f));
-  }
-  fs.watch(logsDir, (_event, filename) => {
-    if (filename && filename.endsWith(".log")) {
-      tailFile(path.join(logsDir, filename));
-    }
-  });
-}
-
 export const config: WebdriverIO.Config = {
   runner: "local",
   hostname: "127.0.0.1",
@@ -137,12 +90,6 @@ export const config: WebdriverIO.Config = {
     // `docker run` output and CI job logs without unzipping artifacts.
     tauriDriver.stdout?.pipe(process.stdout);
     tauriDriver.stderr?.pipe(process.stderr);
-
-    // Tail the app's tauri-plugin-log file sink to stdout. The plugin's
-    // Stdout target is swallowed because tauri-driver doesn't forward the
-    // app's stdio. The LogDir target writes `${E2E_APP_DATA_DIR}/logs/*.log`,
-    // which we follow as soon as it appears.
-    tailAppLogs(path.join(E2E_APP_DATA_DIR, "logs"));
   },
 
   afterSession: () => {

--- a/e2e/wdio.conf.ts
+++ b/e2e/wdio.conf.ts
@@ -86,6 +86,10 @@ export const config: WebdriverIO.Config = {
     const logStream = fs.createWriteStream(logPath, { flags: "a" });
     tauriDriver.stdout?.pipe(logStream);
     tauriDriver.stderr?.pipe(logStream);
+    // Also tee to host stdout/stderr so logs surface live in
+    // `docker run` output and CI job logs without unzipping artifacts.
+    tauriDriver.stdout?.pipe(process.stdout);
+    tauriDriver.stderr?.pipe(process.stderr);
   },
 
   afterSession: () => {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "lint": "eslint",
     "test": "vitest",
     "e2e": "wdio run e2e/wdio.conf.ts",
+    "e2e:docker": "docker compose -f docker-compose.e2e.yml run --build --rm e2e",
     "prepare": "husky"
   },
   "lint-staged": {

--- a/scripts/docker-e2e-entrypoint.sh
+++ b/scripts/docker-e2e-entrypoint.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Entrypoint for Dockerfile.e2e. Starts PulseAudio null-sink, ensures
 # dependencies + release binary exist, then runs `pnpm e2e` under xvfb.
-set -euo pipefail
+set -euxo pipefail
 
 # Hermetic per-container Pulse state (avoids host socket reuse).
 export XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/tmp/xdg}"
@@ -12,12 +12,13 @@ pulseaudio --start --exit-idle-time=-1 --log-target=stderr
 pactl load-module module-null-sink sink_name=dummy sink_properties=device.description=Dummy
 pactl set-default-sink dummy
 
-# Install deps if needed (cache-friendly: skipped when node_modules present).
-if [ ! -d node_modules ]; then
+# Install deps if needed. Detect empty dir (named volume mount) as missing,
+# not just absence — `-d` is true for an empty mounted volume.
+if [ -z "$(ls -A node_modules 2>/dev/null)" ]; then
   pnpm install --frozen-lockfile
 fi
 
-# Build release binary if missing. Skipped if already present from host.
+# Build release binary if missing.
 if [ ! -f src-tauri/target/release/diodedj ]; then
   E2E_BINARY="${E2E_BINARY:-release}" pnpm tauri build --no-bundle
 fi

--- a/scripts/docker-e2e-entrypoint.sh
+++ b/scripts/docker-e2e-entrypoint.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Entrypoint for Dockerfile.e2e. Starts PulseAudio null-sink, ensures
+# dependencies + release binary exist, then runs `pnpm e2e` under xvfb.
+set -euo pipefail
+
+# Hermetic per-container Pulse state (avoids host socket reuse).
+export XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/tmp/xdg}"
+mkdir -p "$XDG_RUNTIME_DIR"
+chmod 700 "$XDG_RUNTIME_DIR"
+
+pulseaudio --start --exit-idle-time=-1 --log-target=stderr
+pactl load-module module-null-sink sink_name=dummy sink_properties=device.description=Dummy
+pactl set-default-sink dummy
+
+# Install deps if needed (cache-friendly: skipped when node_modules present).
+if [ ! -d node_modules ]; then
+  pnpm install --frozen-lockfile
+fi
+
+# Build release binary if missing. Skipped if already present from host.
+if [ ! -f src-tauri/target/release/diodedj ]; then
+  E2E_BINARY="${E2E_BINARY:-release}" pnpm tauri build --no-bundle
+fi
+
+exec xvfb-run -a pnpm e2e

--- a/scripts/docker-e2e-entrypoint.sh
+++ b/scripts/docker-e2e-entrypoint.sh
@@ -24,4 +24,9 @@ if [ ! -f src-tauri/target/release/diodedj ]; then
 fi
 
 mkdir -p e2e-results
+# Pre-create + tail tauri-driver.log so its lines surface in `docker logs`
+# (and bind-mount stdout) live, without piping into the wdio worker's
+# `process.stdout` which causes ERR_STREAM_WRITE_AFTER_END on shutdown.
+: > e2e-results/tauri-driver.log
+tail -F e2e-results/tauri-driver.log &
 exec xvfb-run -a -e e2e-results/xvfb.log pnpm e2e

--- a/scripts/docker-e2e-entrypoint.sh
+++ b/scripts/docker-e2e-entrypoint.sh
@@ -14,13 +14,8 @@ pactl set-default-sink dummy
 
 export E2E_BINARY="${E2E_BINARY:-release}"
 
-# Install deps if needed. Detect empty dir (named volume mount) as missing,
-# not just absence — `-d` is true for an empty mounted volume.
-if [ -z "$(ls -A node_modules 2>/dev/null)" ]; then
-  pnpm install --frozen-lockfile
-fi
-
-# Build release binary if missing.
+# Build release binary if missing. node_modules + cargo deps are baked into
+# the image; the target dir lives in a named volume for incremental rebuilds.
 if [ ! -f "src-tauri/target/${E2E_BINARY}/diodedj" ]; then
   pnpm tauri build --no-bundle
 fi

--- a/scripts/docker-e2e-entrypoint.sh
+++ b/scripts/docker-e2e-entrypoint.sh
@@ -12,6 +12,8 @@ pulseaudio --start --exit-idle-time=-1 --log-target=stderr
 pactl load-module module-null-sink sink_name=dummy sink_properties=device.description=Dummy
 pactl set-default-sink dummy
 
+export E2E_BINARY="${E2E_BINARY:-release}"
+
 # Install deps if needed. Detect empty dir (named volume mount) as missing,
 # not just absence — `-d` is true for an empty mounted volume.
 if [ -z "$(ls -A node_modules 2>/dev/null)" ]; then
@@ -19,8 +21,8 @@ if [ -z "$(ls -A node_modules 2>/dev/null)" ]; then
 fi
 
 # Build release binary if missing.
-if [ ! -f src-tauri/target/release/diodedj ]; then
-  E2E_BINARY="${E2E_BINARY:-release}" pnpm tauri build --no-bundle
+if [ ! -f "src-tauri/target/${E2E_BINARY}/diodedj" ]; then
+  pnpm tauri build --no-bundle
 fi
 
 mkdir -p e2e-results
@@ -29,4 +31,16 @@ mkdir -p e2e-results
 # `process.stdout` which causes ERR_STREAM_WRITE_AFTER_END on shutdown.
 : > e2e-results/tauri-driver.log
 tail -F e2e-results/tauri-driver.log &
-exec xvfb-run -a -e e2e-results/xvfb.log pnpm e2e
+
+# Start Xvfb directly instead of via xvfb-run. xvfb-run waits for SIGUSR1
+# from Xvfb to signal readiness; inside this container that handshake
+# blocks indefinitely and the wrapped command never starts.
+Xvfb :99 -screen 0 1280x1024x24 -nolisten tcp >e2e-results/xvfb.log 2>&1 &
+export DISPLAY=:99
+# Wait for Xvfb's UNIX socket to appear (readiness signal without xset).
+for _ in $(seq 1 50); do
+  if [ -S /tmp/.X11-unix/X99 ]; then break; fi
+  sleep 0.1
+done
+
+exec pnpm e2e

--- a/scripts/docker-e2e-entrypoint.sh
+++ b/scripts/docker-e2e-entrypoint.sh
@@ -23,4 +23,5 @@ if [ ! -f src-tauri/target/release/diodedj ]; then
   E2E_BINARY="${E2E_BINARY:-release}" pnpm tauri build --no-bundle
 fi
 
-exec xvfb-run -a pnpm e2e
+mkdir -p e2e-results
+exec xvfb-run -a -e e2e-results/xvfb.log pnpm e2e


### PR DESCRIPTION
## Summary
Local Linux e2e harness for macOS devs. macOS WKWebView ships no WebDriver, so `pnpm e2e` cannot run natively — this container is the only local feedback loop short of pushing to CI. Not wired into CI (CI already runs e2e on its own Linux runner); image exists solely for `pnpm e2e:docker` on developer machines.

- `Dockerfile.e2e` — multi-stage (`base` → `pnpm-deps` → `cargo-deps` → `runtime`) on `node:24-trixie`. Base installs webkit2gtk, pulseaudio, xvfb, Rust 1.95.0, tauri-driver 2.0.6. ALSA→Pulse bridge via `/etc/asound.conf`. `pnpm-deps` runs `pnpm install --frozen-lockfile` with `HUSKY=0` + `strict-dep-builds=false`. `cargo-deps` warms the registry against a stub crate (real compile deferred — `tauri-build` needs the renderer dist).
- `docker-compose.e2e.yml` — one `e2e` service, `shm_size: 2gb`, `init: true`. `./e2e-results` bind for artifacts; named volume `e2e-target` for incremental `src-tauri/target`. Source COPY'd at build time — no host bind-mount of the tree.
- `scripts/docker-e2e-entrypoint.sh` — starts PulseAudio + null-sink, builds the release binary if missing, starts `Xvfb :99` directly (xvfb-run's SIGUSR1 handshake hangs in-container), tails `e2e-results/tauri-driver.log` for live logs, `exec pnpm e2e`.
- `package.json` — `pnpm e2e:docker` shortcut → `docker compose -f docker-compose.e2e.yml run --build --rm e2e`.
- `.dockerignore` + `.gitignore` — exclude `node_modules`, `dist`, `target`, `.pnpm-store`, `e2e-results` from build context.
- `e2e/README.md` — macOS dev path documented.

## Test plan
- [x] `pnpm e2e:docker` runs the suite end-to-end on macOS host
- [x] Driver log surfaces live in `docker logs` (tail-from-entrypoint pattern)
- [x] Cached `e2e-target` volume → incremental rebuild on source edits

🤖 Generated with [Claude Code](https://claude.com/claude-code)