### PR TITLE
feat: expose currently playing track via webhook + file output

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,16 @@ cargo test --manifest-path src-tauri/Cargo.toml             # 24 cargo backend t
 pnpm typecheck && pnpm lint                                 # tsc + svelte-check + eslint
 ```
 
+## Data files
+
+DiodeDJ stores its database (`diodedj.db`), config (`config.json`), session
+state (`session.json`), and default now-playing output in a per-user data
+directory.
+
+- macOS: `~/Library/Application Support/com.diodedj.app/`
+- Linux: `~/.local/share/com.diodedj.app/` (or `$XDG_DATA_HOME/com.diodedj.app/`)
+- Windows: `%APPDATA%\com.diodedj.app\` (typically `C:\Users\<you>\AppData\Roaming\com.diodedj.app\`)
+
 ## Logs
 
 DiodeDJ writes a rotating log file (`DiodeDJ.log`, 1 MB max, one prior file kept).

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Desktop music player built for radio stations. Manage music, commercials, and ji
 - **Playback modes** — AUTO advances through playlist, MANUAL stops after each track
 - **Native audio** — in-process Rust player (rodio + symphonia) for MP3, FLAC, Vorbis, WAV, AAC, M4A. No browser audio pipeline, no external transcoder
 - **Now playing** — real-time display with seekable progress bar, time, and volume
+- **Now-playing broadcast** — outbound webhook + atomic file output for stream overlays, metadata bridges, and scripted consumers (see [docs/now-playing-broadcast.md](docs/now-playing-broadcast.md))
 
 ## Prerequisites
 

--- a/docs/now-playing-broadcast.md
+++ b/docs/now-playing-broadcast.md
@@ -110,5 +110,14 @@ On a `stopped` event both files are truncated to empty. OBS Text (GDI+)
 sources should be pointed at `now_playing.txt` and configured to display
 nothing while empty.
 
-If no directory is set the files land in
-`<app-data-dir>/now-playing/`.
+If no directory is set the files land in `<app-data-dir>/now-playing/`,
+where `<app-data-dir>` resolves to:
+
+- macOS: `~/Library/Application Support/com.diodedj.app/`
+- Linux: `~/.local/share/com.diodedj.app/` (or
+  `$XDG_DATA_HOME/com.diodedj.app/`)
+- Windows: `%APPDATA%\com.diodedj.app\` (typically
+  `C:\Users\<you>\AppData\Roaming\com.diodedj.app\`)
+
+The same directory holds DiodeDJ's `config.json`, `session.json`, and
+`diodedj.db`.

--- a/docs/now-playing-broadcast.md
+++ b/docs/now-playing-broadcast.md
@@ -1,0 +1,114 @@
+# Now-playing broadcast
+
+DiodeDJ can expose the currently playing track to external consumers via two
+parallel sinks:
+
+- **Webhook** — outbound HTTP POST on every track-start and stop.
+- **File output** — `now_playing.txt` + `now_playing.json` written atomically
+  to a configurable directory. OBS-friendly.
+
+Both are configured from **Settings → Now Playing**. They can be enabled
+independently and changes take effect immediately (no app restart).
+
+Only the **main deck** triggers broadcasts. The cue/preview deck never
+announces.
+
+## Trigger semantics
+
+A `now_playing` event fires when the main deck transitions to playing with
+a different track than the one currently announced. A `stopped` event fires
+on pause, on natural track-end, on explicit stop, and on app quit. Pausing
+mid-track is reported as `stopped` because radio listeners hear silence
+regardless of intent; resuming the same track fires a fresh `now_playing`.
+
+A crash or SIGKILL cannot fire a final `stopped`. Consumers should treat
+"no update in N minutes" as off-air.
+
+## Webhook
+
+```
+POST <configured URL>
+Content-Type: application/json
+User-Agent: DiodeDJ/<version>
+X-DiodeDJ-Signature: sha256=<lowercase hex>      (only if a secret is set)
+```
+
+Delivery is fire-and-forget with a 5-second timeout. Failures are logged
+and dropped; no retry, no auto-disable. If a new event fires before the
+previous request completes, the in-flight request is aborted.
+
+### Payload — track start
+
+```json
+{
+  "event": "now_playing",
+  "track": {
+    "id": 123,
+    "title": "Song",
+    "artist": "Artist",
+    "album": "Album",
+    "genre": "Rock",
+    "durationSec": 245.3,
+    "contentType": "music",
+    "path": "/abs/path/file.mp3"
+  },
+  "startedAt": "2026-05-19T14:23:11.482Z"
+}
+```
+
+### Payload — stop
+
+```json
+{ "event": "stopped", "stoppedAt": "2026-05-19T14:27:16.901Z" }
+```
+
+### Payload — test
+
+The **Test webhook** button sends a synthetic event. Useful for verifying
+connectivity without playing a track.
+
+```json
+{ "event": "test", "sentAt": "2026-05-19T14:23:11.482Z" }
+```
+
+### HMAC verification
+
+If a webhook secret is set, requests carry an `X-DiodeDJ-Signature` header.
+The signature is `sha256=` followed by the lowercase hex of
+`HMAC-SHA256(secret, raw_body_bytes)` — identical scheme to GitHub webhooks.
+
+Node example:
+
+```js
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+function verify(secret, body, header) {
+  const expected =
+    "sha256=" + createHmac("sha256", secret).update(body).digest("hex");
+  const a = Buffer.from(expected);
+  const b = Buffer.from(header ?? "");
+  return a.length === b.length && timingSafeEqual(a, b);
+}
+```
+
+### Dedupe guidance
+
+A crash followed by app restart can replay a `now_playing` for the same
+track (because the prior `stopped` was never delivered). Consumers should
+dedupe by `startedAt` rather than `track.id` alone.
+
+## File output
+
+Two files are rewritten atomically (tmp + rename) in the configured
+directory on every event:
+
+- `now_playing.txt` — one line, `Artist - Title` (or just `Title` if the
+  artist is empty). No trailing newline.
+- `now_playing.json` — identical schema to the webhook payload.
+
+On a `stopped` event both files are truncated to empty. OBS Text (GDI+)
+sources should be pointed at `now_playing.txt` and configured to display
+nothing while empty.
+
+If no directory is set the files land in
+`<app-data-dir>/now-playing/`.

--- a/docs/now-playing-broadcast.md
+++ b/docs/now-playing-broadcast.md
@@ -106,9 +106,11 @@ directory on every event:
   artist is empty). No trailing newline.
 - `now_playing.json` — identical schema to the webhook payload.
 
-On a `stopped` event both files are truncated to empty. OBS Text (GDI+)
-sources should be pointed at `now_playing.txt` and configured to display
-nothing while empty.
+On a `stopped` event `now_playing.txt` is truncated to empty (OBS Text
+(GDI+) sources should be pointed at it and configured to display nothing
+while empty), while `now_playing.json` is rewritten with the Stopped
+payload so it always parses as valid JSON and mirrors what the webhook
+sends.
 
 If no directory is set the files land in `<app-data-dir>/now-playing/`,
 where `<app-data-dir>` resolves to:

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -104,6 +104,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "atk"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -137,6 +147,28 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
 
 [[package]]
 name = "base64"
@@ -399,6 +431,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -448,9 +482,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -536,7 +581,7 @@ dependencies = [
  "alsa",
  "coreaudio-rs",
  "dasp_sample",
- "jni",
+ "jni 0.21.1",
  "js-sys",
  "libc",
  "mach2",
@@ -693,6 +738,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -731,6 +794,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -738,14 +802,18 @@ name = "diodedj"
 version = "0.9.1"
 dependencies = [
  "anyhow",
+ "chrono",
  "cpal",
+ "hmac",
  "lofty",
  "log",
  "parking_lot",
+ "reqwest",
  "rodio",
  "rusqlite",
  "serde",
  "serde_json",
+ "sha2",
  "tauri",
  "tauri-build",
  "tauri-plugin-dialog",
@@ -754,6 +822,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "walkdir",
+ "wiremock",
 ]
 
 [[package]]
@@ -1078,10 +1147,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
+
+[[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-channel"
@@ -1090,6 +1180,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -1144,6 +1235,7 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -1270,8 +1362,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1281,9 +1375,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1448,6 +1544,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap 2.14.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1502,10 +1617,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "html5ever"
@@ -1557,6 +1687,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hyper"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1566,14 +1702,31 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
 ]
 
 [[package]]
@@ -1832,6 +1985,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys 0.4.1",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "jni-sys"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1857,6 +2040,16 @@ checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
 ]
 
 [[package]]
@@ -2042,6 +2235,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "mach2"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2214,6 +2413,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -2494,6 +2703,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "option-ext"
@@ -2797,6 +3012,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "aws-lc-rs",
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.4",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2830,8 +3101,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2841,7 +3122,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2851,6 +3142,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -2951,15 +3251,21 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -2993,6 +3299,20 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3071,7 +3391,7 @@ dependencies = [
  "borsh",
  "bytes",
  "num-traits",
- "rand",
+ "rand 0.8.6",
  "rkyv",
  "serde",
  "serde_json",
@@ -3107,6 +3427,81 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "aws-lc-rs",
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni 0.22.4",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "aws-lc-rs",
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3119,6 +3514,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3183,6 +3587,29 @@ name = "seahash"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.11.1",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "selectors"
@@ -3395,6 +3822,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
 name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3523,6 +3960,12 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "swift-rs"
@@ -3755,7 +4198,7 @@ dependencies = [
  "gdkwayland-sys",
  "gdkx11-sys",
  "gtk",
- "jni",
+ "jni 0.21.1",
  "libc",
  "log",
  "ndk",
@@ -3817,7 +4260,7 @@ dependencies = [
  "gtk",
  "heck 0.5.0",
  "http",
- "jni",
+ "jni 0.21.1",
  "libc",
  "log",
  "mime",
@@ -4018,7 +4461,7 @@ dependencies = [
  "dpi",
  "gtk",
  "http",
- "jni",
+ "jni 0.21.1",
  "objc2",
  "objc2-ui-kit",
  "objc2-web-kit",
@@ -4041,7 +4484,7 @@ checksum = "a3989df2ae1c476404fe0a2e8ffc4cfbde97e51efd613c2bb5355fbc9ab52cf0"
 dependencies = [
  "gtk",
  "http",
- "jni",
+ "jni 0.21.1",
  "log",
  "objc2",
  "objc2-app-kit",
@@ -4240,7 +4683,29 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "socket2",
+ "tokio-macros",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -4540,6 +5005,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4794,6 +5265,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "web_atoms"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4847,6 +5328,15 @@ dependencies = [
  "pkg-config",
  "soup3-sys",
  "system-deps",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -5106,6 +5596,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
  "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5374,6 +5873,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "wiremock"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
+dependencies = [
+ "assert-json-diff",
+ "base64 0.22.1",
+ "deadpool",
+ "futures",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
+]
+
+[[package]]
 name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5491,7 +6013,7 @@ dependencies = [
  "gtk",
  "http",
  "javascriptcore-rs",
- "jni",
+ "jni 0.21.1",
  "libc",
  "ndk",
  "objc2",
@@ -5610,6 +6132,12 @@ dependencies = [
  "syn 2.0.117",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -29,9 +29,14 @@ tokio = { version = "=1.52.3", features = ["rt", "sync", "time"] }
 log = "=0.4.29"
 rodio = { version = "=0.21.1", features = ["symphonia-aac", "symphonia-isomp4"] }
 cpal = "=0.16.0"
+reqwest = { version = "=0.13.3", default-features = false, features = ["json", "rustls"] }
+hmac = "=0.12.1"
+sha2 = "=0.10.9"
+chrono = { version = "=0.4.44", features = ["serde"] }
 
 [dev-dependencies]
 tempfile = "=3.27.0"
+wiremock = "=0.6.5"
 
 [features]
 default = ["custom-protocol"]

--- a/src-tauri/src/broadcast/file_sink.rs
+++ b/src-tauri/src/broadcast/file_sink.rs
@@ -1,0 +1,152 @@
+use anyhow::{Context, Result};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use super::payload::{track_text_line, Payload};
+
+const TXT_NAME: &str = "now_playing.txt";
+const JSON_NAME: &str = "now_playing.json";
+
+/// Atomic file writer for now-playing state.
+///
+/// Writes `now_playing.json` and `now_playing.txt` via tmp+rename.
+/// JSON written first, then TXT — OBS / scripted consumers reading TXT
+/// after JSON observe a consistent snapshot.
+pub struct FileSink {
+    dir: PathBuf,
+}
+
+impl FileSink {
+    pub fn new(dir: PathBuf) -> Self {
+        Self { dir }
+    }
+
+    /// Write current state. Track-start writes both files with content;
+    /// stop truncates both to empty (also via atomic rename).
+    pub fn write(&self, payload: &Payload) -> Result<()> {
+        fs::create_dir_all(&self.dir).with_context(|| {
+            format!("create now-playing dir {}", self.dir.display())
+        })?;
+
+        let (json, text) = match payload {
+            Payload::NowPlaying(p) => {
+                let json = serde_json::to_string_pretty(p)?;
+                let text = track_text_line(&p.track);
+                (json, text)
+            }
+            Payload::Stopped(_) => (String::new(), String::new()),
+        };
+
+        atomic_write(&self.dir.join(JSON_NAME), json.as_bytes())?;
+        atomic_write(&self.dir.join(TXT_NAME), text.as_bytes())?;
+        Ok(())
+    }
+}
+
+fn atomic_write(path: &Path, bytes: &[u8]) -> Result<()> {
+    let tmp = tmp_sibling(path);
+    fs::write(&tmp, bytes)
+        .with_context(|| format!("write {}", tmp.display()))?;
+    fs::rename(&tmp, path)
+        .with_context(|| format!("rename {} -> {}", tmp.display(), path.display()))?;
+    Ok(())
+}
+
+fn tmp_sibling(path: &Path) -> PathBuf {
+    let mut name = path
+        .file_name()
+        .map(|f| f.to_os_string())
+        .unwrap_or_default();
+    name.push(".tmp");
+    path.with_file_name(name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::broadcast::payload::BroadcastTrack;
+    use chrono::DateTime;
+    use tempfile::tempdir;
+
+    fn track() -> BroadcastTrack {
+        BroadcastTrack {
+            id: 1,
+            title: "Song".into(),
+            artist: "Artist".into(),
+            album: "Album".into(),
+            genre: Some("Rock".into()),
+            duration_sec: 100.0,
+            content_type: "music".into(),
+            path: "/p/song.mp3".into(),
+        }
+    }
+
+    #[test]
+    fn now_playing_writes_both_files_with_content() {
+        let dir = tempdir().unwrap();
+        let sink = FileSink::new(dir.path().to_path_buf());
+        let ts: DateTime<chrono::Utc> = "2026-05-19T00:00:00Z".parse().unwrap();
+        sink.write(&Payload::now_playing(track(), ts)).unwrap();
+
+        let txt = fs::read_to_string(dir.path().join(TXT_NAME)).unwrap();
+        assert_eq!(txt, "Artist - Song");
+
+        let json = fs::read_to_string(dir.path().join(JSON_NAME)).unwrap();
+        assert!(json.contains("\"event\": \"now_playing\""));
+        assert!(json.contains("\"title\": \"Song\""));
+    }
+
+    #[test]
+    fn stopped_truncates_both_files() {
+        let dir = tempdir().unwrap();
+        let sink = FileSink::new(dir.path().to_path_buf());
+        let ts: DateTime<chrono::Utc> = "2026-05-19T00:00:00Z".parse().unwrap();
+        sink.write(&Payload::now_playing(track(), ts)).unwrap();
+        sink.write(&Payload::stopped(ts)).unwrap();
+
+        let txt = fs::read_to_string(dir.path().join(TXT_NAME)).unwrap();
+        assert_eq!(txt, "");
+        let json = fs::read_to_string(dir.path().join(JSON_NAME)).unwrap();
+        assert_eq!(json, "");
+    }
+
+    #[test]
+    fn artist_empty_yields_title_only_in_txt() {
+        let dir = tempdir().unwrap();
+        let sink = FileSink::new(dir.path().to_path_buf());
+        let mut t = track();
+        t.artist = "".into();
+        let ts: DateTime<chrono::Utc> = "2026-05-19T00:00:00Z".parse().unwrap();
+        sink.write(&Payload::now_playing(t, ts)).unwrap();
+
+        let txt = fs::read_to_string(dir.path().join(TXT_NAME)).unwrap();
+        assert_eq!(txt, "Song");
+    }
+
+    #[test]
+    fn writes_create_missing_directory() {
+        let dir = tempdir().unwrap();
+        let nested = dir.path().join("a/b/c");
+        let sink = FileSink::new(nested.clone());
+        let ts: DateTime<chrono::Utc> = "2026-05-19T00:00:00Z".parse().unwrap();
+        sink.write(&Payload::now_playing(track(), ts)).unwrap();
+        assert!(nested.join(TXT_NAME).exists());
+        assert!(nested.join(JSON_NAME).exists());
+    }
+
+    #[test]
+    fn no_lingering_tmp_files_after_write() {
+        let dir = tempdir().unwrap();
+        let sink = FileSink::new(dir.path().to_path_buf());
+        let ts: DateTime<chrono::Utc> = "2026-05-19T00:00:00Z".parse().unwrap();
+        sink.write(&Payload::now_playing(track(), ts)).unwrap();
+
+        let entries: Vec<_> = fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().into_string().unwrap())
+            .collect();
+        assert!(!entries.iter().any(|n| n.ends_with(".tmp")));
+        assert_eq!(entries.len(), 2);
+    }
+}

--- a/src-tauri/src/broadcast/file_sink.rs
+++ b/src-tauri/src/broadcast/file_sink.rs
@@ -34,7 +34,10 @@ impl FileSink {
                 let text = track_text_line(&p.track);
                 (json, text)
             }
-            Payload::Stopped(_) => (String::new(), String::new()),
+            Payload::Stopped(p) => {
+                let json = serde_json::to_string_pretty(p)?;
+                (json, String::new())
+            }
         };
 
         atomic_write(&self.dir.join(JSON_NAME), json.as_bytes())?;
@@ -97,7 +100,7 @@ mod tests {
     }
 
     #[test]
-    fn stopped_truncates_both_files() {
+    fn stopped_truncates_txt_and_writes_stopped_payload_to_json() {
         let dir = tempdir().unwrap();
         let sink = FileSink::new(dir.path().to_path_buf());
         let ts: DateTime<chrono::Utc> = "2026-05-19T00:00:00Z".parse().unwrap();
@@ -106,8 +109,12 @@ mod tests {
 
         let txt = fs::read_to_string(dir.path().join(TXT_NAME)).unwrap();
         assert_eq!(txt, "");
+
         let json = fs::read_to_string(dir.path().join(JSON_NAME)).unwrap();
-        assert_eq!(json, "");
+        assert!(json.contains("\"event\": \"stopped\""));
+        assert!(json.contains("\"stoppedAt\": \"2026-05-19T00:00:00Z\""));
+        // Must remain valid JSON.
+        let _: serde_json::Value = serde_json::from_str(&json).unwrap();
     }
 
     #[test]

--- a/src-tauri/src/broadcast/file_sink.rs
+++ b/src-tauri/src/broadcast/file_sink.rs
@@ -24,9 +24,8 @@ impl FileSink {
     /// Write current state. Track-start writes both files with content;
     /// stop truncates both to empty (also via atomic rename).
     pub fn write(&self, payload: &Payload) -> Result<()> {
-        fs::create_dir_all(&self.dir).with_context(|| {
-            format!("create now-playing dir {}", self.dir.display())
-        })?;
+        fs::create_dir_all(&self.dir)
+            .with_context(|| format!("create now-playing dir {}", self.dir.display()))?;
 
         let (json, text) = match payload {
             Payload::NowPlaying(p) => {
@@ -48,8 +47,7 @@ impl FileSink {
 
 fn atomic_write(path: &Path, bytes: &[u8]) -> Result<()> {
     let tmp = tmp_sibling(path);
-    fs::write(&tmp, bytes)
-        .with_context(|| format!("write {}", tmp.display()))?;
+    fs::write(&tmp, bytes).with_context(|| format!("write {}", tmp.display()))?;
     fs::rename(&tmp, path)
         .with_context(|| format!("rename {} -> {}", tmp.display(), path.display()))?;
     Ok(())

--- a/src-tauri/src/broadcast/mod.rs
+++ b/src-tauri/src/broadcast/mod.rs
@@ -1,0 +1,7 @@
+pub mod file_sink;
+pub mod payload;
+pub mod service;
+pub mod state;
+pub mod webhook;
+
+pub use service::BroadcastService;

--- a/src-tauri/src/broadcast/payload.rs
+++ b/src-tauri/src/broadcast/payload.rs
@@ -1,0 +1,160 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct BroadcastTrack {
+    pub id: i64,
+    pub title: String,
+    pub artist: String,
+    pub album: String,
+    pub genre: Option<String>,
+    pub duration_sec: f64,
+    pub content_type: String,
+    pub path: String,
+}
+
+#[derive(Serialize, Clone, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct NowPlayingPayload {
+    pub event: &'static str,
+    pub track: BroadcastTrack,
+    pub started_at: DateTime<Utc>,
+}
+
+#[derive(Serialize, Clone, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct StoppedPayload {
+    pub event: &'static str,
+    pub stopped_at: DateTime<Utc>,
+}
+
+#[derive(Serialize, Clone, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct TestPayload {
+    pub event: &'static str,
+    pub sent_at: DateTime<Utc>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum Payload {
+    NowPlaying(NowPlayingPayload),
+    Stopped(StoppedPayload),
+}
+
+impl Payload {
+    pub fn now_playing(track: BroadcastTrack, started_at: DateTime<Utc>) -> Self {
+        Self::NowPlaying(NowPlayingPayload {
+            event: "now_playing",
+            track,
+            started_at,
+        })
+    }
+
+    pub fn stopped(stopped_at: DateTime<Utc>) -> Self {
+        Self::Stopped(StoppedPayload {
+            event: "stopped",
+            stopped_at,
+        })
+    }
+
+    pub fn to_json_bytes(&self) -> serde_json::Result<Vec<u8>> {
+        match self {
+            Self::NowPlaying(p) => serde_json::to_vec(p),
+            Self::Stopped(p) => serde_json::to_vec(p),
+        }
+    }
+
+    #[cfg(test)]
+    pub fn to_json_pretty(&self) -> serde_json::Result<String> {
+        match self {
+            Self::NowPlaying(p) => serde_json::to_string_pretty(p),
+            Self::Stopped(p) => serde_json::to_string_pretty(p),
+        }
+    }
+}
+
+pub fn test_payload(now: DateTime<Utc>) -> TestPayload {
+    TestPayload {
+        event: "test",
+        sent_at: now,
+    }
+}
+
+pub fn track_text_line(track: &BroadcastTrack) -> String {
+    let title = track.title.trim();
+    let artist = track.artist.trim();
+    if artist.is_empty() {
+        title.to_string()
+    } else {
+        format!("{} - {}", artist, title)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_track() -> BroadcastTrack {
+        BroadcastTrack {
+            id: 7,
+            title: "Song".into(),
+            artist: "Artist".into(),
+            album: "Album".into(),
+            genre: Some("Rock".into()),
+            duration_sec: 245.3,
+            content_type: "music".into(),
+            path: "/abs/path/song.mp3".into(),
+        }
+    }
+
+    #[test]
+    fn now_playing_serializes_camel_case_with_event_discriminator() {
+        let ts: DateTime<Utc> = "2026-05-19T14:23:11.482Z".parse().unwrap();
+        let p = Payload::now_playing(sample_track(), ts);
+        let s = p.to_json_pretty().unwrap();
+        assert!(s.contains("\"event\": \"now_playing\""));
+        assert!(s.contains("\"durationSec\": 245.3"));
+        assert!(s.contains("\"contentType\": \"music\""));
+        assert!(s.contains("\"startedAt\": \"2026-05-19T14:23:11.482Z\""));
+        assert!(s.contains("\"path\": \"/abs/path/song.mp3\""));
+    }
+
+    #[test]
+    fn stopped_serializes_with_event_discriminator() {
+        let ts: DateTime<Utc> = "2026-05-19T14:27:16.901Z".parse().unwrap();
+        let p = Payload::stopped(ts);
+        let s = p.to_json_pretty().unwrap();
+        assert!(s.contains("\"event\": \"stopped\""));
+        assert!(s.contains("\"stoppedAt\": \"2026-05-19T14:27:16.901Z\""));
+    }
+
+    #[test]
+    fn test_payload_uses_test_event() {
+        let ts: DateTime<Utc> = "2026-05-19T00:00:00Z".parse().unwrap();
+        let p = test_payload(ts);
+        let s = serde_json::to_string(&p).unwrap();
+        assert!(s.contains("\"event\":\"test\""));
+        assert!(s.contains("\"sentAt\":\"2026-05-19T00:00:00Z\""));
+    }
+
+    #[test]
+    fn track_text_line_uses_artist_dash_title() {
+        let t = sample_track();
+        assert_eq!(track_text_line(&t), "Artist - Song");
+    }
+
+    #[test]
+    fn track_text_line_omits_dash_when_artist_empty() {
+        let mut t = sample_track();
+        t.artist = "".into();
+        assert_eq!(track_text_line(&t), "Song");
+    }
+
+    #[test]
+    fn track_text_line_trims_whitespace() {
+        let mut t = sample_track();
+        t.artist = "  ".into();
+        assert_eq!(track_text_line(&t), "Song");
+    }
+}

--- a/src-tauri/src/broadcast/service.rs
+++ b/src-tauri/src/broadcast/service.rs
@@ -1,0 +1,192 @@
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+use chrono::Utc;
+use parking_lot::Mutex;
+use tauri::async_runtime::{self, JoinHandle};
+use tauri::{AppHandle, Listener};
+
+use crate::library::db::TrackBroadcastInfo;
+use crate::persist::config::Config;
+
+use super::file_sink::FileSink;
+use super::payload::{test_payload, BroadcastTrack, Payload};
+use super::state::{Effect, State};
+use super::webhook::Webhook;
+
+const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(2);
+
+pub struct BroadcastService {
+    inner: Arc<Inner>,
+}
+
+struct Inner {
+    state: Mutex<State>,
+    config: Arc<Config>,
+    webhook: Webhook,
+    default_dir: PathBuf,
+    in_flight: Mutex<Option<JoinHandle<()>>>,
+    shutdown_done: Mutex<bool>,
+}
+
+impl From<TrackBroadcastInfo> for BroadcastTrack {
+    fn from(info: TrackBroadcastInfo) -> Self {
+        BroadcastTrack {
+            id: info.id,
+            title: info.title,
+            artist: info.artist,
+            album: info.album,
+            genre: info.genre,
+            duration_sec: info.duration,
+            content_type: info.content_type,
+            path: info.path,
+        }
+    }
+}
+
+impl BroadcastService {
+    pub fn new(config: Arc<Config>, default_dir: PathBuf) -> anyhow::Result<Self> {
+        let webhook = Webhook::new()?;
+        Ok(Self {
+            inner: Arc::new(Inner {
+                state: Mutex::new(State::new()),
+                config,
+                webhook,
+                default_dir,
+                in_flight: Mutex::new(None),
+                shutdown_done: Mutex::new(false),
+            }),
+        })
+    }
+
+    pub fn set_pending_track(&self, track: BroadcastTrack) {
+        self.inner.state.lock().set_pending(track);
+    }
+
+    /// Attach app.listen handlers for player:pause-state and player:ended.
+    /// Cue deck uses cue:* topics and is intentionally not subscribed.
+    pub fn attach_to_app(&self, app: &AppHandle) {
+        let pause_state_inner = Arc::clone(&self.inner);
+        app.listen("player:pause-state", move |event| {
+            let paused: bool = serde_json::from_str(event.payload()).unwrap_or(false);
+            Inner::dispatch(&pause_state_inner, |s| s.on_pause_state(paused, Utc::now()));
+        });
+
+        let ended_inner = Arc::clone(&self.inner);
+        app.listen("player:ended", move |_event| {
+            Inner::dispatch(&ended_inner, |s| s.on_ended(Utc::now()));
+        });
+    }
+
+    /// Test webhook: synthetic `{"event":"test"}` payload. Returns delivered status
+    /// or error string for inline UI feedback. Blocks until result.
+    pub fn test_webhook_blocking(&self) -> Result<u16, String> {
+        let cfg = self.inner.config.get_now_playing();
+        let url = cfg.webhook_url.clone().filter(|u| !u.is_empty()).ok_or_else(|| {
+            "webhook URL not configured".to_string()
+        })?;
+        let secret = cfg.webhook_secret.clone();
+        let inner = Arc::clone(&self.inner);
+        async_runtime::block_on(async move {
+            let payload = test_payload(Utc::now());
+            match inner
+                .webhook
+                .send_test(&url, secret.as_deref(), &payload)
+                .await
+            {
+                Ok(status) => Ok(status.as_u16()),
+                Err(e) => Err(e.to_string()),
+            }
+        })
+    }
+
+    /// Synchronous shutdown: fire final stop if needed, wait up to 2s.
+    /// Idempotent. Safe to call from frontend close hook and RunEvent::Exit.
+    pub fn shutdown_blocking(&self) {
+        {
+            let mut done = self.inner.shutdown_done.lock();
+            if *done {
+                return;
+            }
+            *done = true;
+        }
+
+        let effect = self.inner.state.lock().on_shutdown(Utc::now());
+        if let Effect::Fire(payload) = effect {
+            let inner = Arc::clone(&self.inner);
+            let _ = async_runtime::block_on(async move {
+                tokio::time::timeout(SHUTDOWN_TIMEOUT, Inner::deliver(&inner, payload)).await
+            });
+        }
+
+        // Abort any still-running in-flight task; we ignore its result.
+        if let Some(h) = self.inner.in_flight.lock().take() {
+            h.abort();
+        }
+    }
+}
+
+impl Inner {
+    fn dispatch<F>(inner: &Arc<Inner>, f: F)
+    where
+        F: FnOnce(&mut State) -> Effect,
+    {
+        let effect = f(&mut inner.state.lock());
+        if let Effect::Fire(payload) = effect {
+            inner.spawn_deliver(payload);
+        }
+    }
+
+    fn spawn_deliver(self: &Arc<Inner>, payload: Payload) {
+        // Cancel in-flight: new event supersedes prior unfinished delivery.
+        if let Some(h) = self.in_flight.lock().take() {
+            h.abort();
+        }
+        let inner = Arc::clone(self);
+        let handle = async_runtime::spawn(async move {
+            Inner::deliver(&inner, payload).await;
+        });
+        *self.in_flight.lock() = Some(handle);
+    }
+
+    async fn deliver(inner: &Arc<Inner>, payload: Payload) {
+        let cfg = inner.config.get_now_playing();
+        if cfg.file_enabled {
+            let dir = cfg
+                .file_dir
+                .as_ref()
+                .filter(|s| !s.is_empty())
+                .map(PathBuf::from)
+                .unwrap_or_else(|| inner.default_dir.clone());
+            let sink = FileSink::new(dir);
+            if let Err(e) = sink.write(&payload) {
+                log::error!("broadcast: file sink write failed: {e:#}");
+            }
+        }
+
+        if cfg.webhook_enabled {
+            if let Some(url) = cfg.webhook_url.as_deref().filter(|u| !u.is_empty()) {
+                match inner
+                    .webhook
+                    .send(url, cfg.webhook_secret.as_deref(), &payload)
+                    .await
+                {
+                    Ok(status) if status.is_success() => {
+                        log::debug!("broadcast: webhook {} -> {}", url, status);
+                    }
+                    Ok(status) => {
+                        log::warn!("broadcast: webhook {} -> {}", url, status);
+                    }
+                    Err(e) => {
+                        log::warn!("broadcast: webhook {} failed: {e:#}", url);
+                    }
+                }
+            }
+        }
+    }
+}
+
+pub fn default_now_playing_dir(app_data_dir: &std::path::Path) -> PathBuf {
+    app_data_dir.join("now-playing")
+}

--- a/src-tauri/src/broadcast/service.rs
+++ b/src-tauri/src/broadcast/service.rs
@@ -83,9 +83,11 @@ impl BroadcastService {
     /// or error string for inline UI feedback. Blocks until result.
     pub fn test_webhook_blocking(&self) -> Result<u16, String> {
         let cfg = self.inner.config.get_now_playing();
-        let url = cfg.webhook_url.clone().filter(|u| !u.is_empty()).ok_or_else(|| {
-            "webhook URL not configured".to_string()
-        })?;
+        let url = cfg
+            .webhook_url
+            .clone()
+            .filter(|u| !u.is_empty())
+            .ok_or_else(|| "webhook URL not configured".to_string())?;
         let secret = cfg.webhook_secret.clone();
         let inner = Arc::clone(&self.inner);
         async_runtime::block_on(async move {

--- a/src-tauri/src/broadcast/state.rs
+++ b/src-tauri/src/broadcast/state.rs
@@ -1,0 +1,199 @@
+use chrono::{DateTime, Utc};
+
+use super::payload::{BroadcastTrack, Payload};
+
+/// Pure FSM tracking what the broadcast service has last announced.
+///
+/// Inputs come from `BroadcastService` after listening to Tauri events:
+/// - `set_pending(track)` — called from `player_load` with the track about to play.
+/// - `on_pause_state(paused)` — main deck pause-state transitions.
+/// - `on_ended()` — main deck track ended naturally.
+/// - `on_shutdown()` — app quit; fire final stop if currently playing.
+///
+/// Output is `Effect`, telling the service what to broadcast.
+#[derive(Default, Debug)]
+pub struct State {
+    pending: Option<BroadcastTrack>,
+    announced_track_id: Option<i64>,
+}
+
+#[derive(Debug, PartialEq)]
+pub enum Effect {
+    None,
+    Fire(Payload),
+}
+
+impl State {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn set_pending(&mut self, track: BroadcastTrack) {
+        self.pending = Some(track);
+    }
+
+    pub fn on_pause_state(&mut self, paused: bool, now: DateTime<Utc>) -> Effect {
+        if paused {
+            self.fire_stop_if_announced(now)
+        } else if let Some(track) = self.pending.clone() {
+            if self.announced_track_id != Some(track.id) {
+                self.announced_track_id = Some(track.id);
+                Effect::Fire(Payload::now_playing(track, now))
+            } else {
+                Effect::None
+            }
+        } else {
+            Effect::None
+        }
+    }
+
+    pub fn on_ended(&mut self, now: DateTime<Utc>) -> Effect {
+        self.fire_stop_if_announced(now)
+    }
+
+    pub fn on_shutdown(&mut self, now: DateTime<Utc>) -> Effect {
+        self.fire_stop_if_announced(now)
+    }
+
+    fn fire_stop_if_announced(&mut self, now: DateTime<Utc>) -> Effect {
+        if self.announced_track_id.take().is_some() {
+            Effect::Fire(Payload::stopped(now))
+        } else {
+            Effect::None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn t(id: i64) -> BroadcastTrack {
+        BroadcastTrack {
+            id,
+            title: format!("title-{id}"),
+            artist: "a".into(),
+            album: "alb".into(),
+            genre: None,
+            duration_sec: 100.0,
+            content_type: "music".into(),
+            path: format!("/p/{id}.mp3"),
+        }
+    }
+
+    fn now() -> DateTime<Utc> {
+        "2026-05-19T00:00:00Z".parse().unwrap()
+    }
+
+    fn unwrap_now_playing(e: Effect) -> BroadcastTrack {
+        match e {
+            Effect::Fire(Payload::NowPlaying(p)) => p.track,
+            other => panic!("expected NowPlaying, got {other:?}"),
+        }
+    }
+
+    fn unwrap_stopped(e: Effect) {
+        match e {
+            Effect::Fire(Payload::Stopped(_)) => (),
+            other => panic!("expected Stopped, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn pause_state_false_without_pending_does_nothing() {
+        let mut s = State::new();
+        assert_eq!(s.on_pause_state(false, now()), Effect::None);
+    }
+
+    #[test]
+    fn pause_state_false_with_pending_fires_now_playing() {
+        let mut s = State::new();
+        s.set_pending(t(1));
+        let track = unwrap_now_playing(s.on_pause_state(false, now()));
+        assert_eq!(track.id, 1);
+    }
+
+    #[test]
+    fn same_track_playing_twice_does_not_re_fire() {
+        let mut s = State::new();
+        s.set_pending(t(1));
+        unwrap_now_playing(s.on_pause_state(false, now()));
+        // Same pending track + another play (e.g., seek reload) — dedupe.
+        let again = s.on_pause_state(false, now());
+        assert_eq!(again, Effect::None);
+    }
+
+    #[test]
+    fn pause_after_play_fires_stop_then_resume_re_fires_now_playing() {
+        let mut s = State::new();
+        s.set_pending(t(1));
+        unwrap_now_playing(s.on_pause_state(false, now()));
+
+        unwrap_stopped(s.on_pause_state(true, now()));
+
+        // Resume same track — should re-fire (state cleared on stop).
+        let track = unwrap_now_playing(s.on_pause_state(false, now()));
+        assert_eq!(track.id, 1);
+    }
+
+    #[test]
+    fn pause_when_nothing_announced_does_nothing() {
+        let mut s = State::new();
+        assert_eq!(s.on_pause_state(true, now()), Effect::None);
+    }
+
+    #[test]
+    fn ended_fires_stop_once() {
+        let mut s = State::new();
+        s.set_pending(t(1));
+        unwrap_now_playing(s.on_pause_state(false, now()));
+        unwrap_stopped(s.on_ended(now()));
+        // Second ended without intervening play — silent.
+        assert_eq!(s.on_ended(now()), Effect::None);
+    }
+
+    #[test]
+    fn pending_swap_before_play_fires_new_track() {
+        let mut s = State::new();
+        s.set_pending(t(1));
+        s.set_pending(t(2));
+        let track = unwrap_now_playing(s.on_pause_state(false, now()));
+        assert_eq!(track.id, 2);
+    }
+
+    #[test]
+    fn track_change_fires_stop_then_new_now_playing() {
+        let mut s = State::new();
+        s.set_pending(t(1));
+        unwrap_now_playing(s.on_pause_state(false, now()));
+
+        // Track ends, new track loads, plays.
+        unwrap_stopped(s.on_ended(now()));
+        s.set_pending(t(2));
+        let track = unwrap_now_playing(s.on_pause_state(false, now()));
+        assert_eq!(track.id, 2);
+    }
+
+    #[test]
+    fn shutdown_fires_stop_when_announced() {
+        let mut s = State::new();
+        s.set_pending(t(1));
+        unwrap_now_playing(s.on_pause_state(false, now()));
+        unwrap_stopped(s.on_shutdown(now()));
+        assert_eq!(s.on_shutdown(now()), Effect::None);
+    }
+
+    #[test]
+    fn shutdown_without_announcement_is_silent() {
+        let mut s = State::new();
+        assert_eq!(s.on_shutdown(now()), Effect::None);
+    }
+
+    #[test]
+    fn set_pending_without_play_does_not_fire() {
+        let mut s = State::new();
+        s.set_pending(t(1));
+        // No pause-state event yet — broadcast silent.
+        assert_eq!(s.on_ended(now()), Effect::None);
+    }
+}

--- a/src-tauri/src/broadcast/webhook.rs
+++ b/src-tauri/src/broadcast/webhook.rs
@@ -66,8 +66,8 @@ impl Webhook {
 }
 
 pub fn sign(secret: &str, body: &[u8]) -> String {
-    let mut mac = <Hmac<Sha256>>::new_from_slice(secret.as_bytes())
-        .expect("HMAC accepts any key length");
+    let mut mac =
+        <Hmac<Sha256>>::new_from_slice(secret.as_bytes()).expect("HMAC accepts any key length");
     mac.update(body);
     hex_lower(&mac.finalize().into_bytes())
 }
@@ -116,7 +116,9 @@ mod tests {
             "42eb9553cf9288e53d3389208d00db1ac80d3666f1fa74fe02e1038672d0c83a"
         );
         assert_eq!(sig.len(), 64);
-        assert!(sig.chars().all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()));
+        assert!(sig
+            .chars()
+            .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()));
     }
 
     #[test]
@@ -187,10 +189,7 @@ mod tests {
         .await
         .unwrap();
 
-        let reqs: Vec<Request> = server
-            .received_requests()
-            .await
-            .expect("requests recorded");
+        let reqs: Vec<Request> = server.received_requests().await.expect("requests recorded");
         let req = reqs.first().expect("one request");
         let sig_header = req
             .headers

--- a/src-tauri/src/broadcast/webhook.rs
+++ b/src-tauri/src/broadcast/webhook.rs
@@ -1,0 +1,245 @@
+use std::time::Duration;
+
+use anyhow::Result;
+use hmac::{Hmac, Mac};
+use reqwest::{header, Client};
+use sha2::Sha256;
+
+use super::payload::{Payload, TestPayload};
+
+const TIMEOUT: Duration = Duration::from_secs(5);
+const USER_AGENT: &str = concat!("DiodeDJ/", env!("CARGO_PKG_VERSION"));
+pub const SIGNATURE_HEADER: &str = "X-DiodeDJ-Signature";
+
+pub struct Webhook {
+    client: Client,
+}
+
+impl Webhook {
+    pub fn new() -> Result<Self> {
+        let client = Client::builder()
+            .timeout(TIMEOUT)
+            .user_agent(USER_AGENT)
+            .build()?;
+        Ok(Self { client })
+    }
+
+    pub async fn send(
+        &self,
+        url: &str,
+        secret: Option<&str>,
+        payload: &Payload,
+    ) -> Result<reqwest::StatusCode> {
+        let body = payload.to_json_bytes()?;
+        self.post(url, secret, body).await
+    }
+
+    pub async fn send_test(
+        &self,
+        url: &str,
+        secret: Option<&str>,
+        payload: &TestPayload,
+    ) -> Result<reqwest::StatusCode> {
+        let body = serde_json::to_vec(payload)?;
+        self.post(url, secret, body).await
+    }
+
+    async fn post(
+        &self,
+        url: &str,
+        secret: Option<&str>,
+        body: Vec<u8>,
+    ) -> Result<reqwest::StatusCode> {
+        let mut req = self
+            .client
+            .post(url)
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(body.clone());
+
+        if let Some(secret) = secret.filter(|s| !s.is_empty()) {
+            req = req.header(SIGNATURE_HEADER, format!("sha256={}", sign(secret, &body)));
+        }
+
+        let resp = req.send().await?;
+        Ok(resp.status())
+    }
+}
+
+pub fn sign(secret: &str, body: &[u8]) -> String {
+    let mut mac = <Hmac<Sha256>>::new_from_slice(secret.as_bytes())
+        .expect("HMAC accepts any key length");
+    mac.update(body);
+    hex_lower(&mac.finalize().into_bytes())
+}
+
+fn hex_lower(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        out.push(HEX[(b >> 4) as usize] as char);
+        out.push(HEX[(b & 0x0f) as usize] as char);
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::broadcast::payload::{test_payload, BroadcastTrack};
+    use chrono::DateTime;
+    use wiremock::matchers::{header, header_exists, method, path};
+    use wiremock::{Mock, MockServer, Request, ResponseTemplate};
+
+    fn track() -> BroadcastTrack {
+        BroadcastTrack {
+            id: 1,
+            title: "Song".into(),
+            artist: "Artist".into(),
+            album: "Album".into(),
+            genre: None,
+            duration_sec: 100.0,
+            content_type: "music".into(),
+            path: "/p/song.mp3".into(),
+        }
+    }
+
+    fn ts() -> DateTime<chrono::Utc> {
+        "2026-05-19T00:00:00Z".parse().unwrap()
+    }
+
+    #[test]
+    fn hmac_sign_is_deterministic_lowercase_hex() {
+        // Regression guard: HMAC-SHA256("hello", b"hi"), lowercase hex.
+        let sig = sign("hello", b"hi");
+        assert_eq!(
+            sig,
+            "42eb9553cf9288e53d3389208d00db1ac80d3666f1fa74fe02e1038672d0c83a"
+        );
+        assert_eq!(sig.len(), 64);
+        assert!(sig.chars().all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()));
+    }
+
+    #[test]
+    fn hmac_sign_differs_for_different_secrets_and_bodies() {
+        assert_ne!(sign("a", b"x"), sign("b", b"x"));
+        assert_ne!(sign("a", b"x"), sign("a", b"y"));
+    }
+
+    #[tokio::test]
+    async fn posts_json_with_content_type() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/hook"))
+            .and(header("content-type", "application/json"))
+            .respond_with(ResponseTemplate::new(204))
+            .mount(&server)
+            .await;
+
+        let wh = Webhook::new().unwrap();
+        let status = wh
+            .send(
+                &format!("{}/hook", server.uri()),
+                None,
+                &Payload::now_playing(track(), ts()),
+            )
+            .await
+            .unwrap();
+        assert_eq!(status.as_u16(), 204);
+    }
+
+    #[tokio::test]
+    async fn includes_signature_header_when_secret_set() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/hook"))
+            .and(header_exists(SIGNATURE_HEADER))
+            .respond_with(ResponseTemplate::new(200))
+            .mount(&server)
+            .await;
+
+        let wh = Webhook::new().unwrap();
+        let status = wh
+            .send(
+                &format!("{}/hook", server.uri()),
+                Some("topsecret"),
+                &Payload::now_playing(track(), ts()),
+            )
+            .await
+            .unwrap();
+        assert_eq!(status.as_u16(), 200);
+    }
+
+    #[tokio::test]
+    async fn signature_matches_hmac_of_body() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/hook"))
+            .respond_with(ResponseTemplate::new(200))
+            .mount(&server)
+            .await;
+
+        let wh = Webhook::new().unwrap();
+        wh.send(
+            &format!("{}/hook", server.uri()),
+            Some("topsecret"),
+            &Payload::stopped(ts()),
+        )
+        .await
+        .unwrap();
+
+        let reqs: Vec<Request> = server
+            .received_requests()
+            .await
+            .expect("requests recorded");
+        let req = reqs.first().expect("one request");
+        let sig_header = req
+            .headers
+            .get(SIGNATURE_HEADER)
+            .expect("signature header")
+            .to_str()
+            .unwrap();
+        let expected = format!("sha256={}", sign("topsecret", &req.body));
+        assert_eq!(sig_header, expected);
+    }
+
+    #[tokio::test]
+    async fn empty_secret_treated_as_no_secret() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/hook"))
+            .respond_with(ResponseTemplate::new(200))
+            .mount(&server)
+            .await;
+
+        let wh = Webhook::new().unwrap();
+        wh.send(
+            &format!("{}/hook", server.uri()),
+            Some(""),
+            &Payload::stopped(ts()),
+        )
+        .await
+        .unwrap();
+
+        let reqs = server.received_requests().await.unwrap();
+        assert!(reqs[0].headers.get(SIGNATURE_HEADER).is_none());
+    }
+
+    #[tokio::test]
+    async fn test_payload_sends_test_event() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/hook"))
+            .respond_with(ResponseTemplate::new(200))
+            .mount(&server)
+            .await;
+
+        let wh = Webhook::new().unwrap();
+        wh.send_test(&format!("{}/hook", server.uri()), None, &test_payload(ts()))
+            .await
+            .unwrap();
+
+        let reqs = server.received_requests().await.unwrap();
+        let body = String::from_utf8(reqs[0].body.clone()).unwrap();
+        assert!(body.contains("\"event\":\"test\""));
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5,15 +5,17 @@ use std::sync::Arc;
 use tauri::{AppHandle, Manager, State};
 
 mod audio;
+mod broadcast;
 mod library;
 mod persist;
 mod playlist;
 
 use audio::devices::{list_output_devices, resolve_device, resolve_main_device, DeviceInfo};
 use audio::player::{Cmd, PlayerHandle};
+use broadcast::{service::default_now_playing_dir, BroadcastService};
 use library::db::{Db, LibraryStats, Track};
 use library::scan_state::{ScanState, ScanStatus, StartResult};
-use persist::config::{Config, DeviceRef};
+use persist::config::{Config, DeviceRef, NowPlayingConfig};
 use persist::session::{PlaylistItem, Session, SessionState};
 
 pub struct AppState {
@@ -23,6 +25,7 @@ pub struct AppState {
     scan: Arc<ScanState>,
     player: Arc<PlayerHandle>,
     cue: Arc<Mutex<Option<PlayerHandle>>>,
+    broadcast: Arc<BroadcastService>,
     app_handle: AppHandle,
 }
 
@@ -142,16 +145,15 @@ fn pick_filler(app: State<'_, AppState>, content_type: String) -> Result<Option<
 fn player_load(app_state: State<'_, AppState>, id: i64) -> Result<(), String> {
     let track = app_state
         .db
-        .get_media_track(id)
+        .get_track_broadcast_info(id)
         .map_err(err)?
         .ok_or_else(|| "track not found".to_string())?;
+    let path = track.path.clone();
+    let duration = track.duration;
+    app_state.broadcast.set_pending_track(track.into());
     app_state.player.send(Cmd::Load {
-        path: std::path::PathBuf::from(track.path),
-        duration: if track.duration > 0.0 {
-            Some(track.duration)
-        } else {
-            None
-        },
+        path: std::path::PathBuf::from(path),
+        duration: if duration > 0.0 { Some(duration) } else { None },
     });
     Ok(())
 }
@@ -288,6 +290,29 @@ fn cue_set_volume(state: State<'_, AppState>, volume: f32) -> Result<(), String>
 }
 
 #[tauri::command(rename_all = "camelCase")]
+fn get_now_playing_config(state: State<'_, AppState>) -> NowPlayingConfig {
+    state.config.get_now_playing()
+}
+
+#[tauri::command(rename_all = "camelCase")]
+fn set_now_playing_config(
+    state: State<'_, AppState>,
+    config: NowPlayingConfig,
+) -> Result<(), String> {
+    state.config.set_now_playing(config).map_err(err)
+}
+
+#[tauri::command(rename_all = "camelCase")]
+fn now_playing_test(state: State<'_, AppState>) -> Result<u16, String> {
+    state.broadcast.test_webhook_blocking()
+}
+
+#[tauri::command(rename_all = "camelCase")]
+fn broadcast_shutdown(state: State<'_, AppState>) {
+    state.broadcast.shutdown_blocking();
+}
+
+#[tauri::command(rename_all = "camelCase")]
 fn scan_library(app: AppHandle, state: State<'_, AppState>) -> StartResult {
     Arc::clone(&state.scan).start(app, Arc::clone(&state.db), Arc::clone(&state.config))
 }
@@ -353,13 +378,20 @@ pub fn run() {
             let session = Session::open(&data_dir);
             let main_device = resolve_main_device(config.get_main_device().as_ref());
             let player = PlayerHandle::spawn(app.handle().clone(), main_device, "player");
+            let config = Arc::new(config);
+            let broadcast = Arc::new(BroadcastService::new(
+                Arc::clone(&config),
+                default_now_playing_dir(&data_dir),
+            )?);
+            broadcast.attach_to_app(app.handle());
             app.manage(AppState {
                 db: Arc::new(db),
-                config: Arc::new(config),
+                config,
                 session: Arc::new(session),
                 scan: Arc::new(ScanState::default()),
                 player: Arc::new(player),
                 cue: Arc::new(Mutex::new(None)),
+                broadcast,
                 app_handle: app.handle().clone(),
             });
             Ok(())
@@ -398,7 +430,18 @@ pub fn run() {
             player_stop,
             player_seek,
             player_set_volume,
+            get_now_playing_config,
+            set_now_playing_config,
+            now_playing_test,
+            broadcast_shutdown,
         ])
-        .run(tauri::generate_context!())
-        .expect("error while running tauri application");
+        .build(tauri::generate_context!())
+        .expect("error while building tauri application")
+        .run(|app, event| {
+            if let tauri::RunEvent::ExitRequested { .. } = event {
+                if let Some(state) = app.try_state::<AppState>() {
+                    state.broadcast.shutdown_blocking();
+                }
+            }
+        });
 }

--- a/src-tauri/src/library/db.rs
+++ b/src-tauri/src/library/db.rs
@@ -65,6 +65,17 @@ pub struct MediaTrack {
     pub duration: f64,
 }
 
+pub struct TrackBroadcastInfo {
+    pub id: i64,
+    pub title: String,
+    pub artist: String,
+    pub album: String,
+    pub genre: Option<String>,
+    pub duration: f64,
+    pub content_type: String,
+    pub path: String,
+}
+
 pub struct Db {
     conn: Mutex<Connection>,
 }
@@ -179,6 +190,30 @@ impl Db {
             Ok(MediaTrack {
                 path: r.get(0)?,
                 duration: r.get::<_, Option<f64>>(1)?.unwrap_or(0.0),
+            })
+        })?;
+        match rows.next() {
+            Some(r) => r.map(Some).map_err(Into::into),
+            None => Ok(None),
+        }
+    }
+
+    pub fn get_track_broadcast_info(&self, id: i64) -> Result<Option<TrackBroadcastInfo>> {
+        let conn = self.conn.lock();
+        let mut stmt = conn.prepare(
+            "SELECT id, title, artist, album, genre, duration, content_type, path \
+             FROM tracks WHERE id = ?",
+        )?;
+        let mut rows = stmt.query_map([id], |r| {
+            Ok(TrackBroadcastInfo {
+                id: r.get(0)?,
+                title: r.get::<_, Option<String>>(1)?.unwrap_or_default(),
+                artist: r.get::<_, Option<String>>(2)?.unwrap_or_default(),
+                album: r.get::<_, Option<String>>(3)?.unwrap_or_default(),
+                genre: r.get::<_, Option<String>>(4)?,
+                duration: r.get::<_, Option<f64>>(5)?.unwrap_or(0.0),
+                content_type: r.get(6)?,
+                path: r.get(7)?,
             })
         })?;
         match rows.next() {

--- a/src-tauri/src/persist/config.rs
+++ b/src-tauri/src/persist/config.rs
@@ -285,11 +285,7 @@ mod tests {
     fn now_playing_partial_json_fills_defaults() {
         let dir = tempdir().unwrap();
         let path = dir.path().join("config.json");
-        fs::write(
-            &path,
-            r#"{"nowPlaying":{"webhookUrl":"https://x"}}"#,
-        )
-        .unwrap();
+        fs::write(&path, r#"{"nowPlaying":{"webhookUrl":"https://x"}}"#).unwrap();
         let cfg = Config::open(dir.path()).unwrap();
         let np = cfg.get_now_playing();
         assert_eq!(np.webhook_url.as_deref(), Some("https://x"));

--- a/src-tauri/src/persist/config.rs
+++ b/src-tauri/src/persist/config.rs
@@ -11,6 +11,37 @@ pub struct DeviceRef {
     pub description: String,
 }
 
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct NowPlayingConfig {
+    #[serde(default)]
+    pub webhook_url: Option<String>,
+    #[serde(default)]
+    pub webhook_secret: Option<String>,
+    #[serde(default)]
+    pub file_dir: Option<String>,
+    #[serde(default = "default_true")]
+    pub file_enabled: bool,
+    #[serde(default = "default_true")]
+    pub webhook_enabled: bool,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+impl Default for NowPlayingConfig {
+    fn default() -> Self {
+        Self {
+            webhook_url: None,
+            webhook_secret: None,
+            file_dir: None,
+            file_enabled: true,
+            webhook_enabled: true,
+        }
+    }
+}
+
 #[derive(Serialize, Deserialize, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct AppConfig {
@@ -24,6 +55,8 @@ pub struct AppConfig {
     pub main_device: Option<DeviceRef>,
     #[serde(default)]
     pub cue_device: Option<DeviceRef>,
+    #[serde(default)]
+    pub now_playing: NowPlayingConfig,
 }
 
 pub struct Config {
@@ -124,6 +157,16 @@ impl Config {
         self.save_locked(&cfg)
     }
 
+    pub fn get_now_playing(&self) -> NowPlayingConfig {
+        self.inner.lock().now_playing.clone()
+    }
+
+    pub fn set_now_playing(&self, np: NowPlayingConfig) -> Result<()> {
+        let mut cfg = self.inner.lock();
+        cfg.now_playing = np;
+        self.save_locked(&cfg)
+    }
+
     pub fn remove_path(&self, kind: &str, dir_path: &str) -> Result<bool> {
         let resolved = canonicalize_lossy(dir_path);
         let mut cfg = self.inner.lock();
@@ -207,6 +250,51 @@ mod tests {
         let cfg = Config::open(dir.path()).unwrap();
         assert!(cfg.get_main_device().is_none());
         assert!(cfg.get_cue_device().is_none());
+    }
+
+    #[test]
+    fn now_playing_defaults_when_missing() {
+        let dir = tempdir().unwrap();
+        let cfg = Config::open(dir.path()).unwrap();
+        let np = cfg.get_now_playing();
+        assert_eq!(np, NowPlayingConfig::default());
+        assert!(np.file_enabled);
+        assert!(np.webhook_enabled);
+        assert!(np.webhook_url.is_none());
+    }
+
+    #[test]
+    fn now_playing_round_trips_to_disk() {
+        let dir = tempdir().unwrap();
+        let cfg = Config::open(dir.path()).unwrap();
+        let np = NowPlayingConfig {
+            webhook_url: Some("https://example.com/hook".into()),
+            webhook_secret: Some("s3cret".into()),
+            file_dir: Some("/tmp/np".into()),
+            file_enabled: false,
+            webhook_enabled: true,
+        };
+        cfg.set_now_playing(np.clone()).unwrap();
+
+        drop(cfg);
+        let cfg2 = Config::open(dir.path()).unwrap();
+        assert_eq!(cfg2.get_now_playing(), np);
+    }
+
+    #[test]
+    fn now_playing_partial_json_fills_defaults() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("config.json");
+        fs::write(
+            &path,
+            r#"{"nowPlaying":{"webhookUrl":"https://x"}}"#,
+        )
+        .unwrap();
+        let cfg = Config::open(dir.path()).unwrap();
+        let np = cfg.get_now_playing();
+        assert_eq!(np.webhook_url.as_deref(), Some("https://x"));
+        assert!(np.file_enabled);
+        assert!(np.webhook_enabled);
     }
 
     #[test]

--- a/src/features/settings/SettingsOverlay.svelte
+++ b/src/features/settings/SettingsOverlay.svelte
@@ -228,85 +228,106 @@
     {:else}
       <div class="settings-section">
         <h4>Now Playing broadcast</h4>
-        <p class="hint">
+        <p class="np-intro">
           Expose the currently playing track to external consumers via outbound
-          webhook and/or local files. Both update on track-start and on stop.
+          webhook and/or local files. Updates fire on track-start and on stop.
         </p>
 
-        <h5>Webhook</h5>
-        <label class="np-toggle">
-          <input
-            type="checkbox"
-            bind:checked={nowPlaying.webhookEnabled}
-            onchange={saveNowPlaying}
-          />
-          Enable webhook
-        </label>
-        <div class="np-row">
-          <label for="np-webhook-url">URL</label>
-          <input
-            id="np-webhook-url"
-            type="url"
-            placeholder="https://example.com/now-playing"
-            value={nowPlaying.webhookUrl ?? ""}
-            oninput={(e) =>
-              (nowPlaying = {
-                ...nowPlaying,
-                webhookUrl: (e.currentTarget as HTMLInputElement).value || null,
-              })}
-            onchange={saveNowPlaying}
-          />
-        </div>
-        <div class="np-row">
-          <label for="np-webhook-secret">HMAC secret (optional)</label>
-          <input
-            id="np-webhook-secret"
-            type="password"
-            placeholder="leave blank for unsigned"
-            value={nowPlaying.webhookSecret ?? ""}
-            oninput={(e) =>
-              (nowPlaying = {
-                ...nowPlaying,
-                webhookSecret:
-                  (e.currentTarget as HTMLInputElement).value || null,
-              })}
-            onchange={saveNowPlaying}
-          />
-        </div>
-        <div class="np-row">
-          <button
-            id="btn-np-test"
-            onclick={runTestWebhook}
-            disabled={testing || !nowPlaying.webhookUrl}>Test webhook</button
-          >
-          {#if testResult}
-            <span class="np-test-result">{testResult}</span>
-          {/if}
+        <div class="np-group">
+          <div class="np-group-header">
+            <span class="np-group-title">Webhook</span>
+            <label class="np-toggle">
+              <input
+                type="checkbox"
+                bind:checked={nowPlaying.webhookEnabled}
+                onchange={saveNowPlaying}
+              />
+              <span>Enabled</span>
+            </label>
+          </div>
+          <div class="device-row">
+            <label for="np-webhook-url">URL</label>
+            <input
+              id="np-webhook-url"
+              class="np-input"
+              type="url"
+              placeholder="https://example.com/now-playing"
+              value={nowPlaying.webhookUrl ?? ""}
+              oninput={(e) =>
+                (nowPlaying = {
+                  ...nowPlaying,
+                  webhookUrl:
+                    (e.currentTarget as HTMLInputElement).value || null,
+                })}
+              onchange={saveNowPlaying}
+            />
+          </div>
+          <div class="device-row">
+            <label for="np-webhook-secret">HMAC secret</label>
+            <input
+              id="np-webhook-secret"
+              class="np-input"
+              type="password"
+              placeholder="optional"
+              value={nowPlaying.webhookSecret ?? ""}
+              oninput={(e) =>
+                (nowPlaying = {
+                  ...nowPlaying,
+                  webhookSecret:
+                    (e.currentTarget as HTMLInputElement).value || null,
+                })}
+              onchange={saveNowPlaying}
+            />
+          </div>
+          <div class="device-row np-action-row">
+            <span class="np-action-spacer"></span>
+            <button
+              class="btn-scan-now"
+              onclick={runTestWebhook}
+              disabled={testing || !nowPlaying.webhookUrl}
+              >{testing ? "Testing…" : "Test webhook"}</button
+            >
+            {#if testResult}
+              <span class="np-test-result">{testResult}</span>
+            {/if}
+          </div>
         </div>
 
-        <h5>File output</h5>
-        <label class="np-toggle">
-          <input
-            type="checkbox"
-            bind:checked={nowPlaying.fileEnabled}
-            onchange={saveNowPlaying}
-          />
-          Enable file output
-        </label>
-        <div class="np-row">
-          <span>Directory</span>
-          <span class="np-file-dir"
-            >{nowPlaying.fileDir ?? "(app data dir / now-playing)"}</span
-          >
-          <button onclick={pickFileDir}>Pick folder</button>
-          {#if nowPlaying.fileDir}
-            <button onclick={clearFileDir}>Reset</button>
-          {/if}
+        <div class="np-group">
+          <div class="np-group-header">
+            <span class="np-group-title">File output</span>
+            <label class="np-toggle">
+              <input
+                type="checkbox"
+                bind:checked={nowPlaying.fileEnabled}
+                onchange={saveNowPlaying}
+              />
+              <span>Enabled</span>
+            </label>
+          </div>
+          <div class="device-row">
+            <label for="np-file-dir">Directory</label>
+            <code id="np-file-dir" class="np-file-dir"
+              >{nowPlaying.fileDir ?? "(app data dir / now-playing)"}</code
+            >
+          </div>
+          <div class="device-row np-action-row">
+            <span class="np-action-spacer"></span>
+            <button class="btn-scan-now" onclick={pickFileDir}
+              >Pick folder…</button
+            >
+            {#if nowPlaying.fileDir}
+              <button class="btn-scan-now" onclick={clearFileDir}
+                >Reset to default</button
+              >
+            {/if}
+          </div>
+          <div class="hint np-file-hint">
+            Writes <code>now_playing.txt</code> and
+            <code>now_playing.json</code> atomically. TXT is truncated on stop; JSON
+            keeps the Stopped event payload.
+          </div>
         </div>
-        <p class="hint">
-          Writes <code>now_playing.txt</code> and <code>now_playing.json</code>
-          atomically. Both files are truncated on stop.
-        </p>
       </div>
     {/if}
 

--- a/src/features/settings/SettingsOverlay.svelte
+++ b/src/features/settings/SettingsOverlay.svelte
@@ -1,6 +1,12 @@
 <script lang="ts">
+  import { api } from "../../shared/api";
   import { app } from "../../shared/state.svelte";
-  import type { ContentType, DeviceInfo, DeviceRef } from "../../shared/types";
+  import type {
+    ContentType,
+    DeviceInfo,
+    DeviceRef,
+    NowPlayingConfig,
+  } from "../../shared/types";
 
   const sections: { type: ContentType; label: string }[] = [
     { type: "music", label: "Music" },
@@ -8,16 +14,60 @@
     { type: "jingle", label: "Jingles" },
   ];
 
-  type ActiveTab = "library" | "audio";
+  type ActiveTab = "library" | "audio" | "now-playing";
   let activeTab = $state<ActiveTab>("library");
   let mainDeviceChanged = $state(false);
+  let nowPlaying = $state<NowPlayingConfig>({
+    webhookUrl: null,
+    webhookSecret: null,
+    fileDir: null,
+    fileEnabled: true,
+    webhookEnabled: true,
+  });
+  let testResult = $state<string | null>(null);
+  let testing = $state(false);
 
   $effect(() => {
     if (app.settingsOpen) {
       void app.loadAudioConfig();
+      void loadNowPlayingConfig();
       mainDeviceChanged = false;
     }
   });
+
+  async function loadNowPlayingConfig(): Promise<void> {
+    nowPlaying = await api.getNowPlayingConfig();
+  }
+
+  async function saveNowPlaying(): Promise<void> {
+    await api.setNowPlayingConfig(nowPlaying);
+  }
+
+  async function pickFileDir(): Promise<void> {
+    const dir = await api.pickDirectory();
+    if (dir) {
+      nowPlaying = { ...nowPlaying, fileDir: dir };
+      await saveNowPlaying();
+    }
+  }
+
+  function clearFileDir(): void {
+    nowPlaying = { ...nowPlaying, fileDir: null };
+    void saveNowPlaying();
+  }
+
+  async function runTestWebhook(): Promise<void> {
+    testing = true;
+    testResult = null;
+    try {
+      const status = await api.testNowPlayingWebhook();
+      testResult = `HTTP ${status}`;
+    } catch (e) {
+      testResult = `Error: ${e instanceof Error ? e.message : String(e)}`;
+    } finally {
+      testing = false;
+    }
+  }
 
   function deviceKey(d: DeviceInfo | DeviceRef | null): string {
     return d ? `${d.name}|${d.description}` : "";
@@ -79,6 +129,13 @@
         aria-selected={activeTab === "audio"}
         onclick={() => (activeTab = "audio")}>Audio</button
       >
+      <button
+        class="settings-tab"
+        class:active={activeTab === "now-playing"}
+        role="tab"
+        aria-selected={activeTab === "now-playing"}
+        onclick={() => (activeTab = "now-playing")}>Now Playing</button
+      >
     </div>
 
     {#if activeTab === "library"}
@@ -121,7 +178,7 @@
           >
         </div>
       </div>
-    {:else}
+    {:else if activeTab === "audio"}
       <div class="settings-section">
         <h4>Audio devices</h4>
         {#if app.audioDevices.length === 0}
@@ -167,6 +224,89 @@
             Pick a different device than main for headphone preview.
           </div>
         {/if}
+      </div>
+    {:else}
+      <div class="settings-section">
+        <h4>Now Playing broadcast</h4>
+        <p class="hint">
+          Expose the currently playing track to external consumers via outbound
+          webhook and/or local files. Both update on track-start and on stop.
+        </p>
+
+        <h5>Webhook</h5>
+        <label class="np-toggle">
+          <input
+            type="checkbox"
+            bind:checked={nowPlaying.webhookEnabled}
+            onchange={saveNowPlaying}
+          />
+          Enable webhook
+        </label>
+        <div class="np-row">
+          <label for="np-webhook-url">URL</label>
+          <input
+            id="np-webhook-url"
+            type="url"
+            placeholder="https://example.com/now-playing"
+            value={nowPlaying.webhookUrl ?? ""}
+            oninput={(e) =>
+              (nowPlaying = {
+                ...nowPlaying,
+                webhookUrl: (e.currentTarget as HTMLInputElement).value || null,
+              })}
+            onchange={saveNowPlaying}
+          />
+        </div>
+        <div class="np-row">
+          <label for="np-webhook-secret">HMAC secret (optional)</label>
+          <input
+            id="np-webhook-secret"
+            type="password"
+            placeholder="leave blank for unsigned"
+            value={nowPlaying.webhookSecret ?? ""}
+            oninput={(e) =>
+              (nowPlaying = {
+                ...nowPlaying,
+                webhookSecret:
+                  (e.currentTarget as HTMLInputElement).value || null,
+              })}
+            onchange={saveNowPlaying}
+          />
+        </div>
+        <div class="np-row">
+          <button
+            id="btn-np-test"
+            onclick={runTestWebhook}
+            disabled={testing || !nowPlaying.webhookUrl}>Test webhook</button
+          >
+          {#if testResult}
+            <span class="np-test-result">{testResult}</span>
+          {/if}
+        </div>
+
+        <h5>File output</h5>
+        <label class="np-toggle">
+          <input
+            type="checkbox"
+            bind:checked={nowPlaying.fileEnabled}
+            onchange={saveNowPlaying}
+          />
+          Enable file output
+        </label>
+        <div class="np-row">
+          <span>Directory</span>
+          <span class="np-file-dir"
+            >{nowPlaying.fileDir ?? "(app data dir / now-playing)"}</span
+          >
+          <button onclick={pickFileDir}>Pick folder</button>
+          {#if nowPlaying.fileDir}
+            <button onclick={clearFileDir}>Reset</button>
+          {/if}
+        </div>
+        <p class="hint">
+          Writes <code>now_playing.txt</code> and <code>now_playing.json</code>
+          atomically. Both files are truncated on stop.
+        </p>
       </div>
     {/if}
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,7 @@ import { mount } from "svelte";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { attachConsole } from "@tauri-apps/plugin-log";
 import App from "./App.svelte";
+import { api } from "./shared/api";
 import { app } from "./shared/state.svelte";
 import "./styles.css";
 
@@ -23,6 +24,7 @@ void win.onCloseRequested(async (event) => {
   event.preventDefault();
   try {
     await app.flushSave();
+    await api.broadcastShutdown();
   } finally {
     await win.destroy();
   }

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -6,6 +6,7 @@ import type {
   DeviceInfo,
   DeviceRef,
   LibraryStats,
+  NowPlayingConfig,
   ScanResult,
   SortColumn,
   SortDir,
@@ -123,6 +124,22 @@ export const api = {
   },
   setCueDevice(device: DeviceRef | null): Promise<void> {
     return invoke<void>("set_cue_device", { device });
+  },
+  getNowPlayingConfig(): Promise<NowPlayingConfig> {
+    return invoke<NowPlayingConfig>("get_now_playing_config");
+  },
+  setNowPlayingConfig(config: NowPlayingConfig): Promise<void> {
+    return invoke<void>("set_now_playing_config", { config });
+  },
+  testNowPlayingWebhook(): Promise<number> {
+    return invoke<number>("now_playing_test");
+  },
+  broadcastShutdown(): Promise<void> {
+    return invoke<void>("broadcast_shutdown");
+  },
+  async pickDirectory(): Promise<string | null> {
+    const dir = await open({ directory: true, multiple: false });
+    return typeof dir === "string" ? dir : null;
   },
 };
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -50,6 +50,14 @@ export interface ScanResult {
   added: number;
 }
 
+export interface NowPlayingConfig {
+  webhookUrl: string | null;
+  webhookSecret: string | null;
+  fileDir: string | null;
+  fileEnabled: boolean;
+  webhookEnabled: boolean;
+}
+
 export interface DeviceRef {
   name: string;
   description: string;

--- a/src/styles.css
+++ b/src/styles.css
@@ -824,6 +824,114 @@ body {
   font-style: italic;
 }
 
+.np-intro {
+  margin: -4px 0 16px;
+  font-size: 12px;
+  color: var(--text-secondary);
+  line-height: 1.5;
+}
+
+.np-group {
+  margin-bottom: 18px;
+  padding: 12px 14px 8px;
+  background: var(--bg-primary);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+}
+
+.np-group:last-of-type {
+  margin-bottom: 0;
+}
+
+.np-group-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 10px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--border);
+}
+
+.np-group-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.np-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--text-secondary);
+  cursor: pointer;
+}
+
+.np-toggle input[type="checkbox"] {
+  margin: 0;
+  cursor: pointer;
+}
+
+.np-input {
+  flex: 1;
+  padding: 6px 8px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  color: var(--text-primary);
+  font-size: 13px;
+  font-family: inherit;
+}
+
+.np-input:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+.np-input::placeholder {
+  color: var(--text-secondary);
+  opacity: 0.6;
+}
+
+.np-action-row {
+  margin-top: 4px;
+}
+
+.np-action-spacer {
+  flex: 0 0 160px;
+}
+
+.np-test-result {
+  font-size: 12px;
+  color: var(--text-secondary);
+  font-family: var(--font-mono, ui-monospace, monospace);
+}
+
+.np-file-dir {
+  flex: 1;
+  padding: 6px 8px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  color: var(--text-primary);
+  font-size: 12px;
+  font-family: var(--font-mono, ui-monospace, monospace);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.np-file-hint {
+  margin: 4px 0 0 172px;
+}
+
+.np-file-hint code {
+  background: var(--bg-secondary);
+  padding: 1px 4px;
+  border-radius: 3px;
+  font-size: 11px;
+}
+
 #paths-list {
   max-height: 300px;
   overflow-y: auto;


### PR DESCRIPTION
## Summary

Adds a now-playing broadcast feature that exposes the currently-playing
track to external consumers, addressing #29. Two parallel sinks fire on
every track-start and stop:

- **Webhook** — outbound async HTTP POST with optional
  `X-DiodeDJ-Signature` HMAC-SHA256 (GitHub-style).
- **File output** — atomic `now_playing.txt` + `now_playing.json` for
  OBS text sources and scripted consumers.

Only the main deck triggers broadcasts; the cue/preview deck uses
separate `cue:*` event topics and stays silent. Configuration lives in
a new "Now Playing" tab in `Settings`, with a test-webhook button.

See `docs/now-playing-broadcast.md` for the full payload schema, HMAC
verification example, and consumer dedupe guidance. The design tree
that produced this implementation is in #29.

## Test plan

- [x] `cargo test` — 68 backend tests pass (added 25 broadcast tests
      covering payload shape, state-machine transitions, atomic file
      writes, HMAC + wiremock).
- [x] `cargo clippy --all-targets -- -D warnings` — clean.
- [x] `pnpm typecheck` — 0 errors.
- [x] `pnpm lint` + `pnpm format:check` — clean.
- [x] `pnpm test -- run` — 97 vitest tests pass.
- [x] Manual: open Settings → Now Playing, set a `requestbin`-style
      URL, click Test webhook, observe payload.
- [x] Manual: load and play a track, observe `now_playing` event
      delivered + `now_playing.txt` updated.
- [x] Manual: pause, confirm `stopped` event delivered + files
      truncated; resume, confirm `now_playing` re-fires.
- [x] Manual: switch tracks, confirm only the new track gets a
      `now_playing` (no dupe for the prior).
- [x] Manual: quit the app, confirm a final `stopped` event arrives.
- [x] Manual: load + play a track via the cue deck, confirm no
      broadcast fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)