### PR TITLE
feat(deck): network reconnecting banner + buffering shimmer

### DIFF
--- a/src-tauri/src/audio/cache.rs
+++ b/src-tauri/src/audio/cache.rs
@@ -35,6 +35,11 @@ pub const MAX_CACHE_BYTES: usize = 150 * 1024 * 1024;
 /// main-deck concept, so the cache-state event carries the main-deck prefix.
 const CACHE_STATE_EVENT: &str = "main-deck:cache-state";
 
+/// Event topic raised when a prefetch read fails — the share is (probably)
+/// unreachable. Drives the reconnecting indicator; a later cache-state emit
+/// (a read succeeded) signals recovery and clears it on the frontend.
+const PREFETCH_FAILED_EVENT: &str = "main-deck:prefetch-failed";
+
 /// Whole track file resident in RAM. Cheaply cloned (Arc) between the cache and
 /// the decoder.
 type Bytes = Arc<[u8]>;
@@ -206,6 +211,10 @@ fn run_prefetch(inner: &Arc<Mutex<Inner>>, app: &AppHandle) {
             Ok(b) => b,
             Err(e) => {
                 log::warn!("cache: prefetch read {} failed: {}", path.display(), e);
+                // Surface the failure so the UI can flag the share as
+                // unreachable. Idempotent on the frontend; cleared by the next
+                // successful cache-state emit below.
+                let _ = app.emit(PREFETCH_FAILED_EVENT, ());
                 continue;
             }
         };

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -7,8 +7,15 @@
   import SettingsOverlay from "./features/settings/SettingsOverlay.svelte";
   import ScanStatusBar from "./features/scan/ScanStatusBar.svelte";
   import TrackTooltip from "./features/track/TrackTooltip.svelte";
+  import ErrorBanner from "./features/ui/ErrorBanner.svelte";
   import { app } from "./shared/state.svelte";
 </script>
+
+{#if app.reconnecting}
+  <div id="network-toast">
+    <ErrorBanner message="Reconnecting…" type="warning" />
+  </div>
+{/if}
 
 <Toolbar />
 <div id="deck-row" class:has-cue={app.cueDevice !== null}>
@@ -22,3 +29,15 @@
 <SettingsOverlay />
 <ScanStatusBar />
 <TrackTooltip />
+
+<style>
+  /* Floating toast: fixed so reconnect state never shifts deck layout mid-set. */
+  #network-toast {
+    position: fixed;
+    top: 0.75rem;
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 1000;
+    pointer-events: none;
+  }
+</style>

--- a/src/features/deck/NowPlaying.svelte
+++ b/src/features/deck/NowPlaying.svelte
@@ -37,9 +37,7 @@
         >{app.currentTrack ? app.currentTrack.title : "No track loaded"}</span
       >
       <span id="np-artist">{app.currentTrack?.artist ?? ""}</span>
-      {#if app.awaitingNetwork}
-        <span id="np-reconnecting" aria-live="polite">Reconnecting…</span>
-      {:else if app.isBuffering}
+      {#if app.isBuffering}
         <span id="np-buffering" aria-live="polite">Buffering…</span>
       {/if}
     </div>
@@ -103,6 +101,7 @@
   </div>
   <div
     id="progress-bar"
+    class:buffering={app.isBuffering}
     bind:this={progressBar}
     role="slider"
     tabindex="0"

--- a/src/features/deck/NowPlaying.svelte
+++ b/src/features/deck/NowPlaying.svelte
@@ -38,7 +38,9 @@
       >
       <span id="np-artist">{app.currentTrack?.artist ?? ""}</span>
       {#if app.isBuffering}
-        <span id="np-buffering" aria-live="polite">Buffering…</span>
+        <!-- Shimmer on the progress bar is the visual cue; keep a
+             screen-reader-only announcement since CSS is invisible to AT. -->
+        <span class="sr-only" aria-live="polite">Buffering…</span>
       {/if}
     </div>
     <div id="player-controls">

--- a/src/features/deck/backend.ts
+++ b/src/features/deck/backend.ts
@@ -6,6 +6,7 @@ export type DeckEvent =
   | { type: "buffering"; buffering: boolean }
   | { type: "cache-state"; ids: number[] }
   | { type: "load-failed"; id: number }
+  | { type: "prefetch-failed" }
   | { type: "error"; message: string };
 
 export type DeckEventHandler = (event: DeckEvent) => void;

--- a/src/features/deck/nativeBackend.ts
+++ b/src/features/deck/nativeBackend.ts
@@ -57,6 +57,9 @@ export class NativeBackend implements DeckBackend {
       listen<number>(`${p}:load-failed`, (e) =>
         this.emit({ type: "load-failed", id: e.payload }),
       ),
+      listen<null>(`${p}:prefetch-failed`, () =>
+        this.emit({ type: "prefetch-failed" }),
+      ),
     ]);
     this.unlisteners.push(...subs);
   }

--- a/src/features/ui/ErrorBanner.svelte
+++ b/src/features/ui/ErrorBanner.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+  let { message = "An error occurred", type = "error" as "error" | "warning" } =
+    $props();
+</script>
+
+<div
+  class="error-banner {type === 'warning' ? 'warning' : ''}"
+  role={type === "warning" ? "status" : "alert"}
+  aria-live={type === "warning" ? "polite" : "assertive"}
+>
+  <div class="content">
+    <span class="icon">{type === "warning" ? "⚠" : "⛔"}</span>
+    <span class="message">{message}</span>
+  </div>
+</div>
+
+<style>
+  .error-banner {
+    padding: 0.5rem 1rem;
+    border-radius: 4px;
+    background-color: #fee2e2;
+    border: 1px solid #ef4444;
+    color: #991b1b;
+    font-size: 0.875rem;
+    display: flex;
+    align-items: center;
+  }
+
+  .error-banner.warning {
+    background-color: #fef3c7;
+    border-color: #f59e0b;
+    color: #92400e;
+  }
+
+  .content {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  .icon {
+    font-size: 1.1em;
+  }
+</style>

--- a/src/shared/mockBackend.ts
+++ b/src/shared/mockBackend.ts
@@ -88,6 +88,10 @@ export class MockBackend implements DeckBackend {
     this.emit({ type: "load-failed", id });
   }
 
+  emitPrefetchFailed(): void {
+    this.emit({ type: "prefetch-failed" });
+  }
+
   get lastLoadedId(): number | undefined {
     return this.loadedIds[this.loadedIds.length - 1];
   }

--- a/src/shared/state.svelte.ts
+++ b/src/shared/state.svelte.ts
@@ -72,8 +72,13 @@ export class AppState {
   // by cache-state events.
   cachedIds = $state<Set<number>>(new Set());
   // True while no upcoming track is cached and we are waiting for the share to
-  // recover (drives the "Reconnecting…" banner). Cleared on resume.
+  // recover. Set by the playback-advancement state machine when playback is
+  // actually blocked. Cleared on resume.
   awaitingNetwork = $state(false);
+  // True while a prefetch read is failing — the share looks unreachable even
+  // if the current in-RAM track keeps playing. Set by prefetch-failed events,
+  // cleared by the next successful cache-state (a read succeeded).
+  shareUnreachable = $state(false);
 
   // Cue deck (independent transport on a separate audio device)
   cueTrack = $state<Track | null>(null);
@@ -129,9 +134,16 @@ export class AppState {
           break;
         case "cache-state":
           this.cachedIds = new Set(event.ids);
+          // A read succeeded, so the share is reachable again.
+          this.shareUnreachable = false;
           // Cache membership changed — if we were stalled waiting for the
           // share, a newly-cached track may now be playable.
           if (this.awaitingNetwork) this.advancePlan(true);
+          break;
+        case "prefetch-failed":
+          // A prefetch read failed — flag the share as unreachable so the UI
+          // can warn even while an in-RAM track keeps playing.
+          this.shareUnreachable = true;
           break;
         case "error":
           this.isBuffering = false;
@@ -179,6 +191,7 @@ export class AppState {
           logger.error("Cue audio load failed for track:", event.id);
           break;
         case "cache-state":
+        case "prefetch-failed":
           break; // cue deck doesn't use the cache, ignore
         default:
           return isStrictNever(event);
@@ -203,6 +216,12 @@ export class AppState {
 
   get progressPct(): number {
     return this.duration ? (this.currentTime / this.duration) * 100 : 0;
+  }
+
+  // Drives the "Reconnecting…" banner: playback is blocked waiting for the
+  // share, or a prefetch read is currently failing.
+  get reconnecting(): boolean {
+    return this.awaitingNetwork || this.shareUnreachable;
   }
 
   get cueProgressPct(): number {

--- a/src/shared/state.test.ts
+++ b/src/shared/state.test.ts
@@ -594,6 +594,27 @@ describe("AppState outage recovery (skip-to-cached)", () => {
     expect(app.awaitingNetwork).toBe(false);
     expect(app.currentTrack?.id).toBe(2);
   });
+
+  it("prefetch-failed flags the share unreachable while playback continues, cleared on cache-state", async () => {
+    app.addToPlaylist(t(1));
+    app.addToPlaylist(t(2));
+    app.playIndex(0); // current = 1, in RAM and playing
+    await flushAsync();
+
+    // Share drops mid-track: prefetch of an upcoming track fails, but the
+    // current in-RAM track keeps playing — playback is not blocked.
+    mock.emitPrefetchFailed();
+    expect(app.shareUnreachable).toBe(true);
+    expect(app.reconnecting).toBe(true);
+    expect(app.currentTrack?.id).toBe(1); // playback undisturbed
+
+    // A successful read (cache-state) signals recovery.
+    mock.emitCacheState([2]);
+    await flushAsync();
+    expect(app.shareUnreachable).toBe(false);
+    expect(app.reconnecting).toBe(false);
+    expect(app.currentTrack?.id).toBe(1); // still not interrupted
+  });
 });
 
 describe("AppState prefetch window", () => {

--- a/src/styles.css
+++ b/src/styles.css
@@ -624,6 +624,50 @@ body {
   top: 4px;
 }
 
+/* Buffering: indeterminate shimmer sweeping the track — neutral loading, not a fault. */
+#progress-bar.buffering::after {
+  content: "";
+  position: absolute;
+  top: 5px;
+  left: 0;
+  right: 0;
+  height: 4px;
+  background: linear-gradient(
+    90deg,
+    transparent 0%,
+    var(--accent) 50%,
+    transparent 100%
+  );
+  background-size: 40% 100%;
+  background-repeat: no-repeat;
+  opacity: 0.6;
+  animation: buffer-sweep 1.1s linear infinite;
+  pointer-events: none;
+}
+
+@keyframes buffer-sweep {
+  from {
+    background-position: -40% 0;
+  }
+  to {
+    background-position: 140% 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  #progress-bar.buffering::after {
+    animation: none;
+    background-position: 50% 0;
+  }
+}
+
+#np-buffering {
+  display: block;
+  font-size: 12px;
+  font-style: italic;
+  color: var(--text-secondary);
+}
+
 #player-info {
   display: flex;
   align-items: center;

--- a/src/styles.css
+++ b/src/styles.css
@@ -661,11 +661,17 @@ body {
   }
 }
 
-#np-buffering {
-  display: block;
-  font-size: 12px;
-  font-style: italic;
-  color: var(--text-secondary);
+/* Visually hidden but announced by screen readers. */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 #player-info {


### PR DESCRIPTION
## What

Surface network + buffering state to the user in the deck.

- **Reconnecting banner** — fixed toast, top-centre, no layout shift mid-set. Shows whenever playback is blocked waiting for the share **or** a prefetch read is currently failing (`app.reconnecting = awaitingNetwork || shareUnreachable`).
- **Prefetch-failed event** — the prefetch worker previously swallowed read failures (`log::warn` + `continue`). It now emits `main-deck:prefetch-failed` so the UI can flag the share unreachable **even while an in-RAM track keeps playing**. Cleared on the next successful `cache-state` (a read succeeded), without interrupting playback.
- **Buffering shimmer** — indeterminate sweep on the progress bar (neutral loading, distinct from the warning-level reconnect banner), with a `prefers-reduced-motion` fallback. Visible "Buffering…" text dropped; a `.sr-only` `aria-live` region keeps the screen-reader announcement.
- Generic reusable `ErrorBanner` component (`warning` → `role=status`/polite, `error` → `role=alert`/assertive).

## Why

Whole-file-RAM caching means an active track survives a share outage — so the old text-only state never warned the DJ when the share dropped mid-track. The prefetch worker already probes the share continuously; this reuses it as a heartbeat instead of adding a health-check API.

## Notes / caveats

- Any prefetch read error raises the banner, so a lone missing/corrupt file false-positives until the next successful cache. SMB/NFS outages fail the whole mount, so fine in practice; can filter by `io::ErrorKind` later if noisy.
- No auto-clear timeout — banner clears only on a successful prefetch (correct: if the share is down, it stays down).

## Test plan

- `vitest` — new case: `prefetch-failed` flags share unreachable while the in-RAM track plays undisturbed, cleared on `cache-state`. 109 tests pass.
- `svelte-check` 0 errors, `cargo check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)