### PR TITLE
feat(deck): amplitude curve behind seek bars (#234)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .claude/
 .pnpm-store/
+.tmp/
 coverage/
 dist/
 e2e-results/

--- a/src-tauri/src/audio/mod.rs
+++ b/src-tauri/src/audio/mod.rs
@@ -2,3 +2,4 @@ pub mod cache;
 pub mod devices;
 pub mod formats;
 pub mod player;
+pub mod waveform;

--- a/src-tauri/src/audio/waveform.rs
+++ b/src-tauri/src/audio/waveform.rs
@@ -1,79 +1,142 @@
 //! Amplitude-curve (waveform) computation for the seek UI.
 //!
-//! A track's samples are downsampled to a fixed number of peak buckets
-//! ([`WAVEFORM_BUCKETS`]): each bucket holds the maximum absolute sample
-//! amplitude over its slice of the track, quantised to a `u8` (0..=255). The
-//! resulting ~400-byte blob is stored per track in the DB and rendered behind
-//! the deck seek bars so a DJ can see song structure (intro / drop / breakdown)
-//! and seek accurately.
+//! A track's samples are downsampled to a fixed number of RMS-energy buckets
+//! ([`WAVEFORM_BUCKETS`]): each bucket holds the root-mean-square amplitude over
+//! its slice of the track, normalised per-track and quantised to a `u8`
+//! (0..=255). The resulting ~400-byte blob is stored per track in the DB and
+//! rendered behind the deck seek bars so a DJ can see song structure (intro /
+//! drop / breakdown) and seek accurately.
+//!
+//! RMS (perceived energy) rather than raw peak: heavily-limited modern masters
+//! pin max-abs near full-scale across the whole track, hiding structure, whereas
+//! RMS tracks where the energy actually rises and falls. Because RMS values are
+//! small relative to full-scale, the curve is normalised to the loudest bucket
+//! so it uses the full 0..=255 range — one track is shown per deck, so relative
+//! scaling is what matters.
 
 use anyhow::{Context, Result};
-use rodio::{Decoder, Source};
+use rodio::Decoder;
 use std::io::Cursor;
 use std::sync::Arc;
 
-/// Number of peak buckets a track is reduced to. 400 gives enough horizontal
+/// Number of buckets a track is reduced to. 400 gives enough horizontal
 /// resolution for a seek bar a few hundred pixels wide while keeping the stored
 /// blob tiny (one byte per bucket).
 pub const WAVEFORM_BUCKETS: usize = 400;
 
+/// Upper bound on the intermediate mip buffer. Once it fills, adjacent entries
+/// are merged and the decimation doubles, keeping RAM bounded while retaining
+/// resolution far finer than [`WAVEFORM_BUCKETS`] for a track of any length.
+const MIP_CAP: usize = WAVEFORM_BUCKETS * 64;
+
 type Bytes = Arc<[u8]>;
 
-/// Compute the quantised peak curve for an in-memory audio file.
+/// One intermediate mip cell: the summed square amplitude and sample count over
+/// its window, so cells can be merged (on overflow) and re-bucketed by simply
+/// adding the fields — RMS is derived only at the end.
+#[derive(Clone, Copy, Default)]
+struct Cell {
+    sum_sq: f64,
+    count: u64,
+}
+
+impl Cell {
+    fn merge(self, other: Cell) -> Cell {
+        Cell {
+            sum_sq: self.sum_sq + other.sum_sq,
+            count: self.count + other.count,
+        }
+    }
+
+    fn rms(self) -> f32 {
+        if self.count == 0 {
+            0.0
+        } else {
+            (self.sum_sq / self.count as f64).sqrt() as f32
+        }
+    }
+}
+
+/// Compute the quantised RMS curve for an in-memory audio file.
 ///
-/// `duration_hint` (seconds, from tag metadata) lets the common path size the
-/// buckets in a single decode pass. When it is missing or non-positive a first
-/// counting pass establishes the exact sample total before a second filling
-/// pass — correct regardless of the hint, at the cost of decoding twice.
+/// Single decode pass: samples are accumulated into an overflow-merging mip
+/// buffer (so no upfront sample total is needed and RAM stays bounded), then
+/// downsampled to [`WAVEFORM_BUCKETS`] via a float ratio and normalised.
 ///
 /// Returns exactly [`WAVEFORM_BUCKETS`] bytes. Silent or empty tracks yield an
 /// all-zero curve rather than an error.
-pub fn compute_peaks(bytes: Bytes, duration_hint: Option<f64>) -> Result<Vec<u8>> {
-    let decoder = new_decoder(bytes.clone())?;
-    let channels = decoder.channels().max(1) as u64;
-    let sample_rate = decoder.sample_rate().max(1) as u64;
-
-    // Estimated total interleaved samples = frames * channels. Frames are
-    // estimated from the tag duration; None/<=0 falls back to the two-pass path.
-    let estimated_samples = duration_hint
-        .filter(|d| *d > 0.0)
-        .map(|d| (d * sample_rate as f64).ceil() as u64 * channels);
-
-    let total_samples = match estimated_samples {
-        Some(n) if n > 0 => n,
-        // No usable hint: count samples exactly with a throwaway decode pass.
-        _ => new_decoder(bytes.clone())?.count() as u64,
-    };
-
-    Ok(fill_buckets(decoder, total_samples))
+pub fn compute_peaks(bytes: Bytes) -> Result<Vec<u8>> {
+    let decoder = new_decoder(bytes)?;
+    Ok(fill_buckets(decoder))
 }
 
-/// Walk the decoded samples, tracking the max absolute amplitude per bucket, and
-/// quantise each peak to a `u8`. `total_samples` sizes the buckets; the running
-/// index is clamped to the last bucket so a slightly-off estimate never panics
-/// and any extra samples fold into the final bucket.
-fn fill_buckets<S>(source: S, total_samples: u64) -> Vec<u8>
+/// Decode the source once into an overflow-merging mip buffer, downsample that
+/// to [`WAVEFORM_BUCKETS`] RMS buckets, and normalise to the loudest bucket.
+///
+/// The mip buffer avoids needing the total sample count in advance (which the
+/// tag duration cannot supply accurately for VBR codecs): windows of `decim`
+/// samples become one [`Cell`]; when the buffer hits [`MIP_CAP`] its cells are
+/// pairwise-merged and `decim` doubles, so a track of any length collapses to at
+/// most `MIP_CAP` cells — always far more than the 400 output buckets.
+fn fill_buckets<S>(source: S) -> Vec<u8>
 where
     S: Iterator<Item = f32>,
 {
-    let mut peaks = vec![0f32; WAVEFORM_BUCKETS];
-    if total_samples == 0 {
-        return quantise(&peaks);
-    }
-    // Ceil-divide so every sample maps to a bucket in range.
-    let per_bucket = total_samples.div_ceil(WAVEFORM_BUCKETS as u64).max(1);
+    let mut mip: Vec<Cell> = Vec::new();
+    let mut decim: u64 = 1;
+    let mut cur = Cell::default();
 
-    for (i, sample) in source.enumerate() {
-        let bucket = ((i as u64) / per_bucket).min(WAVEFORM_BUCKETS as u64 - 1) as usize;
-        let amp = sample.abs();
-        if amp > peaks[bucket] {
-            peaks[bucket] = amp;
+    for sample in source {
+        let s = sample as f64;
+        cur.sum_sq += s * s;
+        cur.count += 1;
+        if cur.count == decim {
+            mip.push(cur);
+            cur = Cell::default();
+            if mip.len() == MIP_CAP {
+                // Halve resolution: fold adjacent pairs, drop the tail if odd.
+                let merged = mip.len() / 2;
+                for j in 0..merged {
+                    mip[j] = mip[2 * j].merge(mip[2 * j + 1]);
+                }
+                mip.truncate(merged);
+                decim *= 2;
+            }
         }
     }
-    quantise(&peaks)
+    // Trailing partial window.
+    if cur.count > 0 {
+        mip.push(cur);
+    }
+
+    if mip.is_empty() {
+        return vec![0u8; WAVEFORM_BUCKETS];
+    }
+
+    // Downsample the mip cells into the fixed bucket count. A float ratio maps
+    // the last cell onto the last bucket, so there are no starved trailing
+    // buckets (the integer-division approach this replaced left the outro blank
+    // whenever the total was not a multiple of WAVEFORM_BUCKETS).
+    let mut buckets = vec![Cell::default(); WAVEFORM_BUCKETS];
+    let ratio = WAVEFORM_BUCKETS as f64 / mip.len() as f64;
+    for (i, cell) in mip.iter().enumerate() {
+        let b = ((i as f64 * ratio) as usize).min(WAVEFORM_BUCKETS - 1);
+        buckets[b] = buckets[b].merge(*cell);
+    }
+
+    let rms: Vec<f32> = buckets.iter().map(|c| c.rms()).collect();
+    // Per-track normalisation: RMS is small vs full-scale, so scale to the
+    // loudest bucket to use the full 0..=255 range and surface structure.
+    let max_rms = rms.iter().cloned().fold(0.0f32, f32::max);
+    let normalised: Vec<f32> = if max_rms > 0.0 {
+        rms.iter().map(|r| r / max_rms).collect()
+    } else {
+        rms
+    };
+    quantise(&normalised)
 }
 
-/// Map normalised peaks (nominally 0.0..=1.0, clamped) to `u8` 0..=255.
+/// Map normalised amplitudes (nominally 0.0..=1.0, clamped) to `u8` 0..=255.
 fn quantise(peaks: &[f32]) -> Vec<u8> {
     peaks
         .iter()
@@ -89,9 +152,9 @@ fn new_decoder(bytes: Bytes) -> Result<Decoder<Cursor<Bytes>>> {
 mod tests {
     use super::*;
 
-    /// Minimal 16-bit mono PCM WAV whose samples ramp so different buckets get
-    /// different peaks — enough to exercise the downsample without a fixture.
-    fn synth_wav(sample_rate: u32, samples: u32) -> Vec<u8> {
+    /// Minimal 16-bit mono PCM WAV whose per-sample value is supplied by `f`,
+    /// so a test can shape the amplitude envelope without an on-disk fixture.
+    fn synth_wav_with(sample_rate: u32, samples: u32, f: impl Fn(u32) -> i16) -> Vec<u8> {
         let bits = 16u16;
         let channels = 1u16;
         let byte_rate = sample_rate * channels as u32 * (bits as u32 / 8);
@@ -111,13 +174,22 @@ mod tests {
         w.extend_from_slice(&bits.to_le_bytes());
         w.extend_from_slice(b"data");
         w.extend_from_slice(&data_len.to_le_bytes());
-        // First half silent, second half full-scale so the curve is clearly
-        // low-then-high across buckets.
         for i in 0..samples {
-            let v: i16 = if i < samples / 2 { 0 } else { i16::MAX };
-            w.extend_from_slice(&v.to_le_bytes());
+            w.extend_from_slice(&f(i).to_le_bytes());
         }
         w
+    }
+
+    /// 16-bit mono PCM WAV that is silent for the first half and full-scale for
+    /// the second, so the RMS curve is clearly low-then-high across buckets.
+    fn synth_wav(sample_rate: u32, samples: u32) -> Vec<u8> {
+        synth_wav_with(sample_rate, samples, |i| {
+            if i < samples / 2 {
+                0
+            } else {
+                i16::MAX
+            }
+        })
     }
 
     fn bytes_of(v: Vec<u8>) -> Bytes {
@@ -127,14 +199,14 @@ mod tests {
     #[test]
     fn returns_fixed_bucket_count() {
         let wav = bytes_of(synth_wav(8000, 8000));
-        let peaks = compute_peaks(wav, Some(1.0)).expect("compute");
+        let peaks = compute_peaks(wav).expect("compute");
         assert_eq!(peaks.len(), WAVEFORM_BUCKETS);
     }
 
     #[test]
     fn silent_half_is_quieter_than_loud_half() {
         let wav = bytes_of(synth_wav(8000, 8000));
-        let peaks = compute_peaks(wav, Some(1.0)).expect("compute");
+        let peaks = compute_peaks(wav).expect("compute");
         let first = &peaks[..WAVEFORM_BUCKETS / 2];
         let second = &peaks[WAVEFORM_BUCKETS / 2..];
         let max_first = *first.iter().max().unwrap();
@@ -148,27 +220,42 @@ mod tests {
     #[test]
     fn loud_half_reaches_full_scale() {
         let wav = bytes_of(synth_wav(8000, 8000));
-        let peaks = compute_peaks(wav, Some(1.0)).expect("compute");
-        assert_eq!(*peaks.iter().max().unwrap(), 255, "full-scale → 255");
+        let peaks = compute_peaks(wav).expect("compute");
+        // The loudest bucket normalises to 255.
+        assert_eq!(*peaks.iter().max().unwrap(), 255, "loudest bucket → 255");
     }
 
     #[test]
-    fn missing_duration_hint_uses_counting_pass() {
-        // No hint forces the two-pass path; result must match the hinted path.
-        let hinted = compute_peaks(bytes_of(synth_wav(8000, 8000)), Some(1.0)).unwrap();
-        let counted = compute_peaks(bytes_of(synth_wav(8000, 8000)), None).unwrap();
-        assert_eq!(hinted, counted);
+    fn no_trailing_empty_buckets_when_indivisible() {
+        // Sample count not a multiple of WAVEFORM_BUCKETS, with audio in the
+        // final window. The old integer-division bucketing left the last
+        // buckets starved (blank outro); the float ratio must fill bucket 399.
+        let wav = bytes_of(synth_wav(8000, 8001));
+        let peaks = compute_peaks(wav).expect("compute");
+        assert!(
+            peaks[WAVEFORM_BUCKETS - 1] > 0,
+            "last bucket must not be starved"
+        );
+    }
+
+    #[test]
+    fn uniform_amplitude_is_flat() {
+        // Constant full-scale track: every bucket has the same RMS, so after
+        // normalisation the whole curve is flat at the top.
+        let wav = bytes_of(synth_wav_with(8000, 8000, |_| i16::MAX));
+        let peaks = compute_peaks(wav).expect("compute");
+        assert!(peaks.iter().all(|&p| p == 255), "uniform → all 255");
     }
 
     #[test]
     fn garbage_bytes_error() {
         let bad = bytes_of(vec![0u8, 1, 2, 3, 4, 5]);
-        assert!(compute_peaks(bad, Some(1.0)).is_err());
+        assert!(compute_peaks(bad).is_err());
     }
 
     #[test]
     fn empty_source_yields_zero_curve() {
-        let peaks = fill_buckets(std::iter::empty::<f32>(), 0);
+        let peaks = fill_buckets(std::iter::empty::<f32>());
         assert_eq!(peaks, vec![0u8; WAVEFORM_BUCKETS]);
     }
 }

--- a/src-tauri/src/audio/waveform.rs
+++ b/src-tauri/src/audio/waveform.rs
@@ -1,0 +1,174 @@
+//! Amplitude-curve (waveform) computation for the seek UI.
+//!
+//! A track's samples are downsampled to a fixed number of peak buckets
+//! ([`WAVEFORM_BUCKETS`]): each bucket holds the maximum absolute sample
+//! amplitude over its slice of the track, quantised to a `u8` (0..=255). The
+//! resulting ~400-byte blob is stored per track in the DB and rendered behind
+//! the deck seek bars so a DJ can see song structure (intro / drop / breakdown)
+//! and seek accurately.
+
+use anyhow::{Context, Result};
+use rodio::{Decoder, Source};
+use std::io::Cursor;
+use std::sync::Arc;
+
+/// Number of peak buckets a track is reduced to. 400 gives enough horizontal
+/// resolution for a seek bar a few hundred pixels wide while keeping the stored
+/// blob tiny (one byte per bucket).
+pub const WAVEFORM_BUCKETS: usize = 400;
+
+type Bytes = Arc<[u8]>;
+
+/// Compute the quantised peak curve for an in-memory audio file.
+///
+/// `duration_hint` (seconds, from tag metadata) lets the common path size the
+/// buckets in a single decode pass. When it is missing or non-positive a first
+/// counting pass establishes the exact sample total before a second filling
+/// pass — correct regardless of the hint, at the cost of decoding twice.
+///
+/// Returns exactly [`WAVEFORM_BUCKETS`] bytes. Silent or empty tracks yield an
+/// all-zero curve rather than an error.
+pub fn compute_peaks(bytes: Bytes, duration_hint: Option<f64>) -> Result<Vec<u8>> {
+    let decoder = new_decoder(bytes.clone())?;
+    let channels = decoder.channels().max(1) as u64;
+    let sample_rate = decoder.sample_rate().max(1) as u64;
+
+    // Estimated total interleaved samples = frames * channels. Frames are
+    // estimated from the tag duration; None/<=0 falls back to the two-pass path.
+    let estimated_samples = duration_hint
+        .filter(|d| *d > 0.0)
+        .map(|d| (d * sample_rate as f64).ceil() as u64 * channels);
+
+    let total_samples = match estimated_samples {
+        Some(n) if n > 0 => n,
+        // No usable hint: count samples exactly with a throwaway decode pass.
+        _ => new_decoder(bytes.clone())?.count() as u64,
+    };
+
+    Ok(fill_buckets(decoder, total_samples))
+}
+
+/// Walk the decoded samples, tracking the max absolute amplitude per bucket, and
+/// quantise each peak to a `u8`. `total_samples` sizes the buckets; the running
+/// index is clamped to the last bucket so a slightly-off estimate never panics
+/// and any extra samples fold into the final bucket.
+fn fill_buckets<S>(source: S, total_samples: u64) -> Vec<u8>
+where
+    S: Iterator<Item = f32>,
+{
+    let mut peaks = vec![0f32; WAVEFORM_BUCKETS];
+    if total_samples == 0 {
+        return quantise(&peaks);
+    }
+    // Ceil-divide so every sample maps to a bucket in range.
+    let per_bucket = total_samples.div_ceil(WAVEFORM_BUCKETS as u64).max(1);
+
+    for (i, sample) in source.enumerate() {
+        let bucket = ((i as u64) / per_bucket).min(WAVEFORM_BUCKETS as u64 - 1) as usize;
+        let amp = sample.abs();
+        if amp > peaks[bucket] {
+            peaks[bucket] = amp;
+        }
+    }
+    quantise(&peaks)
+}
+
+/// Map normalised peaks (nominally 0.0..=1.0, clamped) to `u8` 0..=255.
+fn quantise(peaks: &[f32]) -> Vec<u8> {
+    peaks
+        .iter()
+        .map(|p| (p.clamp(0.0, 1.0) * 255.0).round() as u8)
+        .collect()
+}
+
+fn new_decoder(bytes: Bytes) -> Result<Decoder<Cursor<Bytes>>> {
+    Decoder::new(Cursor::new(bytes)).context("waveform decoder")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Minimal 16-bit mono PCM WAV whose samples ramp so different buckets get
+    /// different peaks — enough to exercise the downsample without a fixture.
+    fn synth_wav(sample_rate: u32, samples: u32) -> Vec<u8> {
+        let bits = 16u16;
+        let channels = 1u16;
+        let byte_rate = sample_rate * channels as u32 * (bits as u32 / 8);
+        let block_align = channels * (bits / 8);
+        let data_len = samples * (bits as u32 / 8);
+        let mut w = Vec::new();
+        w.extend_from_slice(b"RIFF");
+        w.extend_from_slice(&(36 + data_len).to_le_bytes());
+        w.extend_from_slice(b"WAVE");
+        w.extend_from_slice(b"fmt ");
+        w.extend_from_slice(&16u32.to_le_bytes());
+        w.extend_from_slice(&1u16.to_le_bytes()); // PCM
+        w.extend_from_slice(&channels.to_le_bytes());
+        w.extend_from_slice(&sample_rate.to_le_bytes());
+        w.extend_from_slice(&byte_rate.to_le_bytes());
+        w.extend_from_slice(&block_align.to_le_bytes());
+        w.extend_from_slice(&bits.to_le_bytes());
+        w.extend_from_slice(b"data");
+        w.extend_from_slice(&data_len.to_le_bytes());
+        // First half silent, second half full-scale so the curve is clearly
+        // low-then-high across buckets.
+        for i in 0..samples {
+            let v: i16 = if i < samples / 2 { 0 } else { i16::MAX };
+            w.extend_from_slice(&v.to_le_bytes());
+        }
+        w
+    }
+
+    fn bytes_of(v: Vec<u8>) -> Bytes {
+        Arc::from(v.into_boxed_slice())
+    }
+
+    #[test]
+    fn returns_fixed_bucket_count() {
+        let wav = bytes_of(synth_wav(8000, 8000));
+        let peaks = compute_peaks(wav, Some(1.0)).expect("compute");
+        assert_eq!(peaks.len(), WAVEFORM_BUCKETS);
+    }
+
+    #[test]
+    fn silent_half_is_quieter_than_loud_half() {
+        let wav = bytes_of(synth_wav(8000, 8000));
+        let peaks = compute_peaks(wav, Some(1.0)).expect("compute");
+        let first = &peaks[..WAVEFORM_BUCKETS / 2];
+        let second = &peaks[WAVEFORM_BUCKETS / 2..];
+        let max_first = *first.iter().max().unwrap();
+        let min_second = *second.iter().min().unwrap();
+        assert!(
+            (max_first as u16) < (min_second as u16),
+            "silent half {max_first} should be below loud half {min_second}"
+        );
+    }
+
+    #[test]
+    fn loud_half_reaches_full_scale() {
+        let wav = bytes_of(synth_wav(8000, 8000));
+        let peaks = compute_peaks(wav, Some(1.0)).expect("compute");
+        assert_eq!(*peaks.iter().max().unwrap(), 255, "full-scale → 255");
+    }
+
+    #[test]
+    fn missing_duration_hint_uses_counting_pass() {
+        // No hint forces the two-pass path; result must match the hinted path.
+        let hinted = compute_peaks(bytes_of(synth_wav(8000, 8000)), Some(1.0)).unwrap();
+        let counted = compute_peaks(bytes_of(synth_wav(8000, 8000)), None).unwrap();
+        assert_eq!(hinted, counted);
+    }
+
+    #[test]
+    fn garbage_bytes_error() {
+        let bad = bytes_of(vec![0u8, 1, 2, 3, 4, 5]);
+        assert!(compute_peaks(bad, Some(1.0)).is_err());
+    }
+
+    #[test]
+    fn empty_source_yields_zero_curve() {
+        let peaks = fill_buckets(std::iter::empty::<f32>(), 0);
+        assert_eq!(peaks, vec![0u8; WAVEFORM_BUCKETS]);
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -16,6 +16,7 @@ use audio::player::{Cmd, PlayerHandle};
 use broadcast::{service::default_now_playing_dir, BroadcastService};
 use library::db::{Db, LibraryStats, Track};
 use library::scan_state::{ScanState, ScanStatus, StartResult};
+use library::waveform_scan::WaveformJob;
 use persist::config::{Config, DeviceRef, NowPlayingConfig};
 use persist::session::{PlaylistItem, Session, SessionState};
 
@@ -24,6 +25,8 @@ pub struct AppState {
     config: Arc<Config>,
     session: Arc<Session>,
     scan: Arc<ScanState>,
+    /// Background job that fills track waveforms after a metadata scan.
+    waveform: Arc<WaveformJob>,
     main_deck: Arc<PlayerHandle>,
     cue: Arc<Mutex<Option<PlayerHandle>>>,
     /// Shared prefetch byte cache, resident in both deck players.
@@ -347,12 +350,18 @@ fn broadcast_shutdown(state: State<'_, AppState>) {
 
 #[tauri::command(rename_all = "camelCase")]
 fn scan_libraries(app: AppHandle, state: State<'_, AppState>) -> StartResult {
-    Arc::clone(&state.scan).start(app, Arc::clone(&state.db), Arc::clone(&state.config))
+    Arc::clone(&state.scan).start(
+        app,
+        Arc::clone(&state.db),
+        Arc::clone(&state.config),
+        Arc::clone(&state.waveform),
+    )
 }
 
 #[tauri::command(rename_all = "camelCase")]
 fn cancel_scan(state: State<'_, AppState>) {
     state.scan.cancel();
+    state.waveform.cancel();
 }
 
 #[tauri::command(rename_all = "camelCase")]
@@ -423,11 +432,17 @@ pub fn run() {
                 default_now_playing_dir(&data_dir),
             )?);
             broadcast.attach_to_app(app.handle());
+            let db = Arc::new(db);
+            let waveform = Arc::new(WaveformJob::default());
+            // Backfill waveforms for any already-indexed tracks that lack one,
+            // without waiting for the next scan. No-op on an empty library.
+            Arc::clone(&waveform).start(app.handle().clone(), Arc::clone(&db));
             app.manage(AppState {
-                db: Arc::new(db),
+                db,
                 config,
                 session: Arc::new(session),
                 scan: Arc::new(ScanState::default()),
+                waveform,
                 main_deck: Arc::new(main_deck),
                 cue: Arc::new(Mutex::new(None)),
                 cache,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -16,7 +16,7 @@ use audio::player::{Cmd, PlayerHandle};
 use broadcast::{service::default_now_playing_dir, BroadcastService};
 use library::db::{Db, LibraryStats, Track};
 use library::scan_state::{ScanState, ScanStatus, StartResult};
-use library::waveform_scan::WaveformJob;
+use library::waveform_scan::{WaveformJob, WaveformStatus};
 use persist::config::{Config, DeviceRef, NowPlayingConfig};
 use persist::session::{PlaylistItem, Session, SessionState};
 
@@ -369,6 +369,11 @@ fn get_scan_status(state: State<'_, AppState>) -> ScanStatus {
     state.scan.status()
 }
 
+#[tauri::command(rename_all = "camelCase")]
+fn get_waveform_status(state: State<'_, AppState>) -> WaveformStatus {
+    state.waveform.status()
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     let log_level = std::env::var("RUST_LOG")
@@ -468,6 +473,7 @@ pub fn run() {
             scan_libraries,
             cancel_scan,
             get_scan_status,
+            get_waveform_status,
             audio_list_devices,
             get_main_device,
             set_main_device,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -206,6 +206,14 @@ fn main_deck_set_volume(app_state: State<'_, AppState>, volume: f32) {
     app_state.main_deck.send(Cmd::SetVolume(volume));
 }
 
+/// Return a track's stored amplitude-curve peaks (one byte per bucket) for the
+/// seek UI, or `None` when the track has no waveform. Deck-agnostic — both the
+/// main and cue decks render the same per-track curve.
+#[tauri::command(rename_all = "camelCase")]
+fn get_waveform(app_state: State<'_, AppState>, id: i64) -> Result<Option<Vec<u8>>, String> {
+    app_state.db.get_waveform(id).map_err(err)
+}
+
 #[tauri::command(rename_all = "camelCase")]
 fn audio_list_devices() -> Vec<DeviceInfo> {
     list_output_devices()
@@ -463,6 +471,7 @@ pub fn run() {
             main_deck_stop,
             main_deck_seek,
             main_deck_set_volume,
+            get_waveform,
             get_now_playing_config,
             set_now_playing_config,
             now_playing_test,

--- a/src-tauri/src/library/db.rs
+++ b/src-tauri/src/library/db.rs
@@ -53,19 +53,11 @@ pub struct TrackInsert {
     pub bitrate: Option<i64>,
     pub format: Option<String>,
     pub mtime: Option<i64>,
-    /// Quantised amplitude-curve peaks (one byte per bucket). `None` when the
-    /// track could not be decoded for a waveform; the seek bar falls back to a
-    /// plain progress bar in that case.
-    pub waveform: Option<Vec<u8>>,
 }
 
 pub struct TrackMtimeRow {
     pub content_type: String,
     pub mtime: Option<i64>,
-    /// Whether the row already has a stored waveform. Lets a rescan backfill
-    /// waveforms for tracks scanned before the column existed without needing
-    /// the file's mtime to change.
-    pub has_waveform: bool,
 }
 
 pub struct MediaTrack {
@@ -291,8 +283,8 @@ impl Db {
     }
 
     /// Fetch a track's stored amplitude-curve peaks, or `None` when the track is
-    /// unknown or has no waveform (e.g. it predates the column or failed to
-    /// decode at scan time).
+    /// unknown or has no waveform yet (the async waveform worker fills it after
+    /// the metadata scan).
     pub fn get_waveform(&self, id: i64) -> Result<Option<Vec<u8>>> {
         let conn = self.conn.lock();
         let mut stmt = conn.prepare("SELECT waveform FROM tracks WHERE id = ?")?;
@@ -303,20 +295,52 @@ impl Db {
         }
     }
 
+    /// Store a track's computed amplitude-curve peaks. Written by the async
+    /// waveform worker, separately from the metadata upsert.
+    pub fn set_waveform(&self, id: i64, peaks: &[u8]) -> Result<()> {
+        let conn = self.conn.lock();
+        conn.execute(
+            "UPDATE tracks SET waveform = ? WHERE id = ?",
+            params![peaks, id],
+        )?;
+        Ok(())
+    }
+
+    /// `(id, path, duration)` for every track still missing a waveform, ordered
+    /// by id. Drives the background waveform worker's work list (backfill
+    /// included); the duration seeds the peak-bucket sizing so the worker
+    /// decodes each file only once.
+    pub fn tracks_missing_waveform(&self) -> Result<Vec<(i64, String, Option<f64>)>> {
+        let conn = self.conn.lock();
+        let mut stmt = conn
+            .prepare("SELECT id, path, duration FROM tracks WHERE waveform IS NULL ORDER BY id")?;
+        let rows = stmt.query_map([], |r| {
+            Ok((
+                r.get::<_, i64>(0)?,
+                r.get::<_, String>(1)?,
+                r.get::<_, Option<f64>>(2)?,
+            ))
+        })?;
+        rows.collect::<rusqlite::Result<_>>().map_err(Into::into)
+    }
+
     pub fn insert_track(&self, t: &TrackInsert) -> Result<()> {
         let conn = self.conn.lock();
+        // NB: the waveform column is deliberately not written here. Metadata
+        // scans run tag-only and fast; the waveform is filled asynchronously by
+        // the waveform worker (`set_waveform`). Leaving it out of this upsert
+        // means a metadata rescan never clobbers an already-computed waveform.
         conn.execute(
             "INSERT INTO tracks \
              (path, content_type, title, artist, album, genre, year, duration, bpm, \
-              sample_rate, bitrate, format, mtime, waveform) \
-             VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?) \
+              sample_rate, bitrate, format, mtime) \
+             VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?) \
              ON CONFLICT(path) DO UPDATE SET \
                 content_type=excluded.content_type, \
                 title=excluded.title, artist=excluded.artist, album=excluded.album, \
                 genre=excluded.genre, year=excluded.year, duration=excluded.duration, \
                 bpm=excluded.bpm, sample_rate=excluded.sample_rate, \
-                bitrate=excluded.bitrate, format=excluded.format, mtime=excluded.mtime, \
-                waveform=excluded.waveform",
+                bitrate=excluded.bitrate, format=excluded.format, mtime=excluded.mtime",
             params![
                 t.path,
                 t.content_type,
@@ -331,7 +355,6 @@ impl Db {
                 t.bitrate,
                 t.format,
                 t.mtime,
-                t.waveform,
             ],
         )?;
         Ok(())
@@ -339,14 +362,11 @@ impl Db {
 
     pub fn get_track_by_path(&self, path: &str) -> Result<Option<TrackMtimeRow>> {
         let conn = self.conn.lock();
-        let mut stmt = conn.prepare(
-            "SELECT content_type, mtime, waveform IS NOT NULL FROM tracks WHERE path = ?",
-        )?;
+        let mut stmt = conn.prepare("SELECT content_type, mtime FROM tracks WHERE path = ?")?;
         let mut rows = stmt.query_map([path], |r| {
             Ok(TrackMtimeRow {
                 content_type: r.get(0)?,
                 mtime: r.get::<_, Option<i64>>(1)?,
-                has_waveform: r.get::<_, bool>(2)?,
             })
         })?;
         match rows.next() {
@@ -594,45 +614,78 @@ mod tests {
         assert_eq!(v, 3);
     }
 
-    #[test]
-    fn waveform_roundtrips_through_insert_and_get() {
-        let db = Db::open_in_memory().unwrap();
-        let peaks = vec![0u8, 64, 128, 255];
-        db.insert_track(&TrackInsert {
-            path: "/wave.mp3".into(),
-            content_type: "music".into(),
-            waveform: Some(peaks.clone()),
-            ..Default::default()
-        })
-        .unwrap();
-        let id = db.get_track_by_path("/wave.mp3").unwrap();
-        assert!(id.is_some());
-        let stored = db
-            .search("", Some("music"), None, None)
+    fn only_id(db: &Db) -> i64 {
+        db.search("", Some("music"), None, None)
             .unwrap()
             .first()
             .map(|t| t.id)
-            .unwrap();
-        assert_eq!(db.get_waveform(stored).unwrap(), Some(peaks));
+            .unwrap()
     }
 
     #[test]
-    fn get_waveform_is_none_when_absent() {
+    fn waveform_is_none_until_set_then_roundtrips() {
         let db = Db::open_in_memory().unwrap();
         db.insert_track(&TrackInsert {
-            path: "/plain.mp3".into(),
+            path: "/wave.mp3".into(),
             content_type: "music".into(),
-            waveform: None,
             ..Default::default()
         })
         .unwrap();
-        let id = db
-            .search("", Some("music"), None, None)
-            .unwrap()
-            .first()
-            .map(|t| t.id)
-            .unwrap();
+        let id = only_id(&db);
+        // Metadata insert leaves the waveform empty.
         assert_eq!(db.get_waveform(id).unwrap(), None);
+
+        let peaks = vec![0u8, 64, 128, 255];
+        db.set_waveform(id, &peaks).unwrap();
+        assert_eq!(db.get_waveform(id).unwrap(), Some(peaks));
+    }
+
+    #[test]
+    fn metadata_reinsert_preserves_waveform() {
+        let db = Db::open_in_memory().unwrap();
+        db.insert_track(&TrackInsert {
+            path: "/wave.mp3".into(),
+            content_type: "music".into(),
+            title: Some("Old".into()),
+            ..Default::default()
+        })
+        .unwrap();
+        let id = only_id(&db);
+        db.set_waveform(id, &[1, 2, 3]).unwrap();
+
+        // A metadata rescan (upsert on the same path) must not wipe the waveform.
+        db.insert_track(&TrackInsert {
+            path: "/wave.mp3".into(),
+            content_type: "music".into(),
+            title: Some("New".into()),
+            ..Default::default()
+        })
+        .unwrap();
+        assert_eq!(db.get_waveform(id).unwrap(), Some(vec![1u8, 2, 3]));
+    }
+
+    #[test]
+    fn tracks_missing_waveform_lists_only_unfilled() {
+        let db = Db::open_in_memory().unwrap();
+        db.insert_track(&TrackInsert {
+            path: "/a.mp3".into(),
+            content_type: "music".into(),
+            ..Default::default()
+        })
+        .unwrap();
+        db.insert_track(&TrackInsert {
+            path: "/b.mp3".into(),
+            content_type: "music".into(),
+            ..Default::default()
+        })
+        .unwrap();
+        assert_eq!(db.tracks_missing_waveform().unwrap().len(), 2);
+
+        let first = db.tracks_missing_waveform().unwrap()[0].0;
+        db.set_waveform(first, &[9]).unwrap();
+        let remaining = db.tracks_missing_waveform().unwrap();
+        assert_eq!(remaining.len(), 1);
+        assert_ne!(remaining[0].0, first);
     }
 
     #[test]

--- a/src-tauri/src/library/db.rs
+++ b/src-tauri/src/library/db.rs
@@ -101,18 +101,28 @@ impl Db {
     }
 
     fn migrate(&self) -> Result<()> {
-        let conn = self.conn.lock();
+        let mut conn = self.conn.lock();
         let v: i64 = conn.pragma_query_value(None, "user_version", |r| r.get(0))?;
+        if v >= SCHEMA_VERSION {
+            return Ok(());
+        }
+        // Apply pending steps and bump user_version in a single transaction so
+        // the schema change and its version bump commit together. An interrupted
+        // migration rolls back cleanly instead of leaving the DB half-applied
+        // (schema ahead of version), which on the next launch would re-run an
+        // ADD COLUMN and fail with "duplicate column name".
+        let tx = conn.transaction()?;
         if v < 1 {
-            conn.execute_batch(MIGRATION_001)?;
+            tx.execute_batch(MIGRATION_001)?;
         }
         if v < 2 {
-            conn.execute_batch(MIGRATION_002)?;
+            tx.execute_batch(MIGRATION_002)?;
         }
         if v < 3 {
-            conn.execute_batch(MIGRATION_003)?;
+            tx.execute_batch(MIGRATION_003)?;
         }
-        conn.pragma_update(None, "user_version", 3)?;
+        tx.pragma_update(None, "user_version", SCHEMA_VERSION)?;
+        tx.commit()?;
         Ok(())
     }
 
@@ -572,6 +582,9 @@ CREATE TRIGGER IF NOT EXISTS tracks_au AFTER UPDATE ON tracks BEGIN
 END;
 "#;
 
+/// Current schema version. Bump alongside every new `MIGRATION_00N`.
+const SCHEMA_VERSION: i64 = 3;
+
 const MIGRATION_002: &str = "ALTER TABLE tracks ADD COLUMN mtime INTEGER;";
 
 /// Amplitude-curve peaks for the seek UI, one byte per bucket. Nullable so rows
@@ -607,6 +620,28 @@ mod tests {
     #[test]
     fn migrate_sets_user_version() {
         let db = Db::open_in_memory().unwrap();
+        let conn = db.conn.lock();
+        let v: i64 = conn
+            .pragma_query_value(None, "user_version", |r| r.get(0))
+            .unwrap();
+        assert_eq!(v, 3);
+    }
+
+    #[test]
+    fn migrate_from_v2_adds_waveform_and_bumps_version() {
+        // A released v2 DB (has mtime, no waveform) migrates cleanly to v3.
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(MIGRATION_001).unwrap();
+        conn.execute_batch(MIGRATION_002).unwrap();
+        conn.pragma_update(None, "user_version", 2).unwrap();
+
+        let db = Db::with_connection(conn).expect("migrate v2 -> v3");
+        db.insert_track(&TrackInsert {
+            path: "/a.mp3".into(),
+            content_type: "music".into(),
+            ..Default::default()
+        })
+        .unwrap();
         let conn = db.conn.lock();
         let v: i64 = conn
             .pragma_query_value(None, "user_version", |r| r.get(0))

--- a/src-tauri/src/library/db.rs
+++ b/src-tauri/src/library/db.rs
@@ -83,7 +83,17 @@ pub struct Db {
 impl Db {
     pub fn open(path: &Path) -> Result<Self> {
         let conn = Connection::open(path).context("open sqlite")?;
-        conn.execute_batch("PRAGMA journal_mode = WAL;")?;
+        // WAL for concurrent read/write; `synchronous = NORMAL` drops the fsync
+        // on every autocommit (e.g. the per-track waveform writes) — safe under
+        // WAL since only a crash mid-commit can lose the last transaction, and
+        // all our writes (waveforms especially) are recomputable. `busy_timeout`
+        // lets a writer wait briefly rather than erroring when the background
+        // waveform threads contend for the connection.
+        conn.execute_batch(
+            "PRAGMA journal_mode = WAL;
+             PRAGMA synchronous = NORMAL;
+             PRAGMA busy_timeout = 5000;",
+        )?;
         Self::with_connection(conn)
     }
 

--- a/src-tauri/src/library/db.rs
+++ b/src-tauri/src/library/db.rs
@@ -53,11 +53,19 @@ pub struct TrackInsert {
     pub bitrate: Option<i64>,
     pub format: Option<String>,
     pub mtime: Option<i64>,
+    /// Quantised amplitude-curve peaks (one byte per bucket). `None` when the
+    /// track could not be decoded for a waveform; the seek bar falls back to a
+    /// plain progress bar in that case.
+    pub waveform: Option<Vec<u8>>,
 }
 
 pub struct TrackMtimeRow {
     pub content_type: String,
     pub mtime: Option<i64>,
+    /// Whether the row already has a stored waveform. Lets a rescan backfill
+    /// waveforms for tracks scanned before the column existed without needing
+    /// the file's mtime to change.
+    pub has_waveform: bool,
 }
 
 pub struct MediaTrack {
@@ -109,7 +117,10 @@ impl Db {
         if v < 2 {
             conn.execute_batch(MIGRATION_002)?;
         }
-        conn.pragma_update(None, "user_version", 2)?;
+        if v < 3 {
+            conn.execute_batch(MIGRATION_003)?;
+        }
+        conn.pragma_update(None, "user_version", 3)?;
         Ok(())
     }
 
@@ -279,19 +290,33 @@ impl Db {
             .collect())
     }
 
+    /// Fetch a track's stored amplitude-curve peaks, or `None` when the track is
+    /// unknown or has no waveform (e.g. it predates the column or failed to
+    /// decode at scan time).
+    pub fn get_waveform(&self, id: i64) -> Result<Option<Vec<u8>>> {
+        let conn = self.conn.lock();
+        let mut stmt = conn.prepare("SELECT waveform FROM tracks WHERE id = ?")?;
+        let mut rows = stmt.query_map([id], |r| r.get::<_, Option<Vec<u8>>>(0))?;
+        match rows.next() {
+            Some(r) => r.map_err(Into::into),
+            None => Ok(None),
+        }
+    }
+
     pub fn insert_track(&self, t: &TrackInsert) -> Result<()> {
         let conn = self.conn.lock();
         conn.execute(
             "INSERT INTO tracks \
              (path, content_type, title, artist, album, genre, year, duration, bpm, \
-              sample_rate, bitrate, format, mtime) \
-             VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?) \
+              sample_rate, bitrate, format, mtime, waveform) \
+             VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?) \
              ON CONFLICT(path) DO UPDATE SET \
                 content_type=excluded.content_type, \
                 title=excluded.title, artist=excluded.artist, album=excluded.album, \
                 genre=excluded.genre, year=excluded.year, duration=excluded.duration, \
                 bpm=excluded.bpm, sample_rate=excluded.sample_rate, \
-                bitrate=excluded.bitrate, format=excluded.format, mtime=excluded.mtime",
+                bitrate=excluded.bitrate, format=excluded.format, mtime=excluded.mtime, \
+                waveform=excluded.waveform",
             params![
                 t.path,
                 t.content_type,
@@ -306,6 +331,7 @@ impl Db {
                 t.bitrate,
                 t.format,
                 t.mtime,
+                t.waveform,
             ],
         )?;
         Ok(())
@@ -313,11 +339,14 @@ impl Db {
 
     pub fn get_track_by_path(&self, path: &str) -> Result<Option<TrackMtimeRow>> {
         let conn = self.conn.lock();
-        let mut stmt = conn.prepare("SELECT content_type, mtime FROM tracks WHERE path = ?")?;
+        let mut stmt = conn.prepare(
+            "SELECT content_type, mtime, waveform IS NOT NULL FROM tracks WHERE path = ?",
+        )?;
         let mut rows = stmt.query_map([path], |r| {
             Ok(TrackMtimeRow {
                 content_type: r.get(0)?,
                 mtime: r.get::<_, Option<i64>>(1)?,
+                has_waveform: r.get::<_, bool>(2)?,
             })
         })?;
         match rows.next() {
@@ -525,6 +554,11 @@ END;
 
 const MIGRATION_002: &str = "ALTER TABLE tracks ADD COLUMN mtime INTEGER;";
 
+/// Amplitude-curve peaks for the seek UI, one byte per bucket. Nullable so rows
+/// scanned before this column (or files that failed to decode) simply have no
+/// waveform.
+const MIGRATION_003: &str = "ALTER TABLE tracks ADD COLUMN waveform BLOB;";
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -557,7 +591,48 @@ mod tests {
         let v: i64 = conn
             .pragma_query_value(None, "user_version", |r| r.get(0))
             .unwrap();
-        assert_eq!(v, 2);
+        assert_eq!(v, 3);
+    }
+
+    #[test]
+    fn waveform_roundtrips_through_insert_and_get() {
+        let db = Db::open_in_memory().unwrap();
+        let peaks = vec![0u8, 64, 128, 255];
+        db.insert_track(&TrackInsert {
+            path: "/wave.mp3".into(),
+            content_type: "music".into(),
+            waveform: Some(peaks.clone()),
+            ..Default::default()
+        })
+        .unwrap();
+        let id = db.get_track_by_path("/wave.mp3").unwrap();
+        assert!(id.is_some());
+        let stored = db
+            .search("", Some("music"), None, None)
+            .unwrap()
+            .first()
+            .map(|t| t.id)
+            .unwrap();
+        assert_eq!(db.get_waveform(stored).unwrap(), Some(peaks));
+    }
+
+    #[test]
+    fn get_waveform_is_none_when_absent() {
+        let db = Db::open_in_memory().unwrap();
+        db.insert_track(&TrackInsert {
+            path: "/plain.mp3".into(),
+            content_type: "music".into(),
+            waveform: None,
+            ..Default::default()
+        })
+        .unwrap();
+        let id = db
+            .search("", Some("music"), None, None)
+            .unwrap()
+            .first()
+            .map(|t| t.id)
+            .unwrap();
+        assert_eq!(db.get_waveform(id).unwrap(), None);
     }
 
     #[test]

--- a/src-tauri/src/library/db.rs
+++ b/src-tauri/src/library/db.rs
@@ -334,55 +334,51 @@ impl Db {
         rows.collect::<rusqlite::Result<_>>().map_err(Into::into)
     }
 
+    /// Single-track upsert. Only the tests need this; the scanner batches via
+    /// [`Db::insert_tracks`].
+    #[cfg(test)]
     pub fn insert_track(&self, t: &TrackInsert) -> Result<()> {
-        let conn = self.conn.lock();
-        // NB: the waveform column is deliberately not written here. Metadata
-        // scans run tag-only and fast; the waveform is filled asynchronously by
-        // the waveform worker (`set_waveform`). Leaving it out of this upsert
-        // means a metadata rescan never clobbers an already-computed waveform.
-        conn.execute(
-            "INSERT INTO tracks \
-             (path, content_type, title, artist, album, genre, year, duration, bpm, \
-              sample_rate, bitrate, format, mtime) \
-             VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?) \
-             ON CONFLICT(path) DO UPDATE SET \
-                content_type=excluded.content_type, \
-                title=excluded.title, artist=excluded.artist, album=excluded.album, \
-                genre=excluded.genre, year=excluded.year, duration=excluded.duration, \
-                bpm=excluded.bpm, sample_rate=excluded.sample_rate, \
-                bitrate=excluded.bitrate, format=excluded.format, mtime=excluded.mtime",
-            params![
-                t.path,
-                t.content_type,
-                t.title,
-                t.artist,
-                t.album,
-                t.genre,
-                t.year,
-                t.duration,
-                t.bpm,
-                t.sample_rate,
-                t.bitrate,
-                t.format,
-                t.mtime,
-            ],
-        )?;
+        self.insert_tracks(std::slice::from_ref(t))
+    }
+
+    /// Upsert many tracks in a single transaction with one prepared statement.
+    /// Used by the scanner: a per-row autocommit costs a WAL commit each, which
+    /// dominates a large scan — one transaction turns thousands of commits into
+    /// one. A no-op for an empty slice.
+    pub fn insert_tracks(&self, tracks: &[TrackInsert]) -> Result<()> {
+        if tracks.is_empty() {
+            return Ok(());
+        }
+        let mut conn = self.conn.lock();
+        let tx = conn.transaction()?;
+        {
+            let mut stmt = tx.prepare(UPSERT_TRACK_SQL)?;
+            for t in tracks {
+                stmt.execute(upsert_params(t))?;
+            }
+        }
+        tx.commit()?;
         Ok(())
     }
 
-    pub fn get_track_by_path(&self, path: &str) -> Result<Option<TrackMtimeRow>> {
+    /// Map of `path -> (content_type, mtime)` for every track under `root`, in a
+    /// single query. Lets the scanner decide what to re-parse without a
+    /// per-file SELECT.
+    pub fn track_meta_under(&self, root: &str) -> Result<HashMap<String, TrackMtimeRow>> {
         let conn = self.conn.lock();
-        let mut stmt = conn.prepare("SELECT content_type, mtime FROM tracks WHERE path = ?")?;
-        let mut rows = stmt.query_map([path], |r| {
-            Ok(TrackMtimeRow {
-                content_type: r.get(0)?,
-                mtime: r.get::<_, Option<i64>>(1)?,
-            })
+        let pattern = format!("{}%", root);
+        let mut stmt =
+            conn.prepare("SELECT path, content_type, mtime FROM tracks WHERE path LIKE ?")?;
+        let rows = stmt.query_map([pattern], |r| {
+            Ok((
+                r.get::<_, String>(0)?,
+                TrackMtimeRow {
+                    content_type: r.get(1)?,
+                    mtime: r.get::<_, Option<i64>>(2)?,
+                },
+            ))
         })?;
-        match rows.next() {
-            Some(r) => r.map(Some).map_err(Into::into),
-            None => Ok(None),
-        }
+        rows.collect::<rusqlite::Result<_>>().map_err(Into::into)
     }
 
     pub fn get_paths_under(&self, root: &str) -> Result<Vec<String>> {
@@ -504,6 +500,26 @@ impl Db {
     }
 }
 
+/// Bind params for [`UPSERT_TRACK_SQL`], in column order. Shared by the single
+/// and batch insert paths so the two never drift.
+fn upsert_params(t: &TrackInsert) -> [&dyn rusqlite::ToSql; 13] {
+    [
+        &t.path,
+        &t.content_type,
+        &t.title,
+        &t.artist,
+        &t.album,
+        &t.genre,
+        &t.year,
+        &t.duration,
+        &t.bpm,
+        &t.sample_rate,
+        &t.bitrate,
+        &t.format,
+        &t.mtime,
+    ]
+}
+
 fn order_clause(sort_by: Option<&str>, sort_dir: Option<&str>) -> Option<String> {
     let col = sort_by?;
     if !matches!(col, "title" | "artist" | "album" | "play_count") {
@@ -584,6 +600,21 @@ END;
 
 /// Current schema version. Bump alongside every new `MIGRATION_00N`.
 const SCHEMA_VERSION: i64 = 3;
+
+/// Upsert one track's metadata by path. The waveform column is deliberately
+/// absent: metadata scans run tag-only and fast, and the waveform is filled
+/// asynchronously by the waveform worker (`set_waveform`). Omitting it here
+/// means a metadata rescan never clobbers an already-computed waveform.
+const UPSERT_TRACK_SQL: &str = "INSERT INTO tracks \
+     (path, content_type, title, artist, album, genre, year, duration, bpm, \
+      sample_rate, bitrate, format, mtime) \
+     VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?) \
+     ON CONFLICT(path) DO UPDATE SET \
+        content_type=excluded.content_type, \
+        title=excluded.title, artist=excluded.artist, album=excluded.album, \
+        genre=excluded.genre, year=excluded.year, duration=excluded.duration, \
+        bpm=excluded.bpm, sample_rate=excluded.sample_rate, \
+        bitrate=excluded.bitrate, format=excluded.format, mtime=excluded.mtime";
 
 const MIGRATION_002: &str = "ALTER TABLE tracks ADD COLUMN mtime INTEGER;";
 

--- a/src-tauri/src/library/mod.rs
+++ b/src-tauri/src/library/mod.rs
@@ -1,3 +1,4 @@
 pub mod db;
 pub mod scan_state;
 pub mod scanner;
+pub mod waveform_scan;

--- a/src-tauri/src/library/scan_state.rs
+++ b/src-tauri/src/library/scan_state.rs
@@ -8,6 +8,7 @@ use tauri::{AppHandle, Emitter};
 
 use super::db::Db;
 use super::scanner;
+use super::waveform_scan::WaveformJob;
 use crate::persist::config::Config;
 
 #[derive(Serialize, Clone)]
@@ -89,7 +90,13 @@ impl ScanState {
         let _ = app.emit("scan-state-changed", &next);
     }
 
-    pub fn start(self: Arc<Self>, app: AppHandle, db: Arc<Db>, config: Arc<Config>) -> StartResult {
+    pub fn start(
+        self: Arc<Self>,
+        app: AppHandle,
+        db: Arc<Db>,
+        config: Arc<Config>,
+        waveform: Arc<WaveformJob>,
+    ) -> StartResult {
         if self.is_running() {
             return StartResult {
                 already_running: true,
@@ -114,7 +121,7 @@ impl ScanState {
 
         let s = Arc::clone(&self);
         std::thread::spawn(move || {
-            run(s, app, db, config, cancel);
+            run(s, app, db, config, waveform, cancel);
         });
         StartResult {
             already_running: false,
@@ -127,6 +134,7 @@ fn run(
     app: AppHandle,
     db: Arc<Db>,
     config: Arc<Config>,
+    waveform: Arc<WaveformJob>,
     cancel: Arc<AtomicBool>,
 ) {
     const PROGRESS_THROTTLE: Duration = Duration::from_millis(200);
@@ -215,6 +223,11 @@ fn run(
                 }),
             },
         );
+
+        // Metadata is in — kick the async waveform pass. It runs on its own
+        // thread and lands waveforms later, so the scan reports done now and
+        // never blocks on the heavy per-track decode.
+        Arc::clone(&waveform).start(app.clone(), Arc::clone(&db));
         Ok(())
     })();
 

--- a/src-tauri/src/library/scanner.rs
+++ b/src-tauri/src/library/scanner.rs
@@ -8,7 +8,7 @@ use std::time::UNIX_EPOCH;
 use walkdir::WalkDir;
 
 use super::db::{Db, TrackInsert};
-use crate::audio::formats;
+use crate::audio::{formats, waveform};
 
 pub struct ScanRunResult {
     pub total: usize,
@@ -47,6 +47,7 @@ pub fn should_rescan(
     existing_mtime: Option<i64>,
     file_mtime_ms: i64,
     content_type: &str,
+    has_waveform: bool,
 ) -> bool {
     let Some(prev_ct) = existing_content_type else {
         return true;
@@ -55,6 +56,11 @@ pub fn should_rescan(
         return true;
     };
     if prev_ct != content_type {
+        return true;
+    }
+    // Backfill: a row missing its waveform is rescanned even when unchanged, so
+    // tracks indexed before the waveform column gain one on the next scan.
+    if !has_waveform {
         return true;
     }
     prev_mtime != file_mtime_ms
@@ -93,8 +99,15 @@ where
         let existing = db.get_track_by_path(&path_str)?;
         let existing_ct = existing.as_ref().map(|r| r.content_type.as_str());
         let existing_mtime = existing.as_ref().and_then(|r| r.mtime);
+        let has_waveform = existing.as_ref().map(|r| r.has_waveform).unwrap_or(false);
 
-        if !should_rescan(existing_ct, existing_mtime, mtime_ms, content_type) {
+        if !should_rescan(
+            existing_ct,
+            existing_mtime,
+            mtime_ms,
+            content_type,
+            has_waveform,
+        ) {
             processed += 1;
             on_progress(processed, total);
             continue;
@@ -157,6 +170,11 @@ fn parse_track(path: &str, content_type: &str, mtime_ms: i64) -> Result<TrackIns
     let sample_rate = props.sample_rate().map(|x| x as i64);
     let bitrate = props.audio_bitrate().map(|x| x as i64);
 
+    // Amplitude curve for the seek UI. Best-effort: a decode failure (unsupported
+    // codec, corrupt file) leaves the waveform empty and the scan proceeds — the
+    // deck falls back to a plain progress bar for that track.
+    let waveform = compute_waveform(path, duration);
+
     Ok(TrackInsert {
         path: path.to_string(),
         content_type: content_type.to_string(),
@@ -171,7 +189,29 @@ fn parse_track(path: &str, content_type: &str, mtime_ms: i64) -> Result<TrackIns
         bitrate,
         format,
         mtime: Some(mtime_ms),
+        waveform,
     })
+}
+
+/// Decode `path` into the fixed-size peak curve for the seek UI. Returns `None`
+/// (logged) on any read/decode failure so a single unreadable file never aborts
+/// a scan.
+fn compute_waveform(path: &str, duration: f64) -> Option<Vec<u8>> {
+    let bytes = match std::fs::read(path) {
+        Ok(v) => std::sync::Arc::from(v.into_boxed_slice()),
+        Err(e) => {
+            log::warn!("scan: waveform read {} failed: {}", path, e);
+            return None;
+        }
+    };
+    let hint = if duration > 0.0 { Some(duration) } else { None };
+    match waveform::compute_peaks(bytes, hint) {
+        Ok(peaks) => Some(peaks),
+        Err(e) => {
+            log::warn!("scan: waveform decode {} failed: {}", path, e);
+            None
+        }
+    }
 }
 
 #[cfg(test)]
@@ -180,26 +220,32 @@ mod tests {
 
     #[test]
     fn should_rescan_when_no_existing_row() {
-        assert!(should_rescan(None, None, 100, "music"));
+        assert!(should_rescan(None, None, 100, "music", false));
     }
 
     #[test]
     fn should_rescan_when_existing_lacks_mtime() {
-        assert!(should_rescan(Some("music"), None, 100, "music"));
+        assert!(should_rescan(Some("music"), None, 100, "music", true));
     }
 
     #[test]
     fn should_rescan_when_content_type_changed() {
-        assert!(should_rescan(Some("jingle"), Some(100), 100, "music"));
+        assert!(should_rescan(Some("jingle"), Some(100), 100, "music", true));
     }
 
     #[test]
     fn should_rescan_when_mtime_differs() {
-        assert!(should_rescan(Some("music"), Some(99), 100, "music"));
+        assert!(should_rescan(Some("music"), Some(99), 100, "music", true));
+    }
+
+    #[test]
+    fn should_rescan_when_waveform_missing() {
+        // Unchanged content/mtime but no stored waveform → rescan to backfill.
+        assert!(should_rescan(Some("music"), Some(100), 100, "music", false));
     }
 
     #[test]
     fn should_skip_when_unchanged() {
-        assert!(!should_rescan(Some("music"), Some(100), 100, "music"));
+        assert!(!should_rescan(Some("music"), Some(100), 100, "music", true));
     }
 }

--- a/src-tauri/src/library/scanner.rs
+++ b/src-tauri/src/library/scanner.rs
@@ -3,12 +3,20 @@ use lofty::file::TaggedFileExt;
 use lofty::prelude::*;
 use lofty::probe::Probe;
 use lofty::tag::ItemKey;
+use parking_lot::Mutex;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::UNIX_EPOCH;
 use walkdir::WalkDir;
 
 use super::db::{Db, TrackInsert};
 use crate::audio::formats;
+
+/// Upper bound on parallel tag-read workers. A scan is dominated by per-file
+/// I/O (stat + header read), which on a networked share is latency-bound —
+/// reading several files at once hides that latency. Capped so a scan does not
+/// hammer the share.
+const SCAN_CONCURRENCY: usize = 4;
 
 pub struct ScanRunResult {
     pub total: usize,
@@ -64,52 +72,78 @@ pub fn scan_directory<F>(
     db: &Db,
     dir: &Path,
     content_type: &str,
-    cancel: &impl Fn() -> bool,
-    mut on_progress: F,
+    cancel: &(impl Fn() -> bool + Sync),
+    on_progress: F,
 ) -> Result<ScanRunResult>
 where
-    F: FnMut(usize, usize),
+    F: Fn(usize, usize) + Sync,
 {
     let files = find_audio_files(dir);
     let total = files.len();
-    let mut added = 0usize;
-    let mut processed = 0usize;
-    let mut live: Vec<String> = Vec::with_capacity(total);
+    // All discovered paths — used for prune bookkeeping regardless of how many
+    // we get through (a cancel just skips the prune step upstream).
+    let live: Vec<String> = files
+        .iter()
+        .map(|p| p.to_string_lossy().into_owned())
+        .collect();
 
-    for path in &files {
-        if cancel() {
-            break;
+    // One query for all existing rows under this directory instead of a SELECT
+    // per file.
+    let existing = db.track_meta_under(&dir.to_string_lossy())?;
+
+    // Tag reads are I/O-bound, so fan the files out across a small pool; each
+    // worker claims the next index via `next`. Parsed rows collect in `pending`
+    // and are upserted in a single transaction at the end — a per-row
+    // autocommit is the other thing that makes a big scan slow.
+    let next = AtomicUsize::new(0);
+    let processed = AtomicUsize::new(0);
+    let pending: Mutex<Vec<TrackInsert>> = Mutex::new(Vec::new());
+    let concurrency = std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(1)
+        .min(SCAN_CONCURRENCY);
+
+    std::thread::scope(|scope| {
+        for _ in 0..concurrency {
+            scope.spawn(|| loop {
+                if cancel() {
+                    break;
+                }
+                let i = next.fetch_add(1, Ordering::Relaxed);
+                let Some(path) = files.get(i) else {
+                    break;
+                };
+                let path_str = &live[i];
+
+                let mtime_ms = std::fs::metadata(path)
+                    .and_then(|m| m.modified())
+                    .ok()
+                    .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
+                    .map(|d| d.as_millis() as i64)
+                    .unwrap_or(0);
+
+                let prev = existing.get(path_str);
+                let need = should_rescan(
+                    prev.map(|r| r.content_type.as_str()),
+                    prev.and_then(|r| r.mtime),
+                    mtime_ms,
+                    content_type,
+                );
+                if need {
+                    match parse_track(path_str, content_type, mtime_ms) {
+                        Ok(track) => pending.lock().push(track),
+                        Err(e) => log::error!("scan: failed to parse {}: {}", path_str, e),
+                    }
+                }
+                let done = processed.fetch_add(1, Ordering::Relaxed) + 1;
+                on_progress(done, total);
+            });
         }
-        let path_str = path.to_string_lossy().into_owned();
-        live.push(path_str.clone());
+    });
 
-        let mtime_ms = std::fs::metadata(path)
-            .and_then(|m| m.modified())
-            .ok()
-            .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
-            .map(|d| d.as_millis() as i64)
-            .unwrap_or(0);
-
-        let existing = db.get_track_by_path(&path_str)?;
-        let existing_ct = existing.as_ref().map(|r| r.content_type.as_str());
-        let existing_mtime = existing.as_ref().and_then(|r| r.mtime);
-
-        if !should_rescan(existing_ct, existing_mtime, mtime_ms, content_type) {
-            processed += 1;
-            on_progress(processed, total);
-            continue;
-        }
-
-        match parse_track(&path_str, content_type, mtime_ms) {
-            Ok(track) => {
-                db.insert_track(&track)?;
-                added += 1;
-            }
-            Err(e) => log::error!("scan: failed to parse {}: {}", path_str, e),
-        }
-        processed += 1;
-        on_progress(processed, total);
-    }
+    let pending = pending.into_inner();
+    let added = pending.len();
+    db.insert_tracks(&pending)?;
 
     Ok(ScanRunResult {
         total,

--- a/src-tauri/src/library/scanner.rs
+++ b/src-tauri/src/library/scanner.rs
@@ -58,11 +58,9 @@ pub fn should_rescan(
     if prev_ct != content_type {
         return true;
     }
-    // Backfill: a music row missing its waveform is rescanned even when
-    // unchanged, so tracks indexed before the waveform column gain one on the
-    // next scan. Only music carries a waveform, so non-music rows never trigger
-    // this (otherwise they would rescan on every pass).
-    if content_type == "music" && !has_waveform {
+    // Backfill: a row missing its waveform is rescanned even when unchanged, so
+    // tracks indexed before the waveform column gain one on the next scan.
+    if !has_waveform {
         return true;
     }
     prev_mtime != file_mtime_ms
@@ -172,14 +170,10 @@ fn parse_track(path: &str, content_type: &str, mtime_ms: i64) -> Result<TrackIns
     let sample_rate = props.sample_rate().map(|x| x as i64);
     let bitrate = props.audio_bitrate().map(|x| x as i64);
 
-    // Amplitude curve for the seek UI — music only (jingles/commercials show a
-    // plain progress bar). Best-effort: a decode failure (unsupported codec,
-    // corrupt file) leaves the waveform empty and the scan proceeds.
-    let waveform = if content_type == "music" {
-        compute_waveform(path, duration)
-    } else {
-        None
-    };
+    // Amplitude curve for the seek UI. Best-effort: a decode failure (unsupported
+    // codec, corrupt file) leaves the waveform empty and the scan proceeds — the
+    // deck falls back to a plain progress bar for that track.
+    let waveform = compute_waveform(path, duration);
 
     Ok(TrackInsert {
         path: path.to_string(),
@@ -245,22 +239,9 @@ mod tests {
     }
 
     #[test]
-    fn should_rescan_when_music_waveform_missing() {
-        // Unchanged music with no stored waveform → rescan to backfill.
+    fn should_rescan_when_waveform_missing() {
+        // Unchanged content/mtime but no stored waveform → rescan to backfill.
         assert!(should_rescan(Some("music"), Some(100), 100, "music", false));
-    }
-
-    #[test]
-    fn should_skip_non_music_without_waveform() {
-        // Non-music never carries a waveform, so a missing one must not force a
-        // rescan every pass.
-        assert!(!should_rescan(
-            Some("jingle"),
-            Some(100),
-            100,
-            "jingle",
-            false
-        ));
     }
 
     #[test]

--- a/src-tauri/src/library/scanner.rs
+++ b/src-tauri/src/library/scanner.rs
@@ -58,9 +58,11 @@ pub fn should_rescan(
     if prev_ct != content_type {
         return true;
     }
-    // Backfill: a row missing its waveform is rescanned even when unchanged, so
-    // tracks indexed before the waveform column gain one on the next scan.
-    if !has_waveform {
+    // Backfill: a music row missing its waveform is rescanned even when
+    // unchanged, so tracks indexed before the waveform column gain one on the
+    // next scan. Only music carries a waveform, so non-music rows never trigger
+    // this (otherwise they would rescan on every pass).
+    if content_type == "music" && !has_waveform {
         return true;
     }
     prev_mtime != file_mtime_ms
@@ -170,10 +172,14 @@ fn parse_track(path: &str, content_type: &str, mtime_ms: i64) -> Result<TrackIns
     let sample_rate = props.sample_rate().map(|x| x as i64);
     let bitrate = props.audio_bitrate().map(|x| x as i64);
 
-    // Amplitude curve for the seek UI. Best-effort: a decode failure (unsupported
-    // codec, corrupt file) leaves the waveform empty and the scan proceeds — the
-    // deck falls back to a plain progress bar for that track.
-    let waveform = compute_waveform(path, duration);
+    // Amplitude curve for the seek UI — music only (jingles/commercials show a
+    // plain progress bar). Best-effort: a decode failure (unsupported codec,
+    // corrupt file) leaves the waveform empty and the scan proceeds.
+    let waveform = if content_type == "music" {
+        compute_waveform(path, duration)
+    } else {
+        None
+    };
 
     Ok(TrackInsert {
         path: path.to_string(),
@@ -239,9 +245,22 @@ mod tests {
     }
 
     #[test]
-    fn should_rescan_when_waveform_missing() {
-        // Unchanged content/mtime but no stored waveform → rescan to backfill.
+    fn should_rescan_when_music_waveform_missing() {
+        // Unchanged music with no stored waveform → rescan to backfill.
         assert!(should_rescan(Some("music"), Some(100), 100, "music", false));
+    }
+
+    #[test]
+    fn should_skip_non_music_without_waveform() {
+        // Non-music never carries a waveform, so a missing one must not force a
+        // rescan every pass.
+        assert!(!should_rescan(
+            Some("jingle"),
+            Some(100),
+            100,
+            "jingle",
+            false
+        ));
     }
 
     #[test]

--- a/src-tauri/src/library/scanner.rs
+++ b/src-tauri/src/library/scanner.rs
@@ -8,7 +8,7 @@ use std::time::UNIX_EPOCH;
 use walkdir::WalkDir;
 
 use super::db::{Db, TrackInsert};
-use crate::audio::{formats, waveform};
+use crate::audio::formats;
 
 pub struct ScanRunResult {
     pub total: usize,
@@ -47,7 +47,6 @@ pub fn should_rescan(
     existing_mtime: Option<i64>,
     file_mtime_ms: i64,
     content_type: &str,
-    has_waveform: bool,
 ) -> bool {
     let Some(prev_ct) = existing_content_type else {
         return true;
@@ -56,11 +55,6 @@ pub fn should_rescan(
         return true;
     };
     if prev_ct != content_type {
-        return true;
-    }
-    // Backfill: a row missing its waveform is rescanned even when unchanged, so
-    // tracks indexed before the waveform column gain one on the next scan.
-    if !has_waveform {
         return true;
     }
     prev_mtime != file_mtime_ms
@@ -99,15 +93,8 @@ where
         let existing = db.get_track_by_path(&path_str)?;
         let existing_ct = existing.as_ref().map(|r| r.content_type.as_str());
         let existing_mtime = existing.as_ref().and_then(|r| r.mtime);
-        let has_waveform = existing.as_ref().map(|r| r.has_waveform).unwrap_or(false);
 
-        if !should_rescan(
-            existing_ct,
-            existing_mtime,
-            mtime_ms,
-            content_type,
-            has_waveform,
-        ) {
+        if !should_rescan(existing_ct, existing_mtime, mtime_ms, content_type) {
             processed += 1;
             on_progress(processed, total);
             continue;
@@ -170,11 +157,6 @@ fn parse_track(path: &str, content_type: &str, mtime_ms: i64) -> Result<TrackIns
     let sample_rate = props.sample_rate().map(|x| x as i64);
     let bitrate = props.audio_bitrate().map(|x| x as i64);
 
-    // Amplitude curve for the seek UI. Best-effort: a decode failure (unsupported
-    // codec, corrupt file) leaves the waveform empty and the scan proceeds — the
-    // deck falls back to a plain progress bar for that track.
-    let waveform = compute_waveform(path, duration);
-
     Ok(TrackInsert {
         path: path.to_string(),
         content_type: content_type.to_string(),
@@ -189,29 +171,7 @@ fn parse_track(path: &str, content_type: &str, mtime_ms: i64) -> Result<TrackIns
         bitrate,
         format,
         mtime: Some(mtime_ms),
-        waveform,
     })
-}
-
-/// Decode `path` into the fixed-size peak curve for the seek UI. Returns `None`
-/// (logged) on any read/decode failure so a single unreadable file never aborts
-/// a scan.
-fn compute_waveform(path: &str, duration: f64) -> Option<Vec<u8>> {
-    let bytes = match std::fs::read(path) {
-        Ok(v) => std::sync::Arc::from(v.into_boxed_slice()),
-        Err(e) => {
-            log::warn!("scan: waveform read {} failed: {}", path, e);
-            return None;
-        }
-    };
-    let hint = if duration > 0.0 { Some(duration) } else { None };
-    match waveform::compute_peaks(bytes, hint) {
-        Ok(peaks) => Some(peaks),
-        Err(e) => {
-            log::warn!("scan: waveform decode {} failed: {}", path, e);
-            None
-        }
-    }
 }
 
 #[cfg(test)]
@@ -220,32 +180,26 @@ mod tests {
 
     #[test]
     fn should_rescan_when_no_existing_row() {
-        assert!(should_rescan(None, None, 100, "music", false));
+        assert!(should_rescan(None, None, 100, "music"));
     }
 
     #[test]
     fn should_rescan_when_existing_lacks_mtime() {
-        assert!(should_rescan(Some("music"), None, 100, "music", true));
+        assert!(should_rescan(Some("music"), None, 100, "music"));
     }
 
     #[test]
     fn should_rescan_when_content_type_changed() {
-        assert!(should_rescan(Some("jingle"), Some(100), 100, "music", true));
+        assert!(should_rescan(Some("jingle"), Some(100), 100, "music"));
     }
 
     #[test]
     fn should_rescan_when_mtime_differs() {
-        assert!(should_rescan(Some("music"), Some(99), 100, "music", true));
-    }
-
-    #[test]
-    fn should_rescan_when_waveform_missing() {
-        // Unchanged content/mtime but no stored waveform → rescan to backfill.
-        assert!(should_rescan(Some("music"), Some(100), 100, "music", false));
+        assert!(should_rescan(Some("music"), Some(99), 100, "music"));
     }
 
     #[test]
     fn should_skip_when_unchanged() {
-        assert!(!should_rescan(Some("music"), Some(100), 100, "music", true));
+        assert!(!should_rescan(Some("music"), Some(100), 100, "music"));
     }
 }

--- a/src-tauri/src/library/waveform_scan.rs
+++ b/src-tauri/src/library/waveform_scan.rs
@@ -161,10 +161,10 @@ fn run(job: &WaveformJob, app: &AppHandle, db: &Db) {
                         break;
                     }
                     let i = next.fetch_add(1, Ordering::Relaxed);
-                    let Some((id, path, duration)) = pending.get(i) else {
+                    let Some((id, path, _duration)) = pending.get(i) else {
                         break;
                     };
-                    match compute(path, *duration) {
+                    match compute(path) {
                         Some(peaks) => {
                             if let Err(e) = db.set_waveform(*id, &peaks) {
                                 log::error!("waveform: store {} failed: {}", id, e);
@@ -204,9 +204,9 @@ fn run(job: &WaveformJob, app: &AppHandle, db: &Db) {
     }
 }
 
-/// Read and decode a file into its peak curve. Returns `None` (logged) on any
-/// read/decode failure so a single bad file never stops the worker.
-fn compute(path: &str, duration: Option<f64>) -> Option<Vec<u8>> {
+/// Read and decode a file into its amplitude curve. Returns `None` (logged) on
+/// any read/decode failure so a single bad file never stops the worker.
+fn compute(path: &str) -> Option<Vec<u8>> {
     let bytes = match std::fs::read(path) {
         Ok(v) => Arc::from(v.into_boxed_slice()),
         Err(e) => {
@@ -214,8 +214,7 @@ fn compute(path: &str, duration: Option<f64>) -> Option<Vec<u8>> {
             return None;
         }
     };
-    let hint = duration.filter(|d| *d > 0.0);
-    match waveform::compute_peaks(bytes, hint) {
+    match waveform::compute_peaks(bytes) {
         Ok(peaks) => Some(peaks),
         Err(e) => {
             log::warn!("waveform: decode {} failed: {}", path, e);

--- a/src-tauri/src/library/waveform_scan.rs
+++ b/src-tauri/src/library/waveform_scan.rs
@@ -6,14 +6,23 @@
 //! the DB one at a time and a `waveform-ready` event is emitted per track so the
 //! renderer can refresh a curve for the deck that is currently showing it.
 //!
+//! Progress is surfaced separately from the metadata scan via
+//! `waveform-progress` / `waveform-state-changed` so the UI can show a second
+//! bar under the tag-scan bar. Like the metadata scan, the `processed`/`total`
+//! counts are cumulative across all libraries (the worker drains one flat
+//! missing-waveform list spanning every library).
+//!
 //! The job is single-flight (only one worker at a time) and cancelable. It
 //! drains [`Db::tracks_missing_waveform`] in a loop so tracks added while it runs
 //! are still picked up; ids that fail to decode are remembered for the run so a
 //! permanently-undecodable file never causes an infinite retry loop.
 
+use parking_lot::Mutex;
+use serde::Serialize;
 use std::collections::HashSet;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 use tauri::{AppHandle, Emitter};
 
 use super::db::Db;
@@ -21,14 +30,42 @@ use crate::audio::waveform;
 
 /// Event emitted after a track's waveform is stored. Payload is the track id.
 const WAVEFORM_READY_EVENT: &str = "waveform-ready";
+/// Throttled `{processed, total}` progress updates.
+const WAVEFORM_PROGRESS_EVENT: &str = "waveform-progress";
+/// Running/idle transitions.
+const WAVEFORM_STATE_EVENT: &str = "waveform-state-changed";
+const PROGRESS_THROTTLE: Duration = Duration::from_millis(200);
+
+/// Progress of the background waveform pass, mirrored to the UI. Cumulative
+/// across all libraries.
+#[derive(Serialize, Clone, Default, PartialEq)]
+#[serde(tag = "status", rename_all = "camelCase")]
+pub enum WaveformStatus {
+    #[default]
+    Idle,
+    #[serde(rename_all = "camelCase")]
+    Running { processed: usize, total: usize },
+}
+
+#[derive(Serialize, Clone)]
+struct WaveformProgress {
+    processed: usize,
+    total: usize,
+}
 
 #[derive(Default)]
 pub struct WaveformJob {
     running: AtomicBool,
     cancel: AtomicBool,
+    status: Mutex<WaveformStatus>,
 }
 
 impl WaveformJob {
+    /// Current progress, for hydration when the UI mounts mid-run.
+    pub fn status(&self) -> WaveformStatus {
+        self.status.lock().clone()
+    }
+
     /// Request the running worker (if any) to stop after the current file.
     pub fn cancel(&self) {
         self.cancel.store(true, Ordering::SeqCst);
@@ -48,51 +85,89 @@ impl WaveformJob {
             self.running.store(false, Ordering::SeqCst);
         });
     }
+
+    fn set_status(&self, app: &AppHandle, next: WaveformStatus) {
+        *self.status.lock() = next.clone();
+        let _ = app.emit(WAVEFORM_STATE_EVENT, &next);
+    }
 }
 
 fn run(job: &WaveformJob, app: &AppHandle, db: &Db) {
     // Ids that failed to decode this run — skipped on subsequent passes so a
     // permanently-broken file cannot wedge the drain loop.
     let mut failed: HashSet<i64> = HashSet::new();
+    let mut processed = 0usize;
+    let mut started = false;
+    let mut last_emit = Instant::now()
+        .checked_sub(PROGRESS_THROTTLE)
+        .unwrap_or_else(Instant::now);
 
     loop {
         if job.cancel.load(Ordering::SeqCst) {
-            return;
+            break;
         }
         let missing = match db.tracks_missing_waveform() {
             Ok(m) => m,
             Err(e) => {
                 log::error!("waveform: query missing failed: {}", e);
-                return;
+                break;
             }
         };
-        // Only work left is the set we've already given up on → done.
-        let mut did_work = false;
-        for (id, path, duration) in missing {
+        let pending: Vec<(i64, String, Option<f64>)> = missing
+            .into_iter()
+            .filter(|(id, _, _)| !failed.contains(id))
+            .collect();
+        if pending.is_empty() {
+            break;
+        }
+
+        // Announce Running only once real work exists — avoids a bar flash when
+        // every track already has a waveform.
+        if !started {
+            started = true;
+            job.set_status(
+                app,
+                WaveformStatus::Running {
+                    processed: 0,
+                    total: pending.len(),
+                },
+            );
+        }
+
+        // Total for this pass. It can grow across passes if a concurrent scan
+        // adds tracks; `processed` only ever climbs.
+        let total = processed + pending.len();
+        for (id, path, duration) in pending {
             if job.cancel.load(Ordering::SeqCst) {
-                return;
+                break;
             }
-            if failed.contains(&id) {
-                continue;
-            }
-            did_work = true;
             match compute(&path, duration) {
                 Some(peaks) => {
                     if let Err(e) = db.set_waveform(id, &peaks) {
                         log::error!("waveform: store {} failed: {}", id, e);
                         failed.insert(id);
-                        continue;
+                    } else {
+                        let _ = app.emit(WAVEFORM_READY_EVENT, id);
                     }
-                    let _ = app.emit(WAVEFORM_READY_EVENT, id);
                 }
                 None => {
                     failed.insert(id);
                 }
             }
+            processed += 1;
+            *job.status.lock() = WaveformStatus::Running { processed, total };
+            if last_emit.elapsed() >= PROGRESS_THROTTLE {
+                last_emit = Instant::now();
+                let _ = app.emit(
+                    WAVEFORM_PROGRESS_EVENT,
+                    WaveformProgress { processed, total },
+                );
+            }
         }
-        if !did_work {
-            return;
-        }
+    }
+
+    if started {
+        job.set_status(app, WaveformStatus::Idle);
     }
 }
 

--- a/src-tauri/src/library/waveform_scan.rs
+++ b/src-tauri/src/library/waveform_scan.rs
@@ -20,7 +20,7 @@
 use parking_lot::Mutex;
 use serde::Serialize;
 use std::collections::HashSet;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tauri::{AppHandle, Emitter};
@@ -35,6 +35,10 @@ const WAVEFORM_PROGRESS_EVENT: &str = "waveform-progress";
 /// Running/idle transitions.
 const WAVEFORM_STATE_EVENT: &str = "waveform-state-changed";
 const PROGRESS_THROTTLE: Duration = Duration::from_millis(200);
+/// Upper bound on parallel decode workers. Decoding is CPU-heavy and each file
+/// is independent, so we fan out across cores — capped so a bulk backfill does
+/// not saturate a (possibly networked) share with reads.
+const MAX_CONCURRENCY: usize = 4;
 
 /// Progress of the background waveform pass, mirrored to the UI. Cumulative
 /// across all libraries.
@@ -94,13 +98,21 @@ impl WaveformJob {
 
 fn run(job: &WaveformJob, app: &AppHandle, db: &Db) {
     // Ids that failed to decode this run — skipped on subsequent passes so a
-    // permanently-broken file cannot wedge the drain loop.
-    let mut failed: HashSet<i64> = HashSet::new();
-    let mut processed = 0usize;
+    // permanently-broken file cannot wedge the drain loop. Shared across the
+    // decode threads.
+    let failed: Mutex<HashSet<i64>> = Mutex::new(HashSet::new());
+    // Total files processed across all passes; drives the progress numerator.
+    let processed = AtomicUsize::new(0);
+    let last_emit = Mutex::new(
+        Instant::now()
+            .checked_sub(PROGRESS_THROTTLE)
+            .unwrap_or_else(Instant::now),
+    );
+    let concurrency = std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(1)
+        .min(MAX_CONCURRENCY);
     let mut started = false;
-    let mut last_emit = Instant::now()
-        .checked_sub(PROGRESS_THROTTLE)
-        .unwrap_or_else(Instant::now);
 
     loop {
         if job.cancel.load(Ordering::SeqCst) {
@@ -113,10 +125,13 @@ fn run(job: &WaveformJob, app: &AppHandle, db: &Db) {
                 break;
             }
         };
-        let pending: Vec<(i64, String, Option<f64>)> = missing
-            .into_iter()
-            .filter(|(id, _, _)| !failed.contains(id))
-            .collect();
+        let pending: Vec<(i64, String, Option<f64>)> = {
+            let f = failed.lock();
+            missing
+                .into_iter()
+                .filter(|(id, _, _)| !f.contains(id))
+                .collect()
+        };
         if pending.is_empty() {
             break;
         }
@@ -136,34 +151,52 @@ fn run(job: &WaveformJob, app: &AppHandle, db: &Db) {
 
         // Total for this pass. It can grow across passes if a concurrent scan
         // adds tracks; `processed` only ever climbs.
-        let total = processed + pending.len();
-        for (id, path, duration) in pending {
-            if job.cancel.load(Ordering::SeqCst) {
-                break;
-            }
-            match compute(&path, duration) {
-                Some(peaks) => {
-                    if let Err(e) = db.set_waveform(id, &peaks) {
-                        log::error!("waveform: store {} failed: {}", id, e);
-                        failed.insert(id);
-                    } else {
-                        let _ = app.emit(WAVEFORM_READY_EVENT, id);
+        let total = processed.load(Ordering::Relaxed) + pending.len();
+        // Shared cursor into `pending`; each worker claims the next index.
+        let next = AtomicUsize::new(0);
+        std::thread::scope(|scope| {
+            for _ in 0..concurrency {
+                scope.spawn(|| loop {
+                    if job.cancel.load(Ordering::SeqCst) {
+                        break;
                     }
-                }
-                None => {
-                    failed.insert(id);
-                }
+                    let i = next.fetch_add(1, Ordering::Relaxed);
+                    let Some((id, path, duration)) = pending.get(i) else {
+                        break;
+                    };
+                    match compute(path, *duration) {
+                        Some(peaks) => {
+                            if let Err(e) = db.set_waveform(*id, &peaks) {
+                                log::error!("waveform: store {} failed: {}", id, e);
+                                failed.lock().insert(*id);
+                            } else {
+                                let _ = app.emit(WAVEFORM_READY_EVENT, *id);
+                            }
+                        }
+                        None => {
+                            failed.lock().insert(*id);
+                        }
+                    }
+                    let done = processed.fetch_add(1, Ordering::Relaxed) + 1;
+                    *job.status.lock() = WaveformStatus::Running {
+                        processed: done,
+                        total,
+                    };
+                    let mut le = last_emit.lock();
+                    if le.elapsed() >= PROGRESS_THROTTLE {
+                        *le = Instant::now();
+                        drop(le);
+                        let _ = app.emit(
+                            WAVEFORM_PROGRESS_EVENT,
+                            WaveformProgress {
+                                processed: done,
+                                total,
+                            },
+                        );
+                    }
+                });
             }
-            processed += 1;
-            *job.status.lock() = WaveformStatus::Running { processed, total };
-            if last_emit.elapsed() >= PROGRESS_THROTTLE {
-                last_emit = Instant::now();
-                let _ = app.emit(
-                    WAVEFORM_PROGRESS_EVENT,
-                    WaveformProgress { processed, total },
-                );
-            }
-        }
+        });
     }
 
     if started {

--- a/src-tauri/src/library/waveform_scan.rs
+++ b/src-tauri/src/library/waveform_scan.rs
@@ -35,10 +35,15 @@ const WAVEFORM_PROGRESS_EVENT: &str = "waveform-progress";
 /// Running/idle transitions.
 const WAVEFORM_STATE_EVENT: &str = "waveform-state-changed";
 const PROGRESS_THROTTLE: Duration = Duration::from_millis(200);
-/// Upper bound on parallel decode workers. Decoding is CPU-heavy and each file
-/// is independent, so we fan out across cores — capped so a bulk backfill does
-/// not saturate a (possibly networked) share with reads.
-const MAX_CONCURRENCY: usize = 4;
+/// Hard ceiling on parallel decode workers. Decoding is CPU-heavy and each file
+/// is independent, so we fan out across cores; the actual worker count is
+/// `cores - 2` (reserving headroom for playback/UI) clamped into `2..=MAX`. This
+/// ceiling keeps a huge-core machine — or a networked share — from being flooded
+/// with concurrent reads.
+const MAX_CONCURRENCY: usize = 8;
+/// Cores held back from the decode pool so audio playback and the UI stay
+/// responsive when a backfill runs mid-set.
+const RESERVED_CORES: usize = 2;
 
 /// Progress of the background waveform pass, mirrored to the UI. Cumulative
 /// across all libraries.
@@ -108,10 +113,14 @@ fn run(job: &WaveformJob, app: &AppHandle, db: &Db) {
             .checked_sub(PROGRESS_THROTTLE)
             .unwrap_or_else(Instant::now),
     );
-    let concurrency = std::thread::available_parallelism()
+    // Balanced pool: use the cores that exist minus a reserve for playback/UI,
+    // never fewer than 2, never more than the MAX_CONCURRENCY ceiling.
+    let cores = std::thread::available_parallelism()
         .map(|n| n.get())
-        .unwrap_or(1)
-        .min(MAX_CONCURRENCY);
+        .unwrap_or(1);
+    let concurrency = cores
+        .saturating_sub(RESERVED_CORES)
+        .clamp(2, MAX_CONCURRENCY);
     let mut started = false;
 
     loop {
@@ -165,11 +174,18 @@ fn run(job: &WaveformJob, app: &AppHandle, db: &Db) {
                         break;
                     };
                     match compute(path) {
-                        Some(peaks) => {
+                        Some((peaks, decode_ms)) => {
+                            let store_start = Instant::now();
                             if let Err(e) = db.set_waveform(*id, &peaks) {
                                 log::error!("waveform: store {} failed: {}", id, e);
                                 failed.lock().insert(*id);
                             } else {
+                                log::debug!(
+                                    "waveform: {} decode {}ms write {}ms",
+                                    path,
+                                    decode_ms,
+                                    store_start.elapsed().as_millis()
+                                );
                                 let _ = app.emit(WAVEFORM_READY_EVENT, *id);
                             }
                         }
@@ -204,9 +220,12 @@ fn run(job: &WaveformJob, app: &AppHandle, db: &Db) {
     }
 }
 
-/// Read and decode a file into its amplitude curve. Returns `None` (logged) on
-/// any read/decode failure so a single bad file never stops the worker.
-fn compute(path: &str) -> Option<Vec<u8>> {
+/// Read and decode a file into its amplitude curve. Returns the curve plus the
+/// read+decode duration in milliseconds (for the debug timing log), or `None`
+/// (logged) on any read/decode failure so a single bad file never stops the
+/// worker.
+fn compute(path: &str) -> Option<(Vec<u8>, u128)> {
+    let start = Instant::now();
     let bytes = match std::fs::read(path) {
         Ok(v) => Arc::from(v.into_boxed_slice()),
         Err(e) => {
@@ -215,7 +234,7 @@ fn compute(path: &str) -> Option<Vec<u8>> {
         }
     };
     match waveform::compute_peaks(bytes) {
-        Ok(peaks) => Some(peaks),
+        Ok(peaks) => Some((peaks, start.elapsed().as_millis())),
         Err(e) => {
             log::warn!("waveform: decode {} failed: {}", path, e);
             None

--- a/src-tauri/src/library/waveform_scan.rs
+++ b/src-tauri/src/library/waveform_scan.rs
@@ -1,0 +1,117 @@
+//! Background waveform computation, decoupled from the metadata scan.
+//!
+//! The metadata scan (tag reads) is fast and finishes quickly. Computing a
+//! track's amplitude curve requires a full audio decode, which is far heavier —
+//! so it runs here, on its own worker thread, after the scan. Waveforms land in
+//! the DB one at a time and a `waveform-ready` event is emitted per track so the
+//! renderer can refresh a curve for the deck that is currently showing it.
+//!
+//! The job is single-flight (only one worker at a time) and cancelable. It
+//! drains [`Db::tracks_missing_waveform`] in a loop so tracks added while it runs
+//! are still picked up; ids that fail to decode are remembered for the run so a
+//! permanently-undecodable file never causes an infinite retry loop.
+
+use std::collections::HashSet;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use tauri::{AppHandle, Emitter};
+
+use super::db::Db;
+use crate::audio::waveform;
+
+/// Event emitted after a track's waveform is stored. Payload is the track id.
+const WAVEFORM_READY_EVENT: &str = "waveform-ready";
+
+#[derive(Default)]
+pub struct WaveformJob {
+    running: AtomicBool,
+    cancel: AtomicBool,
+}
+
+impl WaveformJob {
+    /// Request the running worker (if any) to stop after the current file.
+    pub fn cancel(&self) {
+        self.cancel.store(true, Ordering::SeqCst);
+    }
+
+    /// Kick the worker. No-op if one is already running (single-flight): the
+    /// running worker re-drains the work list on each pass, so it will observe
+    /// any tracks a concurrent scan just added.
+    pub fn start(self: Arc<Self>, app: AppHandle, db: Arc<Db>) {
+        // Claim the single-flight slot; bail if a worker already holds it.
+        if self.running.swap(true, Ordering::SeqCst) {
+            return;
+        }
+        self.cancel.store(false, Ordering::SeqCst);
+        std::thread::spawn(move || {
+            run(&self, &app, &db);
+            self.running.store(false, Ordering::SeqCst);
+        });
+    }
+}
+
+fn run(job: &WaveformJob, app: &AppHandle, db: &Db) {
+    // Ids that failed to decode this run — skipped on subsequent passes so a
+    // permanently-broken file cannot wedge the drain loop.
+    let mut failed: HashSet<i64> = HashSet::new();
+
+    loop {
+        if job.cancel.load(Ordering::SeqCst) {
+            return;
+        }
+        let missing = match db.tracks_missing_waveform() {
+            Ok(m) => m,
+            Err(e) => {
+                log::error!("waveform: query missing failed: {}", e);
+                return;
+            }
+        };
+        // Only work left is the set we've already given up on → done.
+        let mut did_work = false;
+        for (id, path, duration) in missing {
+            if job.cancel.load(Ordering::SeqCst) {
+                return;
+            }
+            if failed.contains(&id) {
+                continue;
+            }
+            did_work = true;
+            match compute(&path, duration) {
+                Some(peaks) => {
+                    if let Err(e) = db.set_waveform(id, &peaks) {
+                        log::error!("waveform: store {} failed: {}", id, e);
+                        failed.insert(id);
+                        continue;
+                    }
+                    let _ = app.emit(WAVEFORM_READY_EVENT, id);
+                }
+                None => {
+                    failed.insert(id);
+                }
+            }
+        }
+        if !did_work {
+            return;
+        }
+    }
+}
+
+/// Read and decode a file into its peak curve. Returns `None` (logged) on any
+/// read/decode failure so a single bad file never stops the worker.
+fn compute(path: &str, duration: Option<f64>) -> Option<Vec<u8>> {
+    let bytes = match std::fs::read(path) {
+        Ok(v) => Arc::from(v.into_boxed_slice()),
+        Err(e) => {
+            log::warn!("waveform: read {} failed: {}", path, e);
+            return None;
+        }
+    };
+    let hint = duration.filter(|d| *d > 0.0);
+    match waveform::compute_peaks(bytes, hint) {
+        Ok(peaks) => Some(peaks),
+        Err(e) => {
+            log::warn!("waveform: decode {} failed: {}", path, e);
+            None
+        }
+    }
+}

--- a/src/features/deck/CueDeck.svelte
+++ b/src/features/deck/CueDeck.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { app, formatTime } from "../../shared/state.svelte";
+  import Waveform from "./Waveform.svelte";
 
   let progressBar: HTMLDivElement | undefined = $state();
   let scrubbing = false;
@@ -99,6 +100,11 @@
       onpointerup={onPointerUp}
       onpointercancel={onPointerCancel}
     >
+      <Waveform
+        peaks={app.cueWaveform}
+        progressPct={app.cueProgressPct}
+        id="cue"
+      />
       <div class="cue-progress-fill" style:width="{app.cueProgressPct}%"></div>
     </div>
     {#if app.cueError}

--- a/src/features/deck/CueDeck.svelte
+++ b/src/features/deck/CueDeck.svelte
@@ -4,12 +4,16 @@
 
   let progressBar: HTMLDivElement | undefined = $state();
   let scrubbing = false;
+  let hoverPct = $state<number | null>(null);
+
+  function pctFromClientX(clientX: number): number {
+    if (!progressBar) return 0;
+    const rect = progressBar.getBoundingClientRect();
+    return ((clientX - rect.left) / rect.width) * 100;
+  }
 
   function seekToClientX(clientX: number): void {
-    if (!progressBar) return;
-    const rect = progressBar.getBoundingClientRect();
-    const pct = (clientX - rect.left) / rect.width;
-    app.cueSeekToPct(pct);
+    app.cueSeekToPct(pctFromClientX(clientX) / 100);
   }
 
   function onPointerDown(e: PointerEvent): void {
@@ -20,6 +24,7 @@
   }
 
   function onPointerMove(e: PointerEvent): void {
+    hoverPct = pctFromClientX(e.clientX);
     if (scrubbing) seekToClientX(e.clientX);
   }
 
@@ -31,6 +36,11 @@
 
   function onPointerCancel(): void {
     scrubbing = false;
+    hoverPct = null;
+  }
+
+  function onPointerLeave(): void {
+    hoverPct = null;
   }
 </script>
 
@@ -99,10 +109,12 @@
       onpointermove={onPointerMove}
       onpointerup={onPointerUp}
       onpointercancel={onPointerCancel}
+      onpointerleave={onPointerLeave}
     >
       <Waveform
         peaks={app.cueWaveform}
         progressPct={app.cueProgressPct}
+        {hoverPct}
         id="cue"
       />
       <div class="cue-progress-fill" style:width="{app.cueProgressPct}%"></div>

--- a/src/features/deck/NowPlaying.svelte
+++ b/src/features/deck/NowPlaying.svelte
@@ -4,11 +4,15 @@
 
   let progressBar: HTMLDivElement;
   let scrubbing = false;
+  let hoverPct = $state<number | null>(null);
+
+  function pctFromClientX(clientX: number): number {
+    const rect = progressBar.getBoundingClientRect();
+    return ((clientX - rect.left) / rect.width) * 100;
+  }
 
   function seekToClientX(clientX: number): void {
-    const rect = progressBar.getBoundingClientRect();
-    const pct = (clientX - rect.left) / rect.width;
-    app.seekToPct(pct);
+    app.seekToPct(pctFromClientX(clientX) / 100);
   }
 
   function onPointerDown(e: PointerEvent): void {
@@ -18,6 +22,7 @@
   }
 
   function onPointerMove(e: PointerEvent): void {
+    hoverPct = pctFromClientX(e.clientX);
     if (scrubbing) seekToClientX(e.clientX);
   }
 
@@ -28,6 +33,11 @@
 
   function onPointerCancel(): void {
     scrubbing = false;
+    hoverPct = null;
+  }
+
+  function onPointerLeave(): void {
+    hoverPct = null;
   }
 </script>
 
@@ -116,8 +126,14 @@
     onpointermove={onPointerMove}
     onpointerup={onPointerUp}
     onpointercancel={onPointerCancel}
+    onpointerleave={onPointerLeave}
   >
-    <Waveform peaks={app.waveform} progressPct={app.progressPct} id="main" />
+    <Waveform
+      peaks={app.waveform}
+      progressPct={app.progressPct}
+      {hoverPct}
+      id="main"
+    />
     <div id="progress-fill" style:width="{app.progressPct}%"></div>
   </div>
 </section>

--- a/src/features/deck/NowPlaying.svelte
+++ b/src/features/deck/NowPlaying.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { app, formatTime } from "../../shared/state.svelte";
+  import Waveform from "./Waveform.svelte";
 
   let progressBar: HTMLDivElement;
   let scrubbing = false;
@@ -116,6 +117,7 @@
     onpointerup={onPointerUp}
     onpointercancel={onPointerCancel}
   >
+    <Waveform peaks={app.waveform} progressPct={app.progressPct} id="main" />
     <div id="progress-fill" style:width="{app.progressPct}%"></div>
   </div>
 </section>

--- a/src/features/deck/Waveform.svelte
+++ b/src/features/deck/Waveform.svelte
@@ -14,11 +14,13 @@
   interface Props {
     peaks: number[] | null;
     progressPct: number;
+    /** Cursor position (0..100) while hovering the bar, or null when away. */
+    hoverPct?: number | null;
     /** Unique per instance — clipPath ids must not collide across decks. */
     id: string;
   }
 
-  const { peaks, progressPct, id }: Props = $props();
+  const { peaks, progressPct, hoverPct = null, id }: Props = $props();
 
   // viewBox units: one x-unit per bucket, 0..100 vertical (bars grow up from the
   // baseline at y=100). preserveAspectRatio "none" stretches the grid to the
@@ -35,6 +37,11 @@
   );
   const playedWidth = $derived(
     (Math.min(100, Math.max(0, progressPct)) / 100) * count,
+  );
+  const hoverX = $derived(
+    hoverPct == null
+      ? null
+      : (Math.min(100, Math.max(0, hoverPct)) / 100) * count,
   );
   const clipId = $derived(`wf-clip-${id}`);
 </script>
@@ -61,5 +68,17 @@
         <rect x={b.x + 0.1} y={b.y} width="0.8" height={b.h} />
       {/each}
     </g>
+    {#if hoverX != null}
+      <!-- Seek preview marker: a 1px line at the cursor (non-scaling so it stays
+           crisp under the preserveAspectRatio="none" stretch). -->
+      <line
+        class="wf-cursor"
+        x1={hoverX}
+        y1="0"
+        x2={hoverX}
+        y2={HEIGHT}
+        vector-effect="non-scaling-stroke"
+      />
+    {/if}
   </svg>
 {/if}

--- a/src/features/deck/Waveform.svelte
+++ b/src/features/deck/Waveform.svelte
@@ -1,0 +1,62 @@
+<script lang="ts">
+  /**
+   * Amplitude-curve overlay for a deck seek bar. Renders the stored peak curve
+   * as centered vertical bars: a dim layer for the whole track and an
+   * accent-coloured layer clipped to the played portion, giving the DJ a visual
+   * map of song structure to seek against.
+   *
+   * Bars are drawn once per track (they depend only on `peaks`); only the clip
+   * width tracks `progressPct` as playback advances, so the 100 ms time tick
+   * stays cheap.
+   */
+  interface Props {
+    peaks: number[] | null;
+    progressPct: number;
+    /** Unique per instance — clipPath ids must not collide across decks. */
+    id: string;
+  }
+
+  const { peaks, progressPct, id }: Props = $props();
+
+  // viewBox units: one x-unit per bucket, 0..100 vertical. preserveAspectRatio
+  // "none" lets the fixed bucket grid stretch to the bar's real pixel width.
+  const HEIGHT = 100;
+  const MIN_BAR = 2; // keep silent buckets visible as a thin baseline
+
+  const count = $derived(peaks?.length ?? 0);
+  const bars = $derived(
+    (peaks ?? []).map((v, i) => {
+      const h = Math.max(MIN_BAR, (v / 255) * HEIGHT);
+      return { x: i, y: (HEIGHT - h) / 2, h };
+    }),
+  );
+  const playedWidth = $derived(
+    (Math.min(100, Math.max(0, progressPct)) / 100) * count,
+  );
+  const clipId = $derived(`wf-clip-${id}`);
+</script>
+
+{#if peaks && peaks.length > 0}
+  <svg
+    class="waveform"
+    viewBox="0 0 {count} {HEIGHT}"
+    preserveAspectRatio="none"
+    aria-hidden="true"
+  >
+    <defs>
+      <clipPath id={clipId}>
+        <rect x="0" y="0" width={playedWidth} height={HEIGHT} />
+      </clipPath>
+    </defs>
+    <g class="wf-base">
+      {#each bars as b (b.x)}
+        <rect x={b.x + 0.1} y={b.y} width="0.8" height={b.h} />
+      {/each}
+    </g>
+    <g class="wf-played" clip-path="url(#{clipId})">
+      {#each bars as b (b.x)}
+        <rect x={b.x + 0.1} y={b.y} width="0.8" height={b.h} />
+      {/each}
+    </g>
+  </svg>
+{/if}

--- a/src/features/deck/Waveform.svelte
+++ b/src/features/deck/Waveform.svelte
@@ -1,13 +1,15 @@
 <script lang="ts">
   /**
-   * Amplitude-curve overlay for a deck seek bar. Renders the stored peak curve
-   * as centered vertical bars: a dim layer for the whole track and an
-   * accent-coloured layer clipped to the played portion, giving the DJ a visual
-   * map of song structure to seek against.
+   * Amplitude-curve overlay for a deck seek bar. The stored peak curve is
+   * symmetric, so only the top half is drawn: bars rise from the bar's baseline,
+   * giving the DJ a visual map of song structure to seek against. A dim layer
+   * covers the whole track; an accent layer clipped to the played portion tracks
+   * the playhead.
    *
    * Bars are drawn once per track (they depend only on `peaks`); only the clip
    * width tracks `progressPct` as playback advances, so the 100 ms time tick
-   * stays cheap.
+   * stays cheap. `height`/`width` are pinned to 100% so the SVG fills its bar
+   * instead of falling back to the viewBox's intrinsic aspect ratio.
    */
   interface Props {
     peaks: number[] | null;
@@ -18,16 +20,17 @@
 
   const { peaks, progressPct, id }: Props = $props();
 
-  // viewBox units: one x-unit per bucket, 0..100 vertical. preserveAspectRatio
-  // "none" lets the fixed bucket grid stretch to the bar's real pixel width.
+  // viewBox units: one x-unit per bucket, 0..100 vertical (bars grow up from the
+  // baseline at y=100). preserveAspectRatio "none" stretches the grid to the
+  // bar's real pixel size.
   const HEIGHT = 100;
-  const MIN_BAR = 2; // keep silent buckets visible as a thin baseline
+  const MIN_BAR = 3; // keep silent buckets visible as a thin baseline
 
   const count = $derived(peaks?.length ?? 0);
   const bars = $derived(
     (peaks ?? []).map((v, i) => {
       const h = Math.max(MIN_BAR, (v / 255) * HEIGHT);
-      return { x: i, y: (HEIGHT - h) / 2, h };
+      return { x: i, y: HEIGHT - h, h };
     }),
   );
   const playedWidth = $derived(

--- a/src/features/scan/ScanStatusBar.svelte
+++ b/src/features/scan/ScanStatusBar.svelte
@@ -59,6 +59,22 @@
     return "";
   });
 
+  // Background waveform pass — its own bar, shown under the tag-scan bar only
+  // while it is actively computing.
+  let wfVisible = $derived(app.waveformStatus.status === "running");
+  let wfPct = $derived.by(() => {
+    const s = app.waveformStatus;
+    return s.status === "running" && s.total > 0
+      ? Math.min(100, (s.processed / s.total) * 100)
+      : 0;
+  });
+  let wfLabel = $derived.by(() => {
+    const s = app.waveformStatus;
+    return s.status === "running"
+      ? `Computing waveforms… ${s.processed} / ${s.total}`
+      : "";
+  });
+
   function onCancel(): void {
     void app.cancelScan();
   }
@@ -69,25 +85,43 @@
   }
 </script>
 
-{#if visible}
-  <div
-    id="scan-status-bar"
-    role="status"
-    aria-live="polite"
-    data-state={app.scanStatus.status}
-  >
-    <span class="scan-status-label">{label}</span>
-    {#if app.scanStatus.status === "running"}
-      <div class="scan-status-bar-track">
-        <div class="scan-status-bar-fill" style:width="{pct}%"></div>
+{#if visible || wfVisible}
+  <div id="status-bars">
+    {#if visible}
+      <div
+        id="scan-status-bar"
+        class="scan-status-bar"
+        role="status"
+        aria-live="polite"
+        data-state={app.scanStatus.status}
+      >
+        <span class="scan-status-label">{label}</span>
+        {#if app.scanStatus.status === "running"}
+          <div class="scan-status-bar-track">
+            <div class="scan-status-bar-fill" style:width="{pct}%"></div>
+          </div>
+          <button type="button" class="scan-status-cancel" onclick={onCancel}>
+            Cancel
+          </button>
+        {:else}
+          <button type="button" class="scan-status-cancel" onclick={onDismiss}>
+            Dismiss
+          </button>
+        {/if}
       </div>
-      <button type="button" class="scan-status-cancel" onclick={onCancel}>
-        Cancel
-      </button>
-    {:else}
-      <button type="button" class="scan-status-cancel" onclick={onDismiss}>
-        Dismiss
-      </button>
+    {/if}
+    {#if wfVisible}
+      <div
+        id="waveform-status-bar"
+        class="scan-status-bar"
+        role="status"
+        aria-live="polite"
+      >
+        <span class="scan-status-label">{wfLabel}</span>
+        <div class="scan-status-bar-track">
+          <div class="scan-status-bar-fill" style:width="{wfPct}%"></div>
+        </div>
+      </div>
     {/if}
   </div>
 {/if}

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,6 +14,7 @@ void app.search();
 void app.loadStats();
 void app.loadSession();
 void app.hydrateScanStatus();
+void app.hydrateWaveformStatus();
 void app.loadAudioConfig();
 
 const win = getCurrentWindow();

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -119,6 +119,13 @@ export const api = {
   ): Promise<UnlistenFn> {
     return listen<ScanStatus>("scan-state-changed", (e) => callback(e.payload));
   },
+  /**
+   * Fires when the background worker has stored a track's waveform. Payload is
+   * the track id; the renderer refetches the curve if that track is loaded.
+   */
+  onWaveformReady(callback: (id: number) => void): Promise<UnlistenFn> {
+    return listen<number>("waveform-ready", (e) => callback(e.payload));
+  },
   listAudioDevices(): Promise<DeviceInfo[]> {
     return invoke<DeviceInfo[]>("audio_list_devices");
   },

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -59,6 +59,13 @@ export const api = {
   getTracksByIds(ids: number[]): Promise<Track[]> {
     return invoke<Track[]>("get_tracks_by_ids", { ids });
   },
+  /**
+   * Fetch a track's amplitude-curve peaks (one byte per bucket, 0..=255) for
+   * the seek UI, or `null` when the track has no stored waveform.
+   */
+  getWaveform(id: number): Promise<number[] | null> {
+    return invoke<number[] | null>("get_waveform", { id });
+  },
   loadSession(): Promise<SessionLoadResult> {
     return invoke<SessionLoadResult>("load_session");
   },

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -44,6 +44,9 @@ export interface ScanProgress {
   total: number;
 }
 
+export type WaveformStatus =
+  { status: "idle" } | { status: "running"; processed: number; total: number };
+
 export const api = {
   search(
     query: string,
@@ -125,6 +128,23 @@ export const api = {
    */
   onWaveformReady(callback: (id: number) => void): Promise<UnlistenFn> {
     return listen<number>("waveform-ready", (e) => callback(e.payload));
+  },
+  getWaveformStatus(): Promise<WaveformStatus> {
+    return invoke<WaveformStatus>("get_waveform_status");
+  },
+  onWaveformProgress(
+    callback: (data: ScanProgress) => void,
+  ): Promise<UnlistenFn> {
+    return listen<ScanProgress>("waveform-progress", (e) =>
+      callback(e.payload),
+    );
+  },
+  onWaveformStateChanged(
+    callback: (data: WaveformStatus) => void,
+  ): Promise<UnlistenFn> {
+    return listen<WaveformStatus>("waveform-state-changed", (e) =>
+      callback(e.payload),
+    );
   },
   listAudioDevices(): Promise<DeviceInfo[]> {
     return invoke<DeviceInfo[]>("audio_list_devices");

--- a/src/shared/state.svelte.ts
+++ b/src/shared/state.svelte.ts
@@ -14,6 +14,7 @@ import {
   type PersistedPlaylistItem,
   type ScanStatus,
   type SessionLoadResult,
+  type WaveformStatus,
 } from "./api";
 import type { DeckBackend } from "../features/deck/backend";
 import { NativeBackend } from "../features/deck/nativeBackend";
@@ -56,6 +57,8 @@ export class AppState {
   });
   settingsOpen = $state(false);
   scanStatus = $state<ScanStatus>({ status: "idle", lastResult: null });
+  // Progress of the background waveform pass (runs after the metadata scan).
+  waveformStatus = $state<WaveformStatus>({ status: "idle" });
 
   playlist = $state<PlaylistItem[]>([]);
   history = $state<Track[]>([]);
@@ -225,6 +228,15 @@ export class AppState {
     api.onWaveformReady((id) => {
       if (this.currentTrack?.id === id) this.loadWaveform(id);
       if (this.cueTrack?.id === id) this.loadCueWaveform(id);
+    });
+
+    api.onWaveformProgress(({ processed, total }) => {
+      if (this.waveformStatus.status === "running") {
+        this.waveformStatus = { status: "running", processed, total };
+      }
+    });
+    api.onWaveformStateChanged((next) => {
+      this.waveformStatus = next;
     });
   }
 
@@ -770,6 +782,10 @@ export class AppState {
 
   async hydrateScanStatus(): Promise<void> {
     this.scanStatus = await api.getScanStatus();
+  }
+
+  async hydrateWaveformStatus(): Promise<void> {
+    this.waveformStatus = await api.getWaveformStatus();
   }
 
   private async handleEnded(): Promise<void> {

--- a/src/shared/state.svelte.ts
+++ b/src/shared/state.svelte.ts
@@ -67,6 +67,10 @@ export class AppState {
   volume = $state(1);
   currentTime = $state(0);
   duration = $state(0);
+  // Amplitude-curve peaks (0..=255 per bucket) for the current main-deck track,
+  // rendered behind the seek bar. `null` while none is loaded or the track has
+  // no stored waveform (falls back to a plain progress bar).
+  waveform = $state<number[] | null>(null);
   // Track ids currently resident in the backend prefetch cache. Drives
   // skip-to-cached advancement during a network outage; membership is updated
   // by cache-state events.
@@ -88,6 +92,8 @@ export class AppState {
   cueDuration = $state(0);
   cueVolume = $state(1);
   cueError = $state<string | null>(null);
+  // Amplitude-curve peaks for the current cue-deck track (see `waveform`).
+  cueWaveform = $state<number[] | null>(null);
 
   // Audio device config
   audioDevices = $state<DeviceInfo[]>([]);
@@ -363,6 +369,7 @@ export class AppState {
     this.currentTrack = track;
     this.duration = track.duration ?? 0;
     this.currentTime = 0;
+    this.loadWaveform(track.id);
     void this.loadAndPlay(track);
     void api.trackPlayed(track.id);
     document.title = `${track.title} - ${track.artist} | DiodeDJ`;
@@ -378,6 +385,32 @@ export class AppState {
     } catch (err) {
       logger.error("Load/play failed:", err);
     }
+  }
+
+  /**
+   * Fetch the amplitude curve for `id` and store it, guarding against a race:
+   * a slower fetch for a track the user has already skipped past must not
+   * overwrite the current one. The result is dropped unless `id` is still the
+   * loaded track when it arrives.
+   */
+  private loadWaveform(id: number): void {
+    this.waveform = null;
+    void api
+      .getWaveform(id)
+      .then((peaks) => {
+        if (this.currentTrack?.id === id) this.waveform = peaks;
+      })
+      .catch((err) => logger.error("Waveform load failed:", err));
+  }
+
+  private loadCueWaveform(id: number): void {
+    this.cueWaveform = null;
+    void api
+      .getWaveform(id)
+      .then((peaks) => {
+        if (this.cueTrack?.id === id) this.cueWaveform = peaks;
+      })
+      .catch((err) => logger.error("Cue waveform load failed:", err));
   }
 
   togglePlay(): void {
@@ -402,6 +435,7 @@ export class AppState {
     this.autoPlaylistActive = false;
     this.currentTime = 0;
     this.duration = 0;
+    this.waveform = null;
     this.isPlaying = false;
     document.title = "DiodeDJ";
     this.updatePrefetch();
@@ -508,6 +542,7 @@ export class AppState {
     this.cueTrack = track;
     this.cueDuration = track.duration ?? 0;
     this.cueCurrentTime = 0;
+    this.loadCueWaveform(track.id);
     void this.cueBackend
       .load(track.id)
       .then(() => this.cueBackend.play())
@@ -534,6 +569,7 @@ export class AppState {
     this.cueIsPlaying = false;
     this.cueCurrentTime = 0;
     this.cueDuration = 0;
+    this.cueWaveform = null;
   }
 
   cueSeekToPct(pct: number): void {
@@ -627,6 +663,7 @@ export class AppState {
       if (state.currentTime > 0) {
         this.currentTime = state.currentTime;
       }
+      this.loadWaveform(restored.id);
       void this.loadWithSeek(restored, state.currentTime);
       document.title = `${restored.title} - ${restored.artist} | DiodeDJ`;
     }

--- a/src/shared/state.svelte.ts
+++ b/src/shared/state.svelte.ts
@@ -218,6 +218,14 @@ export class AppState {
         void this.loadStats();
       }
     });
+
+    // A waveform the background worker just computed may belong to a track that
+    // was already loaded (its earlier fetch came back empty). Refetch so the
+    // seek bar fills in without a reload.
+    api.onWaveformReady((id) => {
+      if (this.currentTrack?.id === id) this.loadWaveform(id);
+      if (this.cueTrack?.id === id) this.loadCueWaveform(id);
+    });
   }
 
   get progressPct(): number {

--- a/src/shared/state.test.ts
+++ b/src/shared/state.test.ts
@@ -25,6 +25,9 @@ const { api } = vi.hoisted(() => {
     onScanProgress: vi.fn(),
     onScanStateChanged: vi.fn(),
     onWaveformReady: vi.fn(),
+    onWaveformProgress: vi.fn(),
+    onWaveformStateChanged: vi.fn(),
+    getWaveformStatus: vi.fn(),
     listAudioDevices: vi.fn(),
     getMainDevice: vi.fn(),
     setMainDevice: vi.fn(),
@@ -106,6 +109,7 @@ function resetApi(): void {
   api.getScanStatus.mockResolvedValue({ status: "idle", lastResult: null });
   api.getTracksByIds.mockResolvedValue([]);
   api.getWaveform.mockResolvedValue(null);
+  api.getWaveformStatus.mockResolvedValue({ status: "idle" });
   api.loadSession.mockResolvedValue({
     state: {
       playlistIds: [],
@@ -549,6 +553,31 @@ describe("AppState waveform", () => {
     ) => void;
     onReady(999);
     expect(api.getWaveform).not.toHaveBeenCalled();
+  });
+
+  it("tracks waveform-pass progress via state + progress events", () => {
+    const onState = api.onWaveformStateChanged.mock.calls[0][0] as (s: {
+      status: string;
+      processed?: number;
+      total?: number;
+    }) => void;
+    const onProgress = api.onWaveformProgress.mock.calls[0][0] as (p: {
+      processed: number;
+      total: number;
+    }) => void;
+
+    onState({ status: "running", processed: 0, total: 10 });
+    onProgress({ processed: 4, total: 10 });
+    expect(app.waveformStatus).toEqual({
+      status: "running",
+      processed: 4,
+      total: 10,
+    });
+
+    // Progress arriving after idle is ignored (no resurrecting the bar).
+    onState({ status: "idle" });
+    onProgress({ processed: 9, total: 10 });
+    expect(app.waveformStatus).toEqual({ status: "idle" });
   });
 });
 

--- a/src/shared/state.test.ts
+++ b/src/shared/state.test.ts
@@ -24,6 +24,7 @@ const { api } = vi.hoisted(() => {
     getScanStatus: vi.fn(),
     onScanProgress: vi.fn(),
     onScanStateChanged: vi.fn(),
+    onWaveformReady: vi.fn(),
     listAudioDevices: vi.fn(),
     getMainDevice: vi.fn(),
     setMainDevice: vi.fn(),
@@ -518,6 +519,36 @@ describe("AppState waveform", () => {
     expect(app.cueWaveform).toEqual([5, 6, 7]);
     app.cueStop();
     expect(app.cueWaveform).toBeNull();
+  });
+
+  it("refetches on waveform-ready for the loaded track", async () => {
+    // Track loads before its waveform is computed → first fetch is empty.
+    api.getWaveform.mockResolvedValue(null);
+    app.playNow(t(7));
+    await flushAsync();
+    expect(app.waveform).toBeNull();
+
+    // Background worker finishes → the ready callback refetches, now populated.
+    api.getWaveform.mockResolvedValue([1, 2, 3]);
+    const onReady = api.onWaveformReady.mock.calls[0][0] as (
+      id: number,
+    ) => void;
+    onReady(7);
+    await flushAsync();
+    expect(app.waveform).toEqual([1, 2, 3]);
+  });
+
+  it("ignores waveform-ready for a track that is not loaded", async () => {
+    api.getWaveform.mockResolvedValue(null);
+    app.playNow(t(7));
+    await flushAsync();
+    api.getWaveform.mockClear();
+
+    const onReady = api.onWaveformReady.mock.calls[0][0] as (
+      id: number,
+    ) => void;
+    onReady(999);
+    expect(api.getWaveform).not.toHaveBeenCalled();
   });
 });
 

--- a/src/shared/state.test.ts
+++ b/src/shared/state.test.ts
@@ -7,6 +7,7 @@ const { api } = vi.hoisted(() => {
     search: vi.fn(),
     getTrack: vi.fn(),
     getTracksByIds: vi.fn(),
+    getWaveform: vi.fn(),
     loadSession: vi.fn(),
     saveSession: vi.fn(),
     trackPlayed: vi.fn(),
@@ -103,6 +104,7 @@ function resetApi(): void {
   api.cancelScan.mockResolvedValue(undefined);
   api.getScanStatus.mockResolvedValue({ status: "idle", lastResult: null });
   api.getTracksByIds.mockResolvedValue([]);
+  api.getWaveform.mockResolvedValue(null);
   api.loadSession.mockResolvedValue({
     state: {
       playlistIds: [],
@@ -463,6 +465,59 @@ describe("AppState playback control", () => {
     expect(app.progressPct).toBe(25);
     app.duration = 0;
     expect(app.progressPct).toBe(0);
+  });
+});
+
+describe("AppState waveform", () => {
+  let app: AppState;
+  beforeEach(() => {
+    resetApi();
+    app = makeApp().app;
+  });
+
+  it("loads and stores the waveform when a track starts", async () => {
+    api.getWaveform.mockResolvedValue([0, 128, 255]);
+    app.playNow(t(7));
+    expect(api.getWaveform).toHaveBeenCalledWith(7);
+    await flushAsync();
+    expect(app.waveform).toEqual([0, 128, 255]);
+  });
+
+  it("clears the waveform on stop", async () => {
+    api.getWaveform.mockResolvedValue([1, 2, 3]);
+    app.playNow(t(7));
+    await flushAsync();
+    app.stop();
+    expect(app.waveform).toBeNull();
+  });
+
+  it("ignores a stale fetch after the track changed", async () => {
+    // First track's fetch is slow; second resolves immediately. The stale
+    // first result must not clobber the current waveform.
+    let resolveFirst!: (v: number[] | null) => void;
+    api.getWaveform.mockImplementationOnce(
+      () => new Promise((r) => (resolveFirst = r)),
+    );
+    api.getWaveform.mockResolvedValueOnce([9, 9, 9]);
+
+    app.playNow(t(1));
+    app.playNow(t(2));
+    await flushAsync();
+    expect(app.waveform).toEqual([9, 9, 9]);
+
+    resolveFirst([1, 1, 1]);
+    await flushAsync();
+    expect(app.waveform).toEqual([9, 9, 9]);
+  });
+
+  it("loads the cue waveform independently", async () => {
+    api.getWaveform.mockResolvedValue([5, 6, 7]);
+    app.cueLoadAndPlay(t(3));
+    expect(api.getWaveform).toHaveBeenCalledWith(3);
+    await flushAsync();
+    expect(app.cueWaveform).toEqual([5, 6, 7]);
+    app.cueStop();
+    expect(app.cueWaveform).toBeNull();
   });
 });
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -1134,11 +1134,19 @@ body {
 
 /* --- Scan Status Bar --- */
 
-#scan-status-bar {
+/* Stack of status bars pinned to the window bottom: the metadata-scan bar and,
+   under it, the background waveform-pass bar. */
+#status-bars {
   position: fixed;
   left: 0;
   right: 0;
   bottom: 0;
+  display: flex;
+  flex-direction: column;
+  z-index: 90;
+}
+
+.scan-status-bar {
   display: flex;
   align-items: center;
   gap: 12px;
@@ -1146,7 +1154,6 @@ body {
   background: var(--bg-secondary);
   border-top: 1px solid var(--border);
   font-size: 13px;
-  z-index: 90;
 }
 
 #scan-status-bar[data-state="error"] {

--- a/src/styles.css
+++ b/src/styles.css
@@ -625,10 +625,23 @@ body {
 .waveform .wf-base rect {
   fill: var(--text-secondary);
   opacity: 0.35;
+  transition: opacity 0.1s ease;
 }
 
 .waveform .wf-played rect {
   fill: var(--accent);
+}
+
+/* Seek preview marker following the cursor. */
+.waveform .wf-cursor {
+  stroke: var(--accent-hover);
+  stroke-width: 1.5;
+}
+
+/* Brighten the unplayed curve while hovering the bar — signals it is seekable. */
+#progress-bar:hover .waveform .wf-base rect,
+.cue-progress-bar:hover .waveform .wf-base rect {
+  opacity: 0.6;
 }
 
 /* Seek bar tall enough to hold the waveform. `overflow: hidden` clips the

--- a/src/styles.css
+++ b/src/styles.css
@@ -571,12 +571,21 @@ body {
 }
 
 .cue-progress-bar {
-  height: 12px;
-  padding: 5px 0;
-  background: var(--border);
-  background-clip: content-box;
+  height: 32px;
+  background: var(--bg-secondary);
   cursor: pointer;
   position: relative;
+  overflow: hidden;
+}
+
+.cue-progress-bar::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 2px;
+  background: var(--border);
 }
 
 .cue-progress-fill {
@@ -584,14 +593,14 @@ body {
   background: var(--accent);
   width: 0%;
   position: absolute;
-  top: 5px;
+  bottom: 0;
   left: 0;
   transition: width 0.1s linear;
+  z-index: 1;
 }
 
 .cue-progress-bar:hover .cue-progress-fill {
-  height: 4px;
-  top: 4px;
+  height: 3px;
 }
 
 .cue-error {
@@ -600,15 +609,15 @@ body {
   color: #ff6666;
 }
 
-/* Amplitude curve behind a seek bar. Fills the bar's content area (inset by the
-   5px vertical padding) so it sits inside the track; the progress-fill line and
-   buffering shimmer paint on top as later siblings. */
+/* Amplitude curve behind a seek bar. Pinned to fill the bar exactly (explicit
+   100% sizing, not the SVG's intrinsic viewBox ratio) and clipped by the bar's
+   `overflow: hidden`. The progress-fill line and buffering shimmer paint on top
+   as later siblings. */
 .waveform {
   position: absolute;
-  top: 5px;
-  bottom: 5px;
-  left: 0;
-  right: 0;
+  inset: 0;
+  width: 100%;
+  height: 100%;
   display: block;
   pointer-events: none;
 }
@@ -622,38 +631,51 @@ body {
   fill: var(--accent);
 }
 
+/* Seek bar tall enough to hold the waveform. `overflow: hidden` clips the
+   amplitude curve to the bar so it can never spill onto the library below. */
 #progress-bar {
-  height: 14px;
-  padding: 5px 0;
-  background: var(--border);
-  background-clip: content-box;
+  height: 40px;
+  background: var(--bg-secondary);
   cursor: pointer;
   position: relative;
+  overflow: hidden;
+}
+
+/* Dim baseline track at the very bottom — the fallback when a track has no
+   waveform (e.g. jingles/commercials). */
+#progress-bar::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 2px;
+  background: var(--border);
 }
 
 #progress-fill {
-  height: 4px;
+  height: 2px;
   background: var(--accent);
   width: 0%;
   position: absolute;
-  top: 5px;
+  bottom: 0;
   left: 0;
   transition: width 0.1s linear;
+  z-index: 1;
 }
 
 #progress-bar:hover #progress-fill {
-  height: 6px;
-  top: 4px;
+  height: 3px;
 }
 
 /* Buffering: indeterminate shimmer sweeping the track — neutral loading, not a fault. */
 #progress-bar.buffering::after {
   content: "";
   position: absolute;
-  top: 5px;
+  bottom: 0;
   left: 0;
   right: 0;
-  height: 4px;
+  height: 2px;
   background: linear-gradient(
     90deg,
     transparent 0%,

--- a/src/styles.css
+++ b/src/styles.css
@@ -600,6 +600,28 @@ body {
   color: #ff6666;
 }
 
+/* Amplitude curve behind a seek bar. Fills the bar's content area (inset by the
+   5px vertical padding) so it sits inside the track; the progress-fill line and
+   buffering shimmer paint on top as later siblings. */
+.waveform {
+  position: absolute;
+  top: 5px;
+  bottom: 5px;
+  left: 0;
+  right: 0;
+  display: block;
+  pointer-events: none;
+}
+
+.waveform .wf-base rect {
+  fill: var(--text-secondary);
+  opacity: 0.35;
+}
+
+.waveform .wf-played rect {
+  fill: var(--accent);
+}
+
 #progress-bar {
   height: 14px;
   padding: 5px 0;

--- a/src/styles.css
+++ b/src/styles.css
@@ -1134,16 +1134,15 @@ body {
 
 /* --- Scan Status Bar --- */
 
-/* Stack of status bars pinned to the window bottom: the metadata-scan bar and,
-   under it, the background waveform-pass bar. */
+/* Stack of status bars at the window bottom: the metadata-scan bar and, under
+   it, the background waveform-pass bar. A normal flow child of the #app column
+   (not fixed) so it reserves its own row and shrinks #content instead of
+   overlaying the library/playlist lists — otherwise the last rows hide behind
+   it. Rendered only while a bar is visible, so it costs no space when idle. */
 #status-bars {
-  position: fixed;
-  left: 0;
-  right: 0;
-  bottom: 0;
+  flex: 0 0 auto;
   display: flex;
   flex-direction: column;
-  z-index: 90;
 }
 
 .scan-status-bar {


### PR DESCRIPTION
Closes #234.

Renders a track's waveform behind the main and cue deck seek bars so a DJ can see song structure (intro / drop / breakdown) and seek accurately.

## Approach
Waveforms are computed **once per track by a background worker** (decoupled from the fast tag-metadata scan), stored per track in the DB, and rendered on **both decks**. A per-track `waveform-ready` event refreshes the deck currently showing the track.

## Backend
- `audio/waveform.rs` (new) — `compute_peaks`: rodio decode → **single pass** into an overflow-merging mip buffer (bounded RAM, no upfront sample total) → downsample to 400 **RMS-energy** buckets via a float ratio → per-track normalise to the loudest bucket → quantise to one byte each (~400-byte blob).
  - RMS (perceived energy), not raw peak: heavily-limited masters pin max-abs near full-scale and hide structure; RMS tracks where energy actually rises/falls.
  - No `duration_hint`: the float-ratio downsample is codec/VBR-agnostic — fixes trailing-empty-bucket drift (blank outro) and end-spikes on VBR MP3/AAC, and drops the old second counting-pass decode.
- `library/waveform_scan.rs` (new) — background `WaveformJob`: single-flight, cancelable, drains `tracks_missing_waveform` in a loop. Fans decode across a **core-aware pool** (`cores - 2`, clamped `2..=8`) since decode is CPU-bound and per-file independent; reserves 2 cores so playback/UI stay smooth mid-set. Emits throttled `waveform-progress` / `waveform-state-changed` for a second progress bar. Debug-level per-file `decode/write` timing.
- `db.rs` — migration adds nullable `waveform BLOB`; `get_waveform`/`set_waveform`/`tracks_missing_waveform`. `synchronous = NORMAL` + `busy_timeout` at open so per-track writes don't fsync (safe under WAL; waveforms are recomputable).
- `lib.rs` — `get_waveform` command (deck-agnostic), registered.

## Frontend
- `Waveform.svelte` (new) — SVG bars drawn once per track; only the clip width tracks `progressPct` (cheap on the 10 Hz tick). Hover shows a seek-preview marker + brighten. `pointer-events` wired so seeking still works.
- `state.svelte.ts` — `waveform`/`cueWaveform` state, fetched on track load for both decks + session restore, cleared on stop, stale-fetch guard; live-refresh on `waveform-ready`.
- `api.ts` `getWaveform`; wired into `NowPlaying.svelte` + `CueDeck.svelte`; scan/waveform status bars flow in layout (no longer overlay the library/playlist lists); CSS in `styles.css`.

## Notes
- Waveform computation is a **full audio decode per track**, so a first backfill of a large library takes a while — but it runs in the background off the metadata scan, parallelised across cores, and is one-time (results cached in the DB).
- Changing the curve algorithm invalidates previously-stored blobs; clear them (`UPDATE tracks SET waveform = NULL;`) to regenerate with the current RMS path.

## Verification
- `cargo test` 92 pass · clippy `-D warnings` clean · cargo fmt clean
- `pnpm test` 118 pass · prettier clean

Not run: live app visual check (Tauri desktop needs an audio device + library).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
