### PR TITLE
fix(deck): outage recovery — auto-retry reads, no skip after manual next

### DIFF
--- a/src/shared/state.svelte.ts
+++ b/src/shared/state.svelte.ts
@@ -355,6 +355,11 @@ export class AppState {
   }
 
   private setCurrent(track: Track): void {
+    // Any explicit track change (manual next/prev, playIndex, session restore)
+    // supersedes a pending outage retry. Without this, an armed retry timer —
+    // or a cache-state arriving while awaitingNetwork is still set — fires after
+    // the new track loads and advances again, skipping it.
+    this.clearNetRetry();
     this.currentTrack = track;
     this.duration = track.duration ?? 0;
     this.currentTime = 0;
@@ -796,6 +801,11 @@ export class AppState {
     this.netRetryAttempt += 1;
     this.netRetryTimer = setTimeout(() => {
       this.netRetryTimer = null;
+      // Re-push the prefetch window so the cache worker retries its reads — it
+      // only wakes on set_window, so without this an outage never recovers on
+      // its own (the share could come back but nothing would re-read it). On a
+      // successful read the resulting cache-state advances playback.
+      this.updatePrefetch();
       this.advancePlan(true);
     }, NET_RETRY_BACKOFFS_MS[i]);
   }

--- a/src/shared/state.test.ts
+++ b/src/shared/state.test.ts
@@ -595,6 +595,59 @@ describe("AppState outage recovery (skip-to-cached)", () => {
     expect(app.currentTrack?.id).toBe(2);
   });
 
+  it("manual next during an outage wait cancels the pending retry (no skip after load)", async () => {
+    vi.useFakeTimers();
+    try {
+      app.addToPlaylist(t(1));
+      app.addToPlaylist(t(2));
+      app.addToPlaylist(t(3));
+      app.playIndex(0); // current = 1, playlist = [2, 3]
+      await vi.advanceTimersByTimeAsync(0);
+      mock.emitCacheState([9]); // nothing upcoming cached → outage
+      mock.emitEnded();
+      await vi.advanceTimersByTimeAsync(0);
+      expect(app.awaitingNetwork).toBe(true);
+      expect(app.currentTrack?.id).toBe(1);
+
+      // User clicks next → track 2 loads directly; the pending retry is dropped.
+      app.next();
+      await vi.advanceTimersByTimeAsync(0);
+      expect(app.currentTrack?.id).toBe(2);
+      expect(app.awaitingNetwork).toBe(false);
+
+      // Share recovers: track 3 is cached and the old backoff would have fired.
+      // Neither must skip the track the user just started.
+      mock.emitCacheState([3]);
+      await vi.advanceTimersByTimeAsync(6000);
+      expect(app.currentTrack?.id).toBe(2);
+      expect(mock.lastLoadedId).toBe(2);
+      expect(app.playlist.map(pid)).toEqual([3]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("re-kicks prefetch on each retry tick so recovery needs no manual next", async () => {
+    vi.useFakeTimers();
+    try {
+      app.addToPlaylist(t(1));
+      app.addToPlaylist(t(2));
+      app.playIndex(0); // current = 1, playlist = [2]
+      await vi.advanceTimersByTimeAsync(0);
+      mock.emitCacheState([9]); // nothing upcoming cached → outage
+      mock.emitEnded();
+      await vi.advanceTimersByTimeAsync(0);
+      expect(app.awaitingNetwork).toBe(true);
+      api.prefetch.mockClear();
+
+      // The backoff tick re-pushes the prefetch window to wake the cache worker.
+      await vi.advanceTimersByTimeAsync(1000);
+      expect(api.prefetch).toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("prefetch-failed flags the share unreachable while playback continues, cleared on cache-state", async () => {
     app.addToPlaylist(t(1));
     app.addToPlaylist(t(2));


### PR DESCRIPTION
Two bugs in the network-outage playback-advancement machine (`state.svelte.ts`).

## 1. Recovery stalled until manual next
A pending net-retry tick only rescheduled itself — it never re-woke the prefetch worker, which retries reads only on `set_window` (`updatePrefetch`). During the idle outage wait nothing calls that, so when the share came back nothing re-read it and playback never resumed on its own. Clicking **next** happened to push a new prefetch window, which is why it "worked" only after next.

Fix: the retry tick now re-pushes the prefetch window. On reconnect a read succeeds → `cache-state` → playback resumes automatically.

## 2. Skip after manual next
`next` / `prev` / `playIndex` → `setCurrent` never cleared the armed retry. After the picked track loaded, the stale backoff timer (or a `cache-state` arriving while `awaitingNetwork` was still set) fired `advancePlan` and advanced **again**, skipping the track the user just started.

Fix: `setCurrent` clears the pending retry first, so an explicit track change supersedes any queued outage advance.

## Tests
Two regression tests (fake timers): manual next during an outage wait cancels the retry (no skip on recovery), and the retry tick re-kicks prefetch. `pnpm test` 111 pass, svelte-check clean.

Split out of #252 (waveform feature) — orthogonal fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)