### PR TITLE
feat(audio): network-resilient audio player (SMB/NFS share hardening)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ dist/
 src-tauri/target/
 src-tauri/gen/schemas/
 e2e-results/
+.claude/

--- a/src-tauri/src/audio/cache.rs
+++ b/src-tauri/src/audio/cache.rs
@@ -1,0 +1,324 @@
+//! Shared prefetch byte cache for the audio decks.
+//!
+//! Holds whole track files resident in RAM keyed by track id, so that when a
+//! deck loads an upcoming track the bytes are already available and no
+//! (possibly networked) filesystem read is needed on the hot path.
+//!
+//! Residency is governed by a *keep-window* policy — NOT an LRU:
+//! - The renderer pushes the "window" of upcoming track ids (current + the next
+//!   [`WINDOW_SIZE`]) via `set_window`. Entries whose id falls outside the
+//!   latest window are evicted immediately.
+//! - Total resident bytes are capped at [`MAX_CACHE_BYTES`]. When the window's
+//!   entries would exceed the cap, the nearest entries win: the window is
+//!   walked nearest-first and entries are retained until the cap is reached.
+//!
+//! A single background worker fetches missing window entries sequentially,
+//! nearest-first — never in parallel, to avoid hammering the (network) share.
+
+use anyhow::{Context, Result};
+use parking_lot::Mutex;
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+use std::sync::mpsc::{channel, Receiver, Sender};
+use std::sync::Arc;
+use std::thread;
+use tauri::{AppHandle, Emitter};
+
+/// Number of upcoming tracks kept resident: the current track plus the next 15.
+pub const WINDOW_SIZE: usize = 15;
+
+/// Hard cap on total resident bytes. Whichever of the window size / byte cap is
+/// hit first bounds residency.
+pub const MAX_CACHE_BYTES: usize = 150 * 1024 * 1024;
+
+/// Event topic on which cache membership changes are broadcast. Prefetch is a
+/// main-deck concept, so the cache-state event carries the main-deck prefix.
+const CACHE_STATE_EVENT: &str = "main-deck:cache-state";
+
+/// Whole track file resident in RAM. Cheaply cloned (Arc) between the cache and
+/// the decoder.
+type Bytes = Arc<[u8]>;
+
+/// Internal, lock-guarded cache state. All bookkeeping (window membership and
+/// byte-cap eviction) is implemented here as pure-ish methods so it can be
+/// unit-tested without spawning real reads or touching an audio device.
+struct Inner {
+    /// Cached file bytes by track id.
+    entries: HashMap<i64, Bytes>,
+    /// Desired residency window, ordered nearest-first (current track first),
+    /// paired with the path to read on a miss.
+    window: Vec<(i64, PathBuf)>,
+    /// Bumped on every `set_window`; lets the prefetch worker abort a run whose
+    /// window has been superseded.
+    generation: u64,
+}
+
+impl Inner {
+    fn new() -> Self {
+        Self {
+            entries: HashMap::new(),
+            window: Vec::new(),
+            generation: 0,
+        }
+    }
+
+    /// Evict cached entries whose id is not in the current window. Returns
+    /// `true` if membership changed.
+    fn evict_out_of_window(&mut self) -> bool {
+        let ids: HashSet<i64> = self.window.iter().map(|(id, _)| *id).collect();
+        let before = self.entries.len();
+        self.entries.retain(|id, _| ids.contains(id));
+        self.entries.len() != before
+    }
+
+    /// Enforce the byte cap by dropping entries beyond the cap, nearest-first.
+    /// Returns `true` if membership changed.
+    fn enforce_cap(&mut self) -> bool {
+        let keep = retain_within_cap(&self.window, &self.entries, MAX_CACHE_BYTES);
+        let before = self.entries.len();
+        self.entries.retain(|id, _| keep.contains(id));
+        self.entries.len() != before
+    }
+}
+
+/// Walk `window` nearest-first, keeping ids whose cached bytes fit under `cap`.
+/// Stops at the first entry that would exceed the cap (nearest entries win).
+/// Ids not present in `entries` are ignored (not yet fetched).
+fn retain_within_cap(
+    window: &[(i64, PathBuf)],
+    entries: &HashMap<i64, Bytes>,
+    cap: usize,
+) -> HashSet<i64> {
+    let mut keep = HashSet::new();
+    let mut total = 0usize;
+    for (id, _) in window {
+        if let Some(b) = entries.get(id) {
+            let len = b.len();
+            if total + len > cap {
+                break;
+            }
+            total += len;
+            keep.insert(*id);
+        }
+    }
+    keep
+}
+
+/// Shared byte cache. Clone the `Arc<Cache>` to share it across decks — every
+/// clone points at the same resident entries and the same prefetch worker.
+pub struct Cache {
+    inner: Arc<Mutex<Inner>>,
+    /// Wakes the prefetch worker; the authoritative window lives in `inner`.
+    prefetch_tx: Sender<()>,
+    app: AppHandle,
+}
+
+impl Cache {
+    pub fn new(app: AppHandle) -> Arc<Self> {
+        let inner = Arc::new(Mutex::new(Inner::new()));
+        let (prefetch_tx, prefetch_rx) = channel::<()>();
+        {
+            let inner = Arc::clone(&inner);
+            let app = app.clone();
+            thread::spawn(move || prefetch_worker(inner, app, prefetch_rx));
+        }
+        Arc::new(Self {
+            inner,
+            prefetch_tx,
+            app,
+        })
+    }
+
+    /// Look up resident bytes for a track id. Never reads the filesystem.
+    pub fn get(&self, id: i64) -> Option<Bytes> {
+        self.inner.lock().entries.get(&id).cloned()
+    }
+
+    /// Replace the residency window. Evicts out-of-window entries, enforces the
+    /// byte cap, emits a cache-state event if membership changed, and wakes the
+    /// prefetch worker to fetch any still-missing window entries.
+    pub fn set_window(&self, mut window: Vec<(i64, PathBuf)>) {
+        // Defensively enforce the keep-window bound (current + next
+        // WINDOW_SIZE) regardless of how many ids the renderer pushes.
+        window.truncate(WINDOW_SIZE + 1);
+        let changed = {
+            let mut inner = self.inner.lock();
+            inner.window = window;
+            inner.generation = inner.generation.wrapping_add(1);
+            let a = inner.evict_out_of_window();
+            let b = inner.enforce_cap();
+            a || b
+        };
+        if changed {
+            self.emit_cache_state();
+        }
+        // Kick the worker even if nothing was evicted — the window may contain
+        // not-yet-fetched entries.
+        let _ = self.prefetch_tx.send(());
+    }
+
+    /// Snapshot of the currently cached track ids.
+    pub fn cached_ids(&self) -> Vec<i64> {
+        self.inner.lock().entries.keys().copied().collect()
+    }
+
+    fn emit_cache_state(&self) {
+        let ids = self.cached_ids();
+        let _ = self.app.emit(CACHE_STATE_EVENT, ids);
+    }
+}
+
+/// Background prefetch loop. Woken by `set_window`; reads missing window entries
+/// sequentially, nearest-first, one at a time.
+fn prefetch_worker(inner: Arc<Mutex<Inner>>, app: AppHandle, rx: Receiver<()>) {
+    while rx.recv().is_ok() {
+        // Coalesce a burst of wake-ups into a single run against the latest
+        // window.
+        while rx.try_recv().is_ok() {}
+        run_prefetch(&inner, &app);
+    }
+}
+
+fn run_prefetch(inner: &Arc<Mutex<Inner>>, app: &AppHandle) {
+    // Snapshot the window and generation we are fetching for.
+    let (window, generation) = {
+        let guard = inner.lock();
+        (guard.window.clone(), guard.generation)
+    };
+
+    let mut retained_bytes: usize = 0;
+    for (id, path) in &window {
+        // Abort if a newer window superseded ours; the worker will be woken
+        // again for the new window.
+        {
+            let guard = inner.lock();
+            if guard.generation != generation {
+                return;
+            }
+            if let Some(b) = guard.entries.get(id) {
+                retained_bytes += b.len();
+                continue;
+            }
+        }
+
+        // Read on the worker thread — one file at a time.
+        let bytes = match read_file(path) {
+            Ok(b) => b,
+            Err(e) => {
+                log::warn!("cache: prefetch read {} failed: {}", path.display(), e);
+                continue;
+            }
+        };
+
+        // Stop once the cap would be exceeded — nearest entries are prioritised
+        // and farther ones would only be evicted anyway.
+        if retained_bytes + bytes.len() > MAX_CACHE_BYTES {
+            break;
+        }
+
+        let changed = {
+            let mut guard = inner.lock();
+            if guard.generation != generation {
+                return;
+            }
+            // Only insert if the id is still in the window.
+            if !guard.window.iter().any(|(w, _)| w == id) {
+                continue;
+            }
+            guard.entries.insert(*id, bytes.clone());
+            retained_bytes += bytes.len();
+            // Re-run cap enforcement in case concurrent inserts pushed us over.
+            let _ = guard.enforce_cap();
+            true
+        };
+        if changed {
+            let ids = inner.lock().entries.keys().copied().collect::<Vec<_>>();
+            let _ = app.emit(CACHE_STATE_EVENT, ids);
+        }
+    }
+}
+
+/// Read a whole file into a shared byte buffer. Kept as a standalone helper so
+/// the read path can be shared/adjusted independently of cache bookkeeping.
+fn read_file(path: &Path) -> Result<Bytes> {
+    let vec = std::fs::read(path).with_context(|| format!("read {}", path.display()))?;
+    Ok(Arc::from(vec.into_boxed_slice()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Synthetic cached entry of `len` bytes — no real file/audio needed.
+    fn bytes(len: usize) -> Bytes {
+        Arc::from(vec![0u8; len].into_boxed_slice())
+    }
+
+    fn win(ids: &[i64]) -> Vec<(i64, PathBuf)> {
+        ids.iter().map(|id| (*id, PathBuf::from("x"))).collect()
+    }
+
+    #[test]
+    fn evict_out_of_window_drops_ids_outside_window() {
+        let mut inner = Inner::new();
+        inner.entries.insert(1, bytes(10));
+        inner.entries.insert(2, bytes(10));
+        inner.entries.insert(3, bytes(10));
+        // New window keeps only ids 2 and 4 (4 not yet cached).
+        inner.window = win(&[2, 4]);
+
+        let changed = inner.evict_out_of_window();
+        assert!(changed, "membership should change");
+        let ids: HashSet<i64> = inner.entries.keys().copied().collect();
+        assert_eq!(ids, HashSet::from([2]));
+    }
+
+    #[test]
+    fn evict_out_of_window_is_noop_when_all_in_window() {
+        let mut inner = Inner::new();
+        inner.entries.insert(1, bytes(10));
+        inner.entries.insert(2, bytes(10));
+        inner.window = win(&[1, 2, 3]);
+
+        assert!(!inner.evict_out_of_window());
+        assert_eq!(inner.entries.len(), 2);
+    }
+
+    #[test]
+    fn enforce_cap_retains_nearest_first_until_full() {
+        // Three ~60 MB entries, cap 150 MB → only the first two fit.
+        let big = 60 * 1024 * 1024;
+        let mut inner = Inner::new();
+        inner.window = win(&[1, 2, 3]);
+        inner.entries.insert(1, bytes(big));
+        inner.entries.insert(2, bytes(big));
+        inner.entries.insert(3, bytes(big));
+
+        let changed = inner.enforce_cap();
+        assert!(changed, "third entry should be evicted by the cap");
+        let ids: HashSet<i64> = inner.entries.keys().copied().collect();
+        assert_eq!(ids, HashSet::from([1, 2]), "nearest two entries retained");
+    }
+
+    #[test]
+    fn enforce_cap_noop_when_under_cap() {
+        let mut inner = Inner::new();
+        inner.window = win(&[1, 2]);
+        inner.entries.insert(1, bytes(1024));
+        inner.entries.insert(2, bytes(1024));
+        assert!(!inner.enforce_cap());
+        assert_eq!(inner.entries.len(), 2);
+    }
+
+    #[test]
+    fn retain_within_cap_stops_at_first_overflow() {
+        let big = 100 * 1024 * 1024;
+        let window = win(&[1, 2, 3]);
+        let mut entries: HashMap<i64, Bytes> = HashMap::new();
+        entries.insert(1, bytes(big));
+        entries.insert(2, bytes(big)); // 1 + 2 = 200 MB > 150 MB cap
+        entries.insert(3, bytes(1024));
+        let keep = retain_within_cap(&window, &entries, MAX_CACHE_BYTES);
+        assert_eq!(keep, HashSet::from([1]), "only the nearest entry fits");
+    }
+}

--- a/src-tauri/src/audio/mod.rs
+++ b/src-tauri/src/audio/mod.rs
@@ -1,3 +1,4 @@
+pub mod cache;
 pub mod devices;
 pub mod formats;
 pub mod player;

--- a/src-tauri/src/audio/player.rs
+++ b/src-tauri/src/audio/player.rs
@@ -11,6 +11,23 @@ use tauri::{AppHandle, Emitter};
 const TICK_INTERVAL: Duration = Duration::from_millis(50);
 const TIME_EMIT_INTERVAL: Duration = Duration::from_millis(100);
 
+/// A background read that neither completes nor errors within this budget is
+/// treated as a wedged (e.g. networked) mount. The audio worker stops waiting
+/// on it and declares a timeout; the detached read thread is abandoned (a
+/// blocked `read()` cannot be cancelled — it unwinds whenever the OS finally
+/// errors the mount).
+const READ_WATCHDOG_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Backoff delays applied between failed read attempts. The read thread makes
+/// one initial attempt plus one retry per entry (4 attempts, 3 backoffs) before
+/// giving up. Retries cover *transient* failures (`Err`); hangs are handled by
+/// the watchdog, not retry.
+const READ_RETRY_BACKOFFS: [Duration; 3] = [
+    Duration::from_millis(500),
+    Duration::from_millis(1000),
+    Duration::from_millis(2000),
+];
+
 /// Whole track file resident in RAM. Shared (cheaply cloned) between the
 /// playing `Decoder` and the retained copy used for seeking, so playback and
 /// seek never touch the (possibly networked) filesystem again after load.
@@ -18,6 +35,9 @@ type Bytes = Arc<[u8]>;
 
 pub enum Cmd {
     Load {
+        /// DB track id, threaded through so a failed/timed-out load can name the
+        /// track in the `:load-failed` event for programmatic handling.
+        id: i64,
         path: PathBuf,
         duration: Option<f64>,
     },
@@ -33,6 +53,8 @@ pub enum Cmd {
 /// superseded (e.g. the user skipped again before a slow read finished).
 struct LoadMsg {
     generation: u64,
+    /// Track id this read was issued for; reported in `:load-failed` on failure.
+    id: i64,
     duration: Option<f64>,
     bytes: Result<Bytes>,
 }
@@ -44,6 +66,7 @@ struct Topics {
     ended: String,
     error: String,
     buffering: String,
+    load_failed: String,
 }
 
 impl Topics {
@@ -55,6 +78,7 @@ impl Topics {
             ended: format!("{prefix}:ended"),
             error: format!("{prefix}:error"),
             buffering: format!("{prefix}:buffering"),
+            load_failed: format!("{prefix}:load-failed"),
         }
     }
 }
@@ -82,6 +106,8 @@ impl PlayerHandle {
 }
 
 struct State {
+    /// Track id of the most recent `Load`, reported in `:load-failed`.
+    current_id: Option<i64>,
     current_path: Option<PathBuf>,
     current_duration: Option<f64>,
     /// Bytes of the currently loaded track, kept so seeks re-decode from RAM.
@@ -91,6 +117,9 @@ struct State {
     /// A background read is in flight; suppresses ended-detection and time
     /// emits until the source is ready.
     loading: bool,
+    /// When the in-flight read started; drives the watchdog timeout. `None`
+    /// whenever no read is pending.
+    load_start: Option<Instant>,
     /// Monotonic token identifying the most recent load intent. Bumped on every
     /// `Load` and `Stop`; background reads carry the token they were issued for.
     generation: u64,
@@ -124,12 +153,14 @@ fn run(
         .checked_sub(TIME_EMIT_INTERVAL)
         .unwrap_or_else(Instant::now);
     let mut state = State {
+        current_id: None,
         current_path: None,
         current_duration: None,
         current_bytes: None,
         seek_offset: 0.0,
         active: false,
         loading: false,
+        load_start: None,
         generation: 0,
         volume: 1.0,
     };
@@ -146,6 +177,13 @@ fn run(
         // Drain any completed background reads.
         while let Ok(msg) = load_rx.try_recv() {
             apply_load(&app, &stream, &mut sink, &mut state, topics, msg);
+        }
+
+        // Watchdog: a read that neither completed nor errored within the budget
+        // is a wedged mount. Declare a timeout and abandon the detached read
+        // thread — the worker never blocks waiting on it.
+        if watchdog_timed_out(state.loading, state.load_start, Instant::now()) {
+            handle_load_timeout(&app, &mut state, topics);
         }
 
         if state.active && last_time_emit.elapsed() >= TIME_EMIT_INTERVAL {
@@ -174,7 +212,7 @@ fn apply(
     cmd: Cmd,
 ) {
     match cmd {
-        Cmd::Load { path, duration } => {
+        Cmd::Load { id, path, duration } => {
             // Stop current audio immediately; the new source arrives once the
             // background read completes.
             sink.stop();
@@ -182,22 +220,29 @@ fn apply(
             sink.set_volume(state.volume);
 
             state.generation = state.generation.wrapping_add(1);
+            state.current_id = Some(id);
             state.current_path = Some(path.clone());
             state.current_duration = duration;
             state.current_bytes = None;
             state.seek_offset = 0.0;
             state.active = false;
             state.loading = true;
+            state.load_start = Some(Instant::now());
             let _ = app.emit(&topics.buffering, true);
 
             // Read the whole file off the worker thread so a slow/networked
-            // read never blocks transport commands.
+            // read never blocks transport commands. One read is in flight per
+            // deck at a time: a newer `Load` bumps `generation`, so this read's
+            // result is discarded rather than another thread being blocked on.
             let generation = state.generation;
             let tx = load_tx.clone();
             thread::spawn(move || {
-                let bytes = read_file(&path);
+                // Retry transient failures with backoff; hangs are the
+                // watchdog's job (handled in the worker loop, not here).
+                let bytes = read_with_retry(|| read_file(&path), thread::sleep);
                 let _ = tx.send(LoadMsg {
                     generation,
+                    id,
                     duration,
                     bytes,
                 });
@@ -222,6 +267,8 @@ fn apply(
             state.generation = state.generation.wrapping_add(1);
             state.active = false;
             state.loading = false;
+            state.load_start = None;
+            state.current_id = None;
             state.current_path = None;
             state.current_duration = None;
             state.current_bytes = None;
@@ -293,6 +340,7 @@ fn apply_load(
         return; // superseded
     }
     state.loading = false;
+    state.load_start = None;
     let _ = app.emit(&topics.buffering, false);
 
     let bytes = match msg.bytes {
@@ -303,9 +351,12 @@ fn apply_load(
                 .as_ref()
                 .map(|p| p.display().to_string())
                 .unwrap_or_default();
-            log::error!("player: read {} failed: {}", path, e);
+            // Retries were already exhausted inside the read thread.
+            log::error!("player: read {} failed after retries: {}", path, e);
             let _ = app.emit(&topics.error, format!("read failed: {}", e));
             reset_after_failure(state);
+            // Programmatic signal carrying the track id (human message above).
+            let _ = app.emit(&topics.load_failed, msg.id);
             let _ = app.emit(&topics.pause_state, true);
             return;
         }
@@ -337,10 +388,77 @@ fn apply_load(
 fn reset_after_failure(state: &mut State) {
     state.active = false;
     state.loading = false;
+    state.load_start = None;
+    state.current_id = None;
     state.current_path = None;
     state.current_duration = None;
     state.current_bytes = None;
     state.seek_offset = 0.0;
+}
+
+/// Decide whether an in-flight read has exceeded the watchdog budget. Pure
+/// (given the clock via `now`) so it is unit-testable without threads or sleeps.
+/// A read is timed out only while `loading` is true, a `load_start` is recorded,
+/// and at least `READ_WATCHDOG_TIMEOUT` has elapsed. When a result has arrived
+/// the worker sets `loading = false`, so this returns false.
+fn watchdog_timed_out(loading: bool, load_start: Option<Instant>, now: Instant) -> bool {
+    match load_start {
+        Some(start) if loading => now.saturating_duration_since(start) >= READ_WATCHDOG_TIMEOUT,
+        _ => false,
+    }
+}
+
+/// Handle a watchdog timeout: abandon the detached read, emit the human error
+/// plus a `:load-failed` carrying the track id, and reset load state. The
+/// generation is bumped so a late `LoadMsg` from the abandoned thread is
+/// discarded rather than played.
+fn handle_load_timeout(app: &AppHandle, state: &mut State, topics: &Topics) {
+    let id = state.current_id;
+    let path = state
+        .current_path
+        .as_ref()
+        .map(|p| p.display().to_string())
+        .unwrap_or_default();
+    log::error!(
+        "player: read {} timed out after {:?}; abandoning read",
+        path,
+        READ_WATCHDOG_TIMEOUT
+    );
+    state.generation = state.generation.wrapping_add(1);
+    reset_after_failure(state);
+    let _ = app.emit(&topics.buffering, false);
+    let _ = app.emit(&topics.error, "network down: read timed out".to_string());
+    if let Some(id) = id {
+        let _ = app.emit(&topics.load_failed, id);
+    }
+    let _ = app.emit(&topics.pause_state, true);
+}
+
+/// Read a file with bounded retry + backoff for *transient* failures. Makes an
+/// initial attempt plus one retry per `READ_RETRY_BACKOFFS` entry, sleeping the
+/// matching backoff between attempts, and returns the first success or the last
+/// error. `read`/`sleep` are injected so tests exercise the schedule without
+/// touching the filesystem or actually sleeping.
+fn read_with_retry<R, S>(mut read: R, mut sleep: S) -> Result<Bytes>
+where
+    R: FnMut() -> Result<Bytes>,
+    S: FnMut(Duration),
+{
+    let mut last_err: Option<anyhow::Error> = None;
+    // Attempt indices 0..=len: index 0 is the initial try, and after a failing
+    // attempt `i` we back off by `READ_RETRY_BACKOFFS[i]` if one exists.
+    for attempt in 0..=READ_RETRY_BACKOFFS.len() {
+        match read() {
+            Ok(bytes) => return Ok(bytes),
+            Err(e) => {
+                last_err = Some(e);
+                if let Some(delay) = READ_RETRY_BACKOFFS.get(attempt) {
+                    sleep(*delay);
+                }
+            }
+        }
+    }
+    Err(last_err.unwrap_or_else(|| anyhow::anyhow!("read failed with no attempts")))
 }
 
 fn read_file(path: &Path) -> Result<Bytes> {
@@ -415,15 +533,95 @@ mod tests {
         let latest = 5u64;
         let stale = LoadMsg {
             generation: 4,
+            id: 1,
             duration: None,
             bytes: Ok(Arc::from(Vec::new().into_boxed_slice())),
         };
         let fresh = LoadMsg {
             generation: 5,
+            id: 1,
             duration: None,
             bytes: Ok(Arc::from(Vec::new().into_boxed_slice())),
         };
         assert_ne!(stale.generation, latest);
         assert_eq!(fresh.generation, latest);
+    }
+
+    /// The backoff schedule is the agreed 0.5s / 1s / 2s with three entries
+    /// (three retries after the initial attempt).
+    #[test]
+    fn backoff_schedule_is_half_one_two_seconds() {
+        assert_eq!(
+            READ_RETRY_BACKOFFS,
+            [
+                Duration::from_millis(500),
+                Duration::from_millis(1000),
+                Duration::from_millis(2000),
+            ]
+        );
+    }
+
+    /// A transient failure that clears within the retry budget eventually
+    /// succeeds, and the recorded backoffs follow the schedule exactly.
+    #[test]
+    fn read_with_retry_succeeds_after_transient_failures() {
+        let mut attempts = 0u32;
+        let mut slept: Vec<Duration> = Vec::new();
+        let result = read_with_retry(
+            || {
+                attempts += 1;
+                if attempts <= 2 {
+                    Err(anyhow::anyhow!("transient"))
+                } else {
+                    Ok(Arc::from(vec![1u8, 2, 3].into_boxed_slice()))
+                }
+            },
+            |d| slept.push(d),
+        );
+        assert!(result.is_ok());
+        assert_eq!(attempts, 3, "initial attempt + 2 retries");
+        // Backoffs applied before retry 1 and retry 2 only.
+        assert_eq!(
+            slept,
+            vec![Duration::from_millis(500), Duration::from_millis(1000)]
+        );
+    }
+
+    /// An always-failing read exhausts the budget: 4 attempts (initial + 3
+    /// retries), sleeping the full 0.5s / 1s / 2s schedule, then returns Err.
+    #[test]
+    fn read_with_retry_gives_up_after_exhausting_backoffs() {
+        let mut attempts = 0u32;
+        let mut slept: Vec<Duration> = Vec::new();
+        let result = read_with_retry(
+            || {
+                attempts += 1;
+                Err::<Bytes, _>(anyhow::anyhow!("always fails"))
+            },
+            |d| slept.push(d),
+        );
+        assert!(result.is_err());
+        assert_eq!(attempts, READ_RETRY_BACKOFFS.len() as u32 + 1);
+        assert_eq!(slept, READ_RETRY_BACKOFFS.to_vec());
+    }
+
+    #[test]
+    fn watchdog_times_out_only_after_budget_while_loading() {
+        let start = Instant::now();
+        let before = start
+            .checked_add(READ_WATCHDOG_TIMEOUT - Duration::from_millis(1))
+            .unwrap();
+        let after = start
+            .checked_add(READ_WATCHDOG_TIMEOUT + Duration::from_millis(1))
+            .unwrap();
+
+        // Under budget: not timed out.
+        assert!(!watchdog_timed_out(true, Some(start), before));
+        // Over budget while loading: timed out.
+        assert!(watchdog_timed_out(true, Some(start), after));
+        // A result arrived (loading == false): never a timeout.
+        assert!(!watchdog_timed_out(false, Some(start), after));
+        // No read in flight: never a timeout.
+        assert!(!watchdog_timed_out(true, None, after));
     }
 }

--- a/src-tauri/src/audio/player.rs
+++ b/src-tauri/src/audio/player.rs
@@ -1,15 +1,20 @@
 use anyhow::{Context, Result};
 use rodio::{Decoder, OutputStream, OutputStreamBuilder, Sink, Source};
-use std::fs::File;
-use std::io::BufReader;
-use std::path::PathBuf;
+use std::io::Cursor;
+use std::path::{Path, PathBuf};
 use std::sync::mpsc::{channel, Sender};
+use std::sync::Arc;
 use std::thread;
 use std::time::{Duration, Instant};
 use tauri::{AppHandle, Emitter};
 
 const TICK_INTERVAL: Duration = Duration::from_millis(50);
 const TIME_EMIT_INTERVAL: Duration = Duration::from_millis(100);
+
+/// Whole track file resident in RAM. Shared (cheaply cloned) between the
+/// playing `Decoder` and the retained copy used for seeking, so playback and
+/// seek never touch the (possibly networked) filesystem again after load.
+type Bytes = Arc<[u8]>;
 
 pub enum Cmd {
     Load {
@@ -23,12 +28,22 @@ pub enum Cmd {
     SetVolume(f32),
 }
 
+/// Result of a background file read, routed back to the worker thread.
+/// `generation` lets the worker discard reads that a newer `Load`/`Stop` has
+/// superseded (e.g. the user skipped again before a slow read finished).
+struct LoadMsg {
+    generation: u64,
+    duration: Option<f64>,
+    bytes: Result<Bytes>,
+}
+
 struct Topics {
     time: String,
     duration: String,
     pause_state: String,
     ended: String,
     error: String,
+    buffering: String,
 }
 
 impl Topics {
@@ -39,6 +54,7 @@ impl Topics {
             pause_state: format!("{prefix}:pause-state"),
             ended: format!("{prefix}:ended"),
             error: format!("{prefix}:error"),
+            buffering: format!("{prefix}:buffering"),
         }
     }
 }
@@ -68,13 +84,20 @@ impl PlayerHandle {
 struct State {
     current_path: Option<PathBuf>,
     current_duration: Option<f64>,
+    /// Bytes of the currently loaded track, kept so seeks re-decode from RAM.
+    current_bytes: Option<Bytes>,
     seek_offset: f64,
     active: bool,
+    /// A background read is in flight; suppresses ended-detection and time
+    /// emits until the source is ready.
+    loading: bool,
+    /// Monotonic token identifying the most recent load intent. Bumped on every
+    /// `Load` and `Stop`; background reads carry the token they were issued for.
+    generation: u64,
     volume: f32,
 }
 
 const AUDIO_BUFFER_FRAMES: u32 = 4096;
-const DECODE_BUFREADER_CAPACITY: usize = 64 * 1024;
 
 fn open_stream(device: Option<cpal::Device>) -> Result<OutputStream> {
     let builder = match device {
@@ -95,24 +118,34 @@ fn run(
 ) -> Result<()> {
     let stream = open_stream(device)?;
     let mut sink = Sink::connect_new(stream.mixer());
+    // Completed background reads arrive here; `load_tx` is cloned per read.
+    let (load_tx, load_rx) = channel::<LoadMsg>();
     let mut last_time_emit = Instant::now()
         .checked_sub(TIME_EMIT_INTERVAL)
         .unwrap_or_else(Instant::now);
     let mut state = State {
         current_path: None,
         current_duration: None,
+        current_bytes: None,
         seek_offset: 0.0,
         active: false,
+        loading: false,
+        generation: 0,
         volume: 1.0,
     };
 
     loop {
         loop {
             match rx.try_recv() {
-                Ok(cmd) => apply(&app, &stream, &mut sink, &mut state, topics, cmd),
+                Ok(cmd) => apply(&app, &stream, &mut sink, &mut state, topics, &load_tx, cmd),
                 Err(std::sync::mpsc::TryRecvError::Empty) => break,
                 Err(std::sync::mpsc::TryRecvError::Disconnected) => return Ok(()),
             }
+        }
+
+        // Drain any completed background reads.
+        while let Ok(msg) = load_rx.try_recv() {
+            apply_load(&app, &stream, &mut sink, &mut state, topics, msg);
         }
 
         if state.active && last_time_emit.elapsed() >= TIME_EMIT_INTERVAL {
@@ -121,7 +154,7 @@ fn run(
             let _ = app.emit(&topics.time, pos);
         }
 
-        if state.active && sink.empty() {
+        if state.active && !state.loading && sink.empty() {
             state.active = false;
             let _ = app.emit(&topics.pause_state, true);
             let _ = app.emit(&topics.ended, ());
@@ -137,41 +170,45 @@ fn apply(
     sink: &mut Sink,
     state: &mut State,
     topics: &Topics,
+    load_tx: &Sender<LoadMsg>,
     cmd: Cmd,
 ) {
     match cmd {
         Cmd::Load { path, duration } => {
+            // Stop current audio immediately; the new source arrives once the
+            // background read completes.
             sink.stop();
             *sink = Sink::connect_new(stream.mixer());
             sink.set_volume(state.volume);
-            match decode(&path) {
-                Ok((source, decoded_duration)) => {
-                    let final_duration = duration.or(decoded_duration);
-                    sink.append(source);
-                    sink.play();
-                    state.active = true;
-                    state.current_path = Some(path);
-                    state.current_duration = final_duration;
-                    state.seek_offset = 0.0;
-                    if let Some(d) = final_duration {
-                        let _ = app.emit(&topics.duration, d);
-                    }
-                    let _ = app.emit(&topics.pause_state, false);
-                }
-                Err(e) => {
-                    log::error!("player: decode {} failed: {}", path.display(), e);
-                    let _ = app.emit(&topics.error, format!("decode failed: {}", e));
-                    state.active = false;
-                    state.current_path = None;
-                    state.current_duration = None;
-                    state.seek_offset = 0.0;
-                    let _ = app.emit(&topics.pause_state, true);
-                }
-            }
+
+            state.generation = state.generation.wrapping_add(1);
+            state.current_path = Some(path.clone());
+            state.current_duration = duration;
+            state.current_bytes = None;
+            state.seek_offset = 0.0;
+            state.active = false;
+            state.loading = true;
+            let _ = app.emit(&topics.buffering, true);
+
+            // Read the whole file off the worker thread so a slow/networked
+            // read never blocks transport commands.
+            let generation = state.generation;
+            let tx = load_tx.clone();
+            thread::spawn(move || {
+                let bytes = read_file(&path);
+                let _ = tx.send(LoadMsg {
+                    generation,
+                    duration,
+                    bytes,
+                });
+            });
         }
         Cmd::Play => {
             sink.play();
-            let _ = app.emit(&topics.pause_state, false);
+            // Only report playing if there is (or will be) something to play.
+            if state.active || state.loading {
+                let _ = app.emit(&topics.pause_state, false);
+            }
         }
         Cmd::Pause => {
             sink.pause();
@@ -181,26 +218,35 @@ fn apply(
             sink.stop();
             *sink = Sink::connect_new(stream.mixer());
             sink.set_volume(state.volume);
+            // Invalidate any in-flight read.
+            state.generation = state.generation.wrapping_add(1);
             state.active = false;
+            state.loading = false;
             state.current_path = None;
             state.current_duration = None;
+            state.current_bytes = None;
             state.seek_offset = 0.0;
+            let _ = app.emit(&topics.buffering, false);
             let _ = app.emit(&topics.pause_state, true);
         }
         Cmd::Seek(s) => {
             let target = s.max(0.0);
-            let Some(path) = state.current_path.clone() else {
+            // Seek decodes from the in-RAM bytes — never re-reads the file.
+            let Some(bytes) = state.current_bytes.clone() else {
                 return;
             };
             let was_paused = sink.is_paused();
             sink.stop();
             *sink = Sink::connect_new(stream.mixer());
             sink.set_volume(state.volume);
-            match decode(&path) {
+            match decode_bytes(bytes) {
                 Ok((mut source, _)) => {
                     let target_dur = Duration::from_secs_f64(target);
-                    let actual_offset = match source.try_seek(target_dur) {
-                        Ok(()) => target,
+                    match source.try_seek(target_dur) {
+                        Ok(()) => {
+                            sink.append(source);
+                            state.seek_offset = target;
+                        }
                         Err(e) => {
                             log::warn!(
                                 "player: container seek failed ({}); skip_duration fallback",
@@ -209,17 +255,8 @@ fn apply(
                             let skipped = source.skip_duration(target_dur);
                             sink.append(skipped);
                             state.seek_offset = target;
-                            state.active = true;
-                            if was_paused {
-                                sink.pause();
-                            } else {
-                                sink.play();
-                            }
-                            return;
                         }
-                    };
-                    sink.append(source);
-                    state.seek_offset = actual_offset;
+                    }
                     state.active = true;
                     if was_paused {
                         sink.pause();
@@ -228,7 +265,7 @@ fn apply(
                     }
                 }
                 Err(e) => {
-                    log::error!("player: reload-on-seek failed: {}", e);
+                    log::error!("player: seek decode failed: {}", e);
                     let _ = app.emit(&topics.error, format!("seek failed: {}", e));
                     state.active = false;
                 }
@@ -242,10 +279,151 @@ fn apply(
     }
 }
 
-fn decode(path: &PathBuf) -> Result<(Decoder<BufReader<File>>, Option<f64>)> {
-    let file = File::open(path).with_context(|| format!("open {}", path.display()))?;
-    let decoder = Decoder::new(BufReader::with_capacity(DECODE_BUFREADER_CAPACITY, file))
-        .context("decoder")?;
+/// Handle a completed background read. Stale results (superseded by a newer
+/// `Load`/`Stop`) are dropped.
+fn apply_load(
+    app: &AppHandle,
+    _stream: &OutputStream,
+    sink: &mut Sink,
+    state: &mut State,
+    topics: &Topics,
+    msg: LoadMsg,
+) {
+    if msg.generation != state.generation {
+        return; // superseded
+    }
+    state.loading = false;
+    let _ = app.emit(&topics.buffering, false);
+
+    let bytes = match msg.bytes {
+        Ok(b) => b,
+        Err(e) => {
+            let path = state
+                .current_path
+                .as_ref()
+                .map(|p| p.display().to_string())
+                .unwrap_or_default();
+            log::error!("player: read {} failed: {}", path, e);
+            let _ = app.emit(&topics.error, format!("read failed: {}", e));
+            reset_after_failure(state);
+            let _ = app.emit(&topics.pause_state, true);
+            return;
+        }
+    };
+
+    match decode_bytes(bytes.clone()) {
+        Ok((source, decoded_duration)) => {
+            let final_duration = msg.duration.or(decoded_duration);
+            sink.append(source);
+            sink.play();
+            state.current_bytes = Some(bytes);
+            state.current_duration = final_duration;
+            state.seek_offset = 0.0;
+            state.active = true;
+            if let Some(d) = final_duration {
+                let _ = app.emit(&topics.duration, d);
+            }
+            let _ = app.emit(&topics.pause_state, false);
+        }
+        Err(e) => {
+            log::error!("player: decode failed: {}", e);
+            let _ = app.emit(&topics.error, format!("decode failed: {}", e));
+            reset_after_failure(state);
+            let _ = app.emit(&topics.pause_state, true);
+        }
+    }
+}
+
+fn reset_after_failure(state: &mut State) {
+    state.active = false;
+    state.loading = false;
+    state.current_path = None;
+    state.current_duration = None;
+    state.current_bytes = None;
+    state.seek_offset = 0.0;
+}
+
+fn read_file(path: &Path) -> Result<Bytes> {
+    let vec = std::fs::read(path).with_context(|| format!("read {}", path.display()))?;
+    Ok(Arc::from(vec.into_boxed_slice()))
+}
+
+fn decode_bytes(bytes: Bytes) -> Result<(Decoder<Cursor<Bytes>>, Option<f64>)> {
+    let decoder = Decoder::new(Cursor::new(bytes)).context("decoder")?;
     let total = decoder.total_duration().map(|d| d.as_secs_f64());
     Ok((decoder, total))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a minimal valid 16-bit mono PCM WAV in memory so decode tests are
+    /// hermetic (no fixture files, no audio device).
+    fn synth_wav(sample_rate: u32, samples: u32) -> Vec<u8> {
+        let bits_per_sample = 16u16;
+        let channels = 1u16;
+        let byte_rate = sample_rate * channels as u32 * (bits_per_sample as u32 / 8);
+        let block_align = channels * (bits_per_sample / 8);
+        let data_len = samples * (bits_per_sample as u32 / 8);
+        let mut w = Vec::new();
+        w.extend_from_slice(b"RIFF");
+        w.extend_from_slice(&(36 + data_len).to_le_bytes());
+        w.extend_from_slice(b"WAVE");
+        w.extend_from_slice(b"fmt ");
+        w.extend_from_slice(&16u32.to_le_bytes());
+        w.extend_from_slice(&1u16.to_le_bytes()); // PCM
+        w.extend_from_slice(&channels.to_le_bytes());
+        w.extend_from_slice(&sample_rate.to_le_bytes());
+        w.extend_from_slice(&byte_rate.to_le_bytes());
+        w.extend_from_slice(&block_align.to_le_bytes());
+        w.extend_from_slice(&bits_per_sample.to_le_bytes());
+        w.extend_from_slice(b"data");
+        w.extend_from_slice(&data_len.to_le_bytes());
+        for i in 0..samples {
+            let v = ((i % 32) as i16) * 100;
+            w.extend_from_slice(&v.to_le_bytes());
+        }
+        w
+    }
+
+    #[test]
+    fn decode_bytes_reports_duration() {
+        let sample_rate = 8000;
+        let samples = 8000; // exactly 1 second
+        let bytes: Bytes = Arc::from(synth_wav(sample_rate, samples).into_boxed_slice());
+        let (_source, duration) = decode_bytes(bytes).expect("decode");
+        let d = duration.expect("duration present");
+        assert!((d - 1.0).abs() < 0.05, "expected ~1.0s, got {d}");
+    }
+
+    #[test]
+    fn decode_bytes_rejects_garbage() {
+        let bytes: Bytes = Arc::from(vec![0u8, 1, 2, 3, 4, 5].into_boxed_slice());
+        assert!(decode_bytes(bytes).is_err());
+    }
+
+    #[test]
+    fn read_file_missing_path_errors() {
+        assert!(read_file(Path::new("/nonexistent/diodedj/nope.wav")).is_err());
+    }
+
+    /// The worker only applies a background read if its generation still matches
+    /// the latest intent. This mirrors the guard in `apply_load`.
+    #[test]
+    fn stale_generation_is_discarded() {
+        let latest = 5u64;
+        let stale = LoadMsg {
+            generation: 4,
+            duration: None,
+            bytes: Ok(Arc::from(Vec::new().into_boxed_slice())),
+        };
+        let fresh = LoadMsg {
+            generation: 5,
+            duration: None,
+            bytes: Ok(Arc::from(Vec::new().into_boxed_slice())),
+        };
+        assert_ne!(stale.generation, latest);
+        assert_eq!(fresh.generation, latest);
+    }
 }

--- a/src-tauri/src/audio/player.rs
+++ b/src-tauri/src/audio/player.rs
@@ -8,6 +8,8 @@ use std::thread;
 use std::time::{Duration, Instant};
 use tauri::{AppHandle, Emitter};
 
+use super::cache::Cache;
+
 const TICK_INTERVAL: Duration = Duration::from_millis(50);
 const TIME_EMIT_INTERVAL: Duration = Duration::from_millis(100);
 
@@ -18,6 +20,9 @@ type Bytes = Arc<[u8]>;
 
 pub enum Cmd {
     Load {
+        /// Track id, used to consult the shared prefetch cache before falling
+        /// back to a filesystem read.
+        id: i64,
         path: PathBuf,
         duration: Option<f64>,
     },
@@ -64,11 +69,16 @@ pub struct PlayerHandle {
 }
 
 impl PlayerHandle {
-    pub fn spawn(app: AppHandle, device: Option<cpal::Device>, event_prefix: &'static str) -> Self {
+    pub fn spawn(
+        app: AppHandle,
+        device: Option<cpal::Device>,
+        event_prefix: &'static str,
+        cache: Arc<Cache>,
+    ) -> Self {
         let (tx, rx) = channel();
         let topics = Topics::new(event_prefix);
         thread::spawn(move || {
-            if let Err(e) = run(app.clone(), rx, device, &topics) {
+            if let Err(e) = run(app.clone(), rx, device, &topics, cache) {
                 log::error!("[{}] player thread exited: {}", event_prefix, e);
                 let _ = app.emit(&topics.error, e.to_string());
             }
@@ -115,6 +125,7 @@ fn run(
     rx: std::sync::mpsc::Receiver<Cmd>,
     device: Option<cpal::Device>,
     topics: &Topics,
+    cache: Arc<Cache>,
 ) -> Result<()> {
     let stream = open_stream(device)?;
     let mut sink = Sink::connect_new(stream.mixer());
@@ -137,7 +148,9 @@ fn run(
     loop {
         loop {
             match rx.try_recv() {
-                Ok(cmd) => apply(&app, &stream, &mut sink, &mut state, topics, &load_tx, cmd),
+                Ok(cmd) => apply(
+                    &app, &stream, &mut sink, &mut state, topics, &load_tx, &cache, cmd,
+                ),
                 Err(std::sync::mpsc::TryRecvError::Empty) => break,
                 Err(std::sync::mpsc::TryRecvError::Disconnected) => return Ok(()),
             }
@@ -164,6 +177,7 @@ fn run(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn apply(
     app: &AppHandle,
     stream: &OutputStream,
@@ -171,10 +185,11 @@ fn apply(
     state: &mut State,
     topics: &Topics,
     load_tx: &Sender<LoadMsg>,
+    cache: &Arc<Cache>,
     cmd: Cmd,
 ) {
     match cmd {
-        Cmd::Load { path, duration } => {
+        Cmd::Load { id, path, duration } => {
             // Stop current audio immediately; the new source arrives once the
             // background read completes.
             sink.stop();
@@ -190,18 +205,28 @@ fn apply(
             state.loading = true;
             let _ = app.emit(&topics.buffering, true);
 
-            // Read the whole file off the worker thread so a slow/networked
-            // read never blocks transport commands.
             let generation = state.generation;
             let tx = load_tx.clone();
-            thread::spawn(move || {
-                let bytes = read_file(&path);
+            if let Some(bytes) = cache.get(id) {
+                // Cache hit: route the resident bytes through the same
+                // completion path as a background read — no filesystem access.
                 let _ = tx.send(LoadMsg {
                     generation,
                     duration,
-                    bytes,
+                    bytes: Ok(bytes),
                 });
-            });
+            } else {
+                // Miss: read the whole file off the worker thread so a
+                // slow/networked read never blocks transport commands.
+                thread::spawn(move || {
+                    let bytes = read_file(&path);
+                    let _ = tx.send(LoadMsg {
+                        generation,
+                        duration,
+                        bytes,
+                    });
+                });
+            }
         }
         Cmd::Play => {
             sink.play();

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -10,6 +10,7 @@ mod library;
 mod persist;
 mod playlist;
 
+use audio::cache::Cache;
 use audio::devices::{list_output_devices, resolve_device, resolve_main_device, DeviceInfo};
 use audio::player::{Cmd, PlayerHandle};
 use broadcast::{service::default_now_playing_dir, BroadcastService};
@@ -25,6 +26,8 @@ pub struct AppState {
     scan: Arc<ScanState>,
     main_deck: Arc<PlayerHandle>,
     cue: Arc<Mutex<Option<PlayerHandle>>>,
+    /// Shared prefetch byte cache, resident in both deck players.
+    cache: Arc<Cache>,
     broadcast: Arc<BroadcastService>,
     app_handle: AppHandle,
 }
@@ -155,9 +158,26 @@ fn main_deck_load(app_state: State<'_, AppState>, id: i64) -> Result<(), String>
     let duration = track.duration;
     app_state.broadcast.set_pending_track(track.into());
     app_state.main_deck.send(Cmd::Load {
+        id,
         path: std::path::PathBuf::from(path),
         duration: if duration > 0.0 { Some(duration) } else { None },
     });
+    Ok(())
+}
+
+/// Update the prefetch residency window from the renderer's upcoming-track list.
+/// Resolves each id's path from the DB and hands the window to the shared cache,
+/// which evicts out-of-window entries and prefetches missing ones.
+#[tauri::command(rename_all = "camelCase")]
+fn main_deck_prefetch(app_state: State<'_, AppState>, ids: Vec<i64>) -> Result<(), String> {
+    let window: Vec<(i64, std::path::PathBuf)> = app_state
+        .db
+        .get_paths_by_ids(&ids)
+        .map_err(err)?
+        .into_iter()
+        .map(|(id, path)| (id, std::path::PathBuf::from(path)))
+        .collect();
+    app_state.cache.set_window(window);
     Ok(())
 }
 
@@ -240,6 +260,7 @@ where
             state.app_handle.clone(),
             Some(device),
             "cue",
+            Arc::clone(&state.cache),
         ));
     }
     if let Some(handle) = guard.as_ref() {
@@ -257,6 +278,7 @@ fn cue_load(state: State<'_, AppState>, id: i64) -> Result<(), String> {
         .ok_or_else(|| "track not found".to_string())?;
     with_cue(&state, |h| {
         h.send(Cmd::Load {
+            id,
             path: std::path::PathBuf::from(track.path),
             duration: if track.duration > 0.0 {
                 Some(track.duration)
@@ -380,7 +402,13 @@ pub fn run() {
             let config = Config::open(&data_dir)?;
             let session = Session::open(&data_dir);
             let main_device = resolve_main_device(config.get_main_device().as_ref());
-            let main_deck = PlayerHandle::spawn(app.handle().clone(), main_device, "main-deck");
+            let cache = Cache::new(app.handle().clone());
+            let main_deck = PlayerHandle::spawn(
+                app.handle().clone(),
+                main_device,
+                "main-deck",
+                Arc::clone(&cache),
+            );
             let config = Arc::new(config);
             let broadcast = Arc::new(BroadcastService::new(
                 Arc::clone(&config),
@@ -394,6 +422,7 @@ pub fn run() {
                 scan: Arc::new(ScanState::default()),
                 main_deck: Arc::new(main_deck),
                 cue: Arc::new(Mutex::new(None)),
+                cache,
                 broadcast,
                 app_handle: app.handle().clone(),
             });
@@ -428,6 +457,7 @@ pub fn run() {
             cue_seek,
             cue_set_volume,
             main_deck_load,
+            main_deck_prefetch,
             main_deck_play,
             main_deck_pause,
             main_deck_stop,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -155,6 +155,7 @@ fn main_deck_load(app_state: State<'_, AppState>, id: i64) -> Result<(), String>
     let duration = track.duration;
     app_state.broadcast.set_pending_track(track.into());
     app_state.main_deck.send(Cmd::Load {
+        id,
         path: std::path::PathBuf::from(path),
         duration: if duration > 0.0 { Some(duration) } else { None },
     });
@@ -257,6 +258,7 @@ fn cue_load(state: State<'_, AppState>, id: i64) -> Result<(), String> {
         .ok_or_else(|| "track not found".to_string())?;
     with_cue(&state, |h| {
         h.send(Cmd::Load {
+            id,
             path: std::path::PathBuf::from(track.path),
             duration: if track.duration > 0.0 {
                 Some(track.duration)

--- a/src-tauri/src/library/db.rs
+++ b/src-tauri/src/library/db.rs
@@ -252,6 +252,33 @@ impl Db {
         Ok(ids.iter().filter_map(|i| by_id.get(i).cloned()).collect())
     }
 
+    /// Resolve `(id, path)` for the given ids, preserving the input order and
+    /// skipping ids with no matching row. Used by the prefetch cache to build
+    /// its residency window without loading full track rows.
+    pub fn get_paths_by_ids(&self, ids: &[i64]) -> Result<Vec<(i64, String)>> {
+        if ids.is_empty() {
+            return Ok(vec![]);
+        }
+        let conn = self.conn.lock();
+        let placeholders = std::iter::repeat("?")
+            .take(ids.len())
+            .collect::<Vec<_>>()
+            .join(",");
+        let sql = format!("SELECT id, path FROM tracks WHERE id IN ({})", placeholders);
+        let mut stmt = conn.prepare(&sql)?;
+        let rows = stmt.query_map(params_from_iter(ids.iter()), |r| {
+            Ok((r.get::<_, i64>(0)?, r.get::<_, String>(1)?))
+        })?;
+        let by_id: HashMap<i64, String> = rows
+            .collect::<rusqlite::Result<Vec<_>>>()?
+            .into_iter()
+            .collect();
+        Ok(ids
+            .iter()
+            .filter_map(|i| by_id.get(i).map(|p| (*i, p.clone())))
+            .collect())
+    }
+
     pub fn insert_track(&self, t: &TrackInsert) -> Result<()> {
         let conn = self.conn.lock();
         conn.execute(

--- a/src/features/deck/NowPlaying.svelte
+++ b/src/features/deck/NowPlaying.svelte
@@ -37,6 +37,9 @@
         >{app.currentTrack ? app.currentTrack.title : "No track loaded"}</span
       >
       <span id="np-artist">{app.currentTrack?.artist ?? ""}</span>
+      {#if app.isBuffering}
+        <span id="np-buffering" aria-live="polite">Buffering…</span>
+      {/if}
     </div>
     <div id="player-controls">
       <button

--- a/src/features/deck/NowPlaying.svelte
+++ b/src/features/deck/NowPlaying.svelte
@@ -37,7 +37,9 @@
         >{app.currentTrack ? app.currentTrack.title : "No track loaded"}</span
       >
       <span id="np-artist">{app.currentTrack?.artist ?? ""}</span>
-      {#if app.isBuffering}
+      {#if app.awaitingNetwork}
+        <span id="np-reconnecting" aria-live="polite">Reconnecting…</span>
+      {:else if app.isBuffering}
         <span id="np-buffering" aria-live="polite">Buffering…</span>
       {/if}
     </div>

--- a/src/features/deck/backend.ts
+++ b/src/features/deck/backend.ts
@@ -3,6 +3,7 @@ export type DeckEvent =
   | { type: "duration"; seconds: number }
   | { type: "pause-state"; paused: boolean }
   | { type: "ended" }
+  | { type: "buffering"; buffering: boolean }
   | { type: "error"; message: string };
 
 export type DeckEventHandler = (event: DeckEvent) => void;

--- a/src/features/deck/backend.ts
+++ b/src/features/deck/backend.ts
@@ -4,7 +4,8 @@ export type DeckEvent =
   | { type: "pause-state"; paused: boolean }
   | { type: "ended" }
   | { type: "buffering"; buffering: boolean }
-  | { type: "error"; message: string };
+  | { type: "error"; message: string }
+  | { type: "load-failed"; id: number };
 
 export type DeckEventHandler = (event: DeckEvent) => void;
 

--- a/src/features/deck/backend.ts
+++ b/src/features/deck/backend.ts
@@ -4,6 +4,7 @@ export type DeckEvent =
   | { type: "pause-state"; paused: boolean }
   | { type: "ended" }
   | { type: "buffering"; buffering: boolean }
+  | { type: "cache-state"; ids: number[] }
   | { type: "error"; message: string };
 
 export type DeckEventHandler = (event: DeckEvent) => void;

--- a/src/features/deck/nativeBackend.test.ts
+++ b/src/features/deck/nativeBackend.test.ts
@@ -40,6 +40,7 @@ describe("NativeBackend (deckId='main' default)", () => {
         "main-deck:pause-state",
         "main-deck:ended",
         "main-deck:error",
+        "main-deck:load-failed",
       ]),
     );
   });
@@ -93,6 +94,15 @@ describe("NativeBackend (deckId='main' default)", () => {
       { type: "buffering", buffering: false },
     ]);
   });
+
+  it("forwards main-deck:load-failed events with the track id", async () => {
+    const b = new NativeBackend();
+    const events: DeckEvent[] = [];
+    b.on((e) => events.push(e));
+    await b.load(1); // ensure ready
+    listeners["main-deck:load-failed"]({ payload: 99 });
+    expect(events).toEqual([{ type: "load-failed", id: 99 }]);
+  });
 });
 
 describe("NativeBackend (deckId='cue')", () => {
@@ -107,6 +117,7 @@ describe("NativeBackend (deckId='cue')", () => {
         "cue:pause-state",
         "cue:ended",
         "cue:error",
+        "cue:load-failed",
       ]),
     );
   });

--- a/src/features/deck/nativeBackend.test.ts
+++ b/src/features/deck/nativeBackend.test.ts
@@ -80,6 +80,19 @@ describe("NativeBackend (deckId='main' default)", () => {
       { type: "error", message: "boom" },
     ]);
   });
+
+  it("forwards main-deck:buffering events to handlers", async () => {
+    const b = new NativeBackend();
+    const events: DeckEvent[] = [];
+    b.on((e) => events.push(e));
+    await b.load(1); // ensure ready
+    listeners["main-deck:buffering"]({ payload: true });
+    listeners["main-deck:buffering"]({ payload: false });
+    expect(events).toEqual([
+      { type: "buffering", buffering: true },
+      { type: "buffering", buffering: false },
+    ]);
+  });
 });
 
 describe("NativeBackend (deckId='cue')", () => {

--- a/src/features/deck/nativeBackend.test.ts
+++ b/src/features/deck/nativeBackend.test.ts
@@ -93,6 +93,15 @@ describe("NativeBackend (deckId='main' default)", () => {
       { type: "buffering", buffering: false },
     ]);
   });
+
+  it("forwards main-deck:cache-state events to handlers", async () => {
+    const b = new NativeBackend();
+    const events: DeckEvent[] = [];
+    b.on((e) => events.push(e));
+    await b.load(1); // ensure ready
+    listeners["main-deck:cache-state"]({ payload: [1, 2, 3] });
+    expect(events).toEqual([{ type: "cache-state", ids: [1, 2, 3] }]);
+  });
 });
 
 describe("NativeBackend (deckId='cue')", () => {

--- a/src/features/deck/nativeBackend.ts
+++ b/src/features/deck/nativeBackend.ts
@@ -45,6 +45,9 @@ export class NativeBackend implements DeckBackend {
         this.emit({ type: "pause-state", paused: e.payload }),
       ),
       listen<null>(`${p}:ended`, () => this.emit({ type: "ended" })),
+      listen<boolean>(`${p}:buffering`, (e) =>
+        this.emit({ type: "buffering", buffering: e.payload }),
+      ),
       listen<string>(`${p}:error`, (e) =>
         this.emit({ type: "error", message: e.payload }),
       ),

--- a/src/features/deck/nativeBackend.ts
+++ b/src/features/deck/nativeBackend.ts
@@ -48,6 +48,9 @@ export class NativeBackend implements DeckBackend {
       listen<boolean>(`${p}:buffering`, (e) =>
         this.emit({ type: "buffering", buffering: e.payload }),
       ),
+      listen<number[]>(`${p}:cache-state`, (e) =>
+        this.emit({ type: "cache-state", ids: e.payload }),
+      ),
       listen<string>(`${p}:error`, (e) =>
         this.emit({ type: "error", message: e.payload }),
       ),

--- a/src/features/deck/nativeBackend.ts
+++ b/src/features/deck/nativeBackend.ts
@@ -51,6 +51,9 @@ export class NativeBackend implements DeckBackend {
       listen<string>(`${p}:error`, (e) =>
         this.emit({ type: "error", message: e.payload }),
       ),
+      listen<number>(`${p}:load-failed`, (e) =>
+        this.emit({ type: "load-failed", id: e.payload }),
+      ),
     ]);
     this.unlisteners.push(...subs);
   }

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -68,6 +68,9 @@ export const api = {
   trackPlayed(id: number): Promise<void> {
     return invoke<void>("track_played", { id });
   },
+  prefetch(ids: number[]): Promise<void> {
+    return invoke<void>("main_deck_prefetch", { ids });
+  },
   generatePlaylist(count: number): Promise<Track[]> {
     return invoke<Track[]>("generate_playlist", { count });
   },

--- a/src/shared/mockBackend.ts
+++ b/src/shared/mockBackend.ts
@@ -80,6 +80,10 @@ export class MockBackend implements DeckBackend {
     this.emit({ type: "error", message });
   }
 
+  emitCacheState(ids: number[]): void {
+    this.emit({ type: "cache-state", ids });
+  }
+
   get lastLoadedId(): number | undefined {
     return this.loadedIds[this.loadedIds.length - 1];
   }

--- a/src/shared/mockBackend.ts
+++ b/src/shared/mockBackend.ts
@@ -84,6 +84,10 @@ export class MockBackend implements DeckBackend {
     this.emit({ type: "cache-state", ids });
   }
 
+  emitLoadFailed(id: number): void {
+    this.emit({ type: "load-failed", id });
+  }
+
   get lastLoadedId(): number | undefined {
     return this.loadedIds[this.loadedIds.length - 1];
   }

--- a/src/shared/state.svelte.ts
+++ b/src/shared/state.svelte.ts
@@ -34,6 +34,9 @@ const SESSION_SAVE_THROTTLE_MS = 500;
 // Number of upcoming playlist tracks to prefetch ahead of the current track.
 // Mirrors the backend cache keep-window (audio/cache.rs WINDOW_SIZE).
 const PREFETCH_WINDOW = 15;
+// Backoff schedule (ms) for retrying advancement while nothing playable is
+// cached (network outage). The last value repeats until recovery.
+const NET_RETRY_BACKOFFS_MS = [1000, 2000, 5000];
 
 export type PlaylistTab = "playlist" | "history";
 
@@ -63,9 +66,13 @@ export class AppState {
   volume = $state(1);
   currentTime = $state(0);
   duration = $state(0);
-  // Track ids currently resident in the backend prefetch cache. Exposed for
-  // future skip/availability logic; membership is driven by cache-state events.
+  // Track ids currently resident in the backend prefetch cache. Drives
+  // skip-to-cached advancement during a network outage; membership is updated
+  // by cache-state events.
   cachedIds = $state<Set<number>>(new Set());
+  // True while no upcoming track is cached and we are waiting for the share to
+  // recover (drives the "Reconnecting…" banner). Cleared on resume.
+  awaitingNetwork = $state(false);
 
   // Cue deck (independent transport on a separate audio device)
   cueTrack = $state<Track | null>(null);
@@ -90,6 +97,8 @@ export class AppState {
 
   private throttledSave: Throttled;
   private sessionLoaded = false;
+  private netRetryTimer: ReturnType<typeof setTimeout> | null = null;
+  private netRetryAttempt = 0;
 
   constructor(backend?: DeckBackend, cueBackend?: DeckBackend) {
     this.backend = backend ?? new NativeBackend("main");
@@ -119,16 +128,20 @@ export class AppState {
           break;
         case "cache-state":
           this.cachedIds = new Set(event.ids);
+          // Cache membership changed — if we were stalled waiting for the
+          // share, a newly-cached track may now be playable.
+          if (this.awaitingNetwork) this.advancePlan(true);
           break;
         case "error":
           this.isBuffering = false;
           logger.error("Audio error:", event.message);
           break;
         case "load-failed":
-          // Read failed after retries or watchdog timeout. Clear buffering;
-          // skip-to-cached handling is a later issue.
+          // Read failed after retries or watchdog timeout. Skip to the next
+          // cached track (or wait for the share) instead of dead air.
           this.isBuffering = false;
           logger.error("Audio load failed for track:", event.id);
+          if (this.autoAdvance) this.advancePlan(true);
           break;
       }
     });
@@ -351,6 +364,7 @@ export class AppState {
   }
 
   stop(): void {
+    this.clearNetRetry();
     if (this.currentTrack) this.appendHistory(this.currentTrack);
     void this.backend.stop();
     this.currentTrack = null;
@@ -692,7 +706,82 @@ export class AppState {
     }
 
     await this.maybeRefillPlaylist();
-    if (this.playlist.length > 0) this.playIndex(0);
+    this.advancePlan(false);
+  }
+
+  /**
+   * Decide what to play next given the current cache membership.
+   *
+   * - `empty`: nothing queued.
+   * - `fallback`: no cache knowledge yet (cold start / tests) — use the legacy
+   *   "play the head" behavior.
+   * - `stop`: a stop marker is the next barrier; honor it.
+   * - `play`: the first upcoming cached track (skipping uncached tracks ahead
+   *   of it, which stay queued for when the share recovers).
+   * - `wait`: cache is known but nothing upcoming is cached — an outage.
+   */
+  private planAdvance():
+    | { kind: "empty" | "fallback" | "wait" }
+    | { kind: "stop" | "play"; index: number } {
+    if (this.playlist.length === 0) return { kind: "empty" };
+    if (this.cachedIds.size === 0) return { kind: "fallback" };
+    for (let i = 0; i < this.playlist.length; i++) {
+      const item = this.playlist[i];
+      if (isStopMarker(item)) return { kind: "stop", index: i };
+      if (this.cachedIds.has(item.track.id)) return { kind: "play", index: i };
+    }
+    return { kind: "wait" };
+  }
+
+  /**
+   * Advance to the next playable track, skipping uncached ones during an
+   * outage. `afterFailure` is set when a load just failed or timed out: in that
+   * case an empty cache means "wait for the share" rather than blindly retrying
+   * the head (which would burn through the queue on a cold offline start).
+   */
+  private advancePlan(afterFailure: boolean): void {
+    const plan = this.planAdvance();
+    switch (plan.kind) {
+      case "empty":
+        this.clearNetRetry();
+        return;
+      case "fallback":
+        if (afterFailure) {
+          this.scheduleNetRetry();
+          return;
+        }
+        this.clearNetRetry();
+        this.playIndex(0);
+        return;
+      case "stop":
+      case "play":
+        this.clearNetRetry();
+        this.playIndex(plan.index);
+        return;
+      case "wait":
+        this.scheduleNetRetry();
+        return;
+    }
+  }
+
+  private scheduleNetRetry(): void {
+    this.awaitingNetwork = true;
+    if (this.netRetryTimer !== null) return;
+    const i = Math.min(this.netRetryAttempt, NET_RETRY_BACKOFFS_MS.length - 1);
+    this.netRetryAttempt += 1;
+    this.netRetryTimer = setTimeout(() => {
+      this.netRetryTimer = null;
+      this.advancePlan(true);
+    }, NET_RETRY_BACKOFFS_MS[i]);
+  }
+
+  private clearNetRetry(): void {
+    if (this.netRetryTimer !== null) {
+      clearTimeout(this.netRetryTimer);
+      this.netRetryTimer = null;
+    }
+    this.netRetryAttempt = 0;
+    this.awaitingNetwork = false;
   }
 }
 

--- a/src/shared/state.svelte.ts
+++ b/src/shared/state.svelte.ts
@@ -115,6 +115,12 @@ export class AppState {
           this.isBuffering = false;
           logger.error("Audio error:", event.message);
           break;
+        case "load-failed":
+          // Read failed after retries or watchdog timeout. Clear buffering;
+          // skip-to-cached handling is a later issue.
+          this.isBuffering = false;
+          logger.error("Audio load failed for track:", event.id);
+          break;
       }
     });
 
@@ -140,6 +146,12 @@ export class AppState {
           this.cueIsBuffering = false;
           logger.error("Cue audio error:", event.message);
           this.cueError = event.message;
+          break;
+        case "load-failed":
+          // Read failed after retries or watchdog timeout. Clear buffering;
+          // skip-to-cached handling is a later issue.
+          this.cueIsBuffering = false;
+          logger.error("Cue audio load failed for track:", event.id);
           break;
       }
     });

--- a/src/shared/state.svelte.ts
+++ b/src/shared/state.svelte.ts
@@ -56,6 +56,7 @@ export class AppState {
   autoPlaylistActive = $state(false);
   autoAdvance = $state(true);
   isPlaying = $state(false);
+  isBuffering = $state(false);
   volume = $state(1);
   currentTime = $state(0);
   duration = $state(0);
@@ -63,6 +64,7 @@ export class AppState {
   // Cue deck (independent transport on a separate audio device)
   cueTrack = $state<Track | null>(null);
   cueIsPlaying = $state(false);
+  cueIsBuffering = $state(false);
   cueCurrentTime = $state(0);
   cueDuration = $state(0);
   cueVolume = $state(1);
@@ -106,7 +108,11 @@ export class AppState {
         case "ended":
           void this.handleEnded();
           break;
+        case "buffering":
+          this.isBuffering = event.buffering;
+          break;
         case "error":
+          this.isBuffering = false;
           logger.error("Audio error:", event.message);
           break;
       }
@@ -127,7 +133,11 @@ export class AppState {
           this.cueIsPlaying = false;
           this.cueCurrentTime = 0;
           break;
+        case "buffering":
+          this.cueIsBuffering = event.buffering;
+          break;
         case "error":
+          this.cueIsBuffering = false;
           logger.error("Cue audio error:", event.message);
           this.cueError = event.message;
           break;

--- a/src/shared/state.svelte.ts
+++ b/src/shared/state.svelte.ts
@@ -31,6 +31,9 @@ const AUTO_PLAYLIST_BUFFER = 20;
 const AUTO_PLAYLIST_THRESHOLD = 5;
 const HISTORY_CAP = 100;
 const SESSION_SAVE_THROTTLE_MS = 500;
+// Number of upcoming playlist tracks to prefetch ahead of the current track.
+// Mirrors the backend cache keep-window (audio/cache.rs WINDOW_SIZE).
+const PREFETCH_WINDOW = 15;
 
 export type PlaylistTab = "playlist" | "history";
 
@@ -60,6 +63,9 @@ export class AppState {
   volume = $state(1);
   currentTime = $state(0);
   duration = $state(0);
+  // Track ids currently resident in the backend prefetch cache. Exposed for
+  // future skip/availability logic; membership is driven by cache-state events.
+  cachedIds = $state<Set<number>>(new Set());
 
   // Cue deck (independent transport on a separate audio device)
   cueTrack = $state<Track | null>(null);
@@ -110,6 +116,9 @@ export class AppState {
           break;
         case "buffering":
           this.isBuffering = event.buffering;
+          break;
+        case "cache-state":
+          this.cachedIds = new Set(event.ids);
           break;
         case "error":
           this.isBuffering = false;
@@ -202,11 +211,13 @@ export class AppState {
 
   addToPlaylist(track: Track): void {
     this.playlist.push(trackItem(track));
+    this.updatePrefetch();
     this.scheduleSave();
   }
 
   addStopMarker(): void {
     this.playlist.push(stopMarker());
+    this.updatePrefetch();
     this.scheduleSave();
   }
 
@@ -214,6 +225,7 @@ export class AppState {
     const track = await api.pickFiller(contentType);
     if (!track) return;
     this.playlist.push(trackItem(track));
+    this.updatePrefetch();
     this.scheduleSave();
   }
 
@@ -223,6 +235,7 @@ export class AppState {
 
   removeFromPlaylist(index: number): void {
     this.playlist.splice(index, 1);
+    this.updatePrefetch();
     this.scheduleSave();
   }
 
@@ -230,11 +243,13 @@ export class AppState {
     if (from === to) return;
     const [item] = this.playlist.splice(from, 1);
     this.playlist.splice(to, 0, item);
+    this.updatePrefetch();
     this.scheduleSave();
   }
 
   clearPlaylist(): void {
     this.playlist.length = 0;
+    this.updatePrefetch();
     this.scheduleSave();
   }
 
@@ -284,6 +299,7 @@ export class AppState {
     const track = this.history[i];
     if (!track) return;
     this.playlist.push(trackItem(track));
+    this.updatePrefetch();
     this.scheduleSave();
   }
 
@@ -295,6 +311,7 @@ export class AppState {
     void api.trackPlayed(track.id);
     document.title = `${track.title} - ${track.artist} | DiodeDJ`;
     void this.maybeRefillPlaylist();
+    this.updatePrefetch();
     this.scheduleSave();
   }
 
@@ -330,6 +347,7 @@ export class AppState {
     this.duration = 0;
     this.isPlaying = false;
     document.title = "DiodeDJ";
+    this.updatePrefetch();
     this.scheduleSave();
   }
 
@@ -383,8 +401,30 @@ export class AppState {
       const count = AUTO_PLAYLIST_BUFFER - this.playlist.length;
       const tracks = await api.generatePlaylist(count);
       this.playlist.push(...tracks.map(trackItem));
+      this.updatePrefetch();
       this.scheduleSave();
     }
+  }
+
+  /**
+   * Push the upcoming-track window to the backend prefetch cache: the current
+   * track followed by the next `PREFETCH_WINDOW` playlist tracks (stop markers
+   * skipped). Called after every playlist mutation and on track changes.
+   */
+  private updatePrefetch(): void {
+    const upcoming: number[] = [];
+    for (const item of this.playlist) {
+      if (isTrackItem(item)) {
+        upcoming.push(item.track.id);
+        if (upcoming.length >= PREFETCH_WINDOW) break;
+      }
+    }
+    const ids = this.currentTrack
+      ? [this.currentTrack.id, ...upcoming]
+      : upcoming;
+    void api
+      .prefetch(ids)
+      .catch((err) => logger.error("Prefetch failed:", err));
   }
 
   setHover(track: Track, rect: DOMRect): void {
@@ -465,6 +505,7 @@ export class AppState {
   promoteCueToMain(): void {
     if (!this.cueTrack) return;
     this.playlist.unshift(trackItem(this.cueTrack));
+    this.updatePrefetch();
     this.scheduleSave();
   }
 
@@ -537,6 +578,7 @@ export class AppState {
     }
 
     this.sessionLoaded = true;
+    this.updatePrefetch();
   }
 
   private rebuildPlaylist(

--- a/src/shared/state.test.ts
+++ b/src/shared/state.test.ts
@@ -520,6 +520,82 @@ describe("AppState backend events", () => {
   });
 });
 
+describe("AppState outage recovery (skip-to-cached)", () => {
+  let app: AppState;
+  let mock: MockBackend;
+  beforeEach(() => {
+    resetApi();
+    ({ app, mock } = makeApp());
+  });
+
+  it("on ended, skips an uncached track to the first cached one and keeps the skipped track queued", async () => {
+    app.addToPlaylist(t(1));
+    app.addToPlaylist(t(2));
+    app.addToPlaylist(t(3));
+    app.playIndex(0); // current = 1, playlist = [2, 3]
+    await flushAsync();
+    mock.emitCacheState([3]); // 2 uncached, 3 cached
+    mock.emitEnded();
+    await flushAsync();
+    expect(app.currentTrack?.id).toBe(3);
+    expect(mock.lastLoadedId).toBe(3);
+    // The skipped, still-uncached track stays queued for when the share recovers.
+    expect(app.playlist.map(pid)).toEqual([2]);
+    expect(app.awaitingNetwork).toBe(false);
+  });
+
+  it("waits with a reconnecting banner when nothing upcoming is cached, then resumes on cache-state", async () => {
+    app.addToPlaylist(t(1));
+    app.addToPlaylist(t(2));
+    app.playIndex(0); // current = 1, playlist = [2]
+    await flushAsync();
+    mock.emitCacheState([9]); // nothing in the queue is cached
+    mock.emitEnded();
+    await flushAsync();
+    expect(app.awaitingNetwork).toBe(true);
+    expect(app.currentTrack?.id).toBe(1); // did not advance
+    expect(mock.loadedIds).toEqual([1]); // no doomed load of track 2
+
+    mock.emitCacheState([2]); // share recovered, track 2 now cached
+    await flushAsync();
+    expect(app.awaitingNetwork).toBe(false);
+    expect(app.currentTrack?.id).toBe(2);
+    expect(mock.lastLoadedId).toBe(2);
+  });
+
+  it("on load-failed, skips to the next cached track", async () => {
+    app.addToPlaylist(t(5));
+    app.addToPlaylist(t(6));
+    app.playIndex(0); // current = 5, playlist = [6]
+    await flushAsync();
+    mock.emitCacheState([6]);
+    mock.emitLoadFailed(5);
+    await flushAsync();
+    expect(app.currentTrack?.id).toBe(6);
+    expect(mock.lastLoadedId).toBe(6);
+  });
+
+  it("on load-failed with no cache knowledge (cold offline start), waits instead of burning the queue", async () => {
+    app.addToPlaylist(t(1));
+    app.addToPlaylist(t(2));
+    app.playIndex(0); // current = 1, playlist = [2]
+    await flushAsync();
+    // cachedIds is empty (never received a cache-state) — a failed head load
+    // must not blindly advance through the queue.
+    mock.emitLoadFailed(1);
+    await flushAsync();
+    expect(app.awaitingNetwork).toBe(true);
+    expect(app.playlist.map(pid)).toEqual([2]);
+    expect(mock.loadedIds).toEqual([1]);
+
+    // Recovery clears the wait and cancels the pending retry timer.
+    mock.emitCacheState([2]);
+    await flushAsync();
+    expect(app.awaitingNetwork).toBe(false);
+    expect(app.currentTrack?.id).toBe(2);
+  });
+});
+
 describe("AppState prefetch window", () => {
   let app: AppState;
   beforeEach(() => {

--- a/src/shared/state.test.ts
+++ b/src/shared/state.test.ts
@@ -10,6 +10,7 @@ const { api } = vi.hoisted(() => {
     loadSession: vi.fn(),
     saveSession: vi.fn(),
     trackPlayed: vi.fn(),
+    prefetch: vi.fn(),
     generatePlaylist: vi.fn(),
     pickFiller: vi.fn(),
     getStats: vi.fn(),
@@ -83,6 +84,7 @@ function resetApi(): void {
   vi.clearAllMocks();
   api.search.mockResolvedValue([]);
   api.trackPlayed.mockResolvedValue(undefined);
+  api.prefetch.mockResolvedValue(undefined);
   api.generatePlaylist.mockResolvedValue([]);
   api.getStats.mockResolvedValue({
     totalTracks: 0,
@@ -507,6 +509,46 @@ describe("AppState backend events", () => {
     mock.emitEnded();
     await flushAsync();
     expect(app.currentTrack).toBeNull();
+  });
+
+  it("cache-state event populates cachedIds as a Set", () => {
+    expect(app.cachedIds.size).toBe(0);
+    mock.emitCacheState([3, 7, 9]);
+    expect([...app.cachedIds].sort((a, b) => a - b)).toEqual([3, 7, 9]);
+    mock.emitCacheState([7]);
+    expect([...app.cachedIds]).toEqual([7]);
+  });
+});
+
+describe("AppState prefetch window", () => {
+  let app: AppState;
+  beforeEach(() => {
+    resetApi();
+    app = makeApp().app;
+  });
+
+  it("prefetches upcoming playlist track ids after a mutation", () => {
+    app.addToPlaylist(t(1));
+    app.addToPlaylist(t(2));
+    expect(api.prefetch).toHaveBeenLastCalledWith([1, 2]);
+  });
+
+  it("prepends the current track id and skips stop markers", () => {
+    app.addToPlaylist(t(1));
+    app.addToPlaylist(t(2));
+    app.addToPlaylist(t(3));
+    // playIndex(0) removes t(1) and makes it current; playlist is [2, 3].
+    app.playIndex(0);
+    app.addStopMarker();
+    expect(api.prefetch).toHaveBeenLastCalledWith([1, 2, 3]);
+  });
+
+  it("caps the prefetch window at PREFETCH_WINDOW upcoming tracks", () => {
+    for (let i = 1; i <= 20; i++) app.addToPlaylist(t(i));
+    const last = api.prefetch.mock.calls.at(-1)?.[0] as number[];
+    expect(last).toHaveLength(15);
+    expect(last[0]).toBe(1);
+    expect(last[14]).toBe(15);
   });
 });
 


### PR DESCRIPTION
## Network-resilient audio player (SMB/NFS share hardening)

Hardens the audio player against a mounted network share so playback survives slow links, brief drops, minutes-long disconnects, and reads that hang forever — without dead air or a frozen UI. Implements the full plan from #235.

### What changed

- **Whole file → RAM (#236):** the whole track file is read into an `Arc<[u8]>` and decoded from an in-memory `Cursor`, so a mid-song network stall no longer starves the sink. The read runs off the audio worker thread (with a generation token to discard superseded reads), so a slow load never blocks Play/Pause/Stop/Skip. Seek re-decodes from the retained in-RAM bytes.
- **Prefetch window + shared cache (#237):** `main_deck_prefetch(ids)` — the renderer pushes the next ~15 playlist ids on every queue mutation; a shared `Arc<Cache>` (keep-window: current + next 15, capped 150 MB, nearest-first) prefetches them sequentially. Load hits the cache first. Membership is emitted as `:cache-state`.
- **Watchdog + retry (#238):** each read runs on its own detached thread; a ~10 s watchdog abandons a wedged read (never blocks the worker); transient failures retry 3× with 0.5/1/2 s backoff; exhaustion/timeout emits `:load-failed{id}`.
- **Outage recovery (#239):** on advance/`load-failed`, skip past uncached tracks to the first cached one (skipped tracks stay queued); when nothing is cached (outage or cold offline start) show a "Reconnecting…" banner and retry with backoff, resuming immediately on the next `:cache-state`. Gated on cache knowledge so normal operation is unchanged.
- **Cue deck (#240):** satisfied by construction — the cue deck runs the same player code with the shared cache, so it inherited whole-file-RAM, cache-lookup, watchdog, and retry (no prefetch; single RAM slot). No cue-specific code needed.

### New per-deck events
`:buffering` (bool), `:cache-state` (id[]), `:load-failed` (id).

### Accepted limit
RAM-only durability: a disconnect that outlasts the in-RAM window eventually stalls and self-heals on recovery. Persistent disk cache / library mirror and moving the playlist to the backend were explicitly deferred (the latter tracked separately).

### Verification
`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` (81), `pnpm test -- run` (108), `pnpm typecheck`, `pnpm lint` — all green. New Rust tests cover decode-from-bytes, generation discard, cache window/eviction, retry-then-fail, watchdog decision; new renderer tests cover cache-state, skip-to-cached, wait-then-resume, and cold-offline wait. End-to-end physical-unplug verification needs the GUI + a real mount (manual).

Closes #236, #237, #238, #239, #240. Implements #235.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
