### PR TITLE
fix(deck): self-healing audio output — launch stream-open failure can't mute the session

### DIFF
--- a/src-tauri/src/audio/devices.rs
+++ b/src-tauri/src/audio/devices.rs
@@ -57,24 +57,6 @@ pub fn resolve_device(reference: &DeviceRef) -> Option<cpal::Device> {
     found_by_name.or(found_by_desc)
 }
 
-/// Resolve `main_device` config — falls back to the system default
-/// device when the reference is `None` or no match exists.
-pub fn resolve_main_device(reference: Option<&DeviceRef>) -> Option<cpal::Device> {
-    match reference {
-        None => None, // None signals "use rodio's open_default_stream"
-        Some(r) => match resolve_device(r) {
-            Some(d) => Some(d),
-            None => {
-                log::warn!(
-                    "main device '{}' not found among current outputs; falling back to default",
-                    r.description
-                );
-                None
-            }
-        },
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -93,22 +75,5 @@ mod tests {
             description: "definitely-not-a-real-device-xyz123".to_string(),
         };
         assert!(resolve_device(&reference).is_none());
-    }
-
-    #[test]
-    fn resolve_main_device_with_none_returns_none() {
-        // None reference means "use system default" — caller passes the
-        // resolved Option<Device> into rodio, which treats None as default.
-        assert!(resolve_main_device(None).is_none());
-    }
-
-    #[test]
-    fn resolve_main_device_with_unknown_falls_back_to_none() {
-        let reference = DeviceRef {
-            name: "ghost-device".to_string(),
-            description: "ghost-device".to_string(),
-        };
-        // Unknown device → caller falls back to default (None).
-        assert!(resolve_main_device(Some(&reference)).is_none());
     }
 }

--- a/src-tauri/src/audio/player.rs
+++ b/src-tauri/src/audio/player.rs
@@ -9,6 +9,8 @@ use std::time::{Duration, Instant};
 use tauri::{AppHandle, Emitter};
 
 use super::cache::Cache;
+use super::devices::resolve_device;
+use crate::persist::config::DeviceRef;
 
 const TICK_INTERVAL: Duration = Duration::from_millis(50);
 const TIME_EMIT_INTERVAL: Duration = Duration::from_millis(100);
@@ -93,7 +95,7 @@ pub struct PlayerHandle {
 impl PlayerHandle {
     pub fn spawn(
         app: AppHandle,
-        device: Option<cpal::Device>,
+        device: Option<DeviceRef>,
         event_prefix: &'static str,
         cache: Arc<Cache>,
     ) -> Self {
@@ -165,15 +167,80 @@ fn open_stream(device: Option<cpal::Device>) -> Result<OutputStream> {
     }
 }
 
+/// Resolve the configured device (if any) and open an output stream + sink on
+/// the audio thread. A missing or unopenable configured device is **not fatal**:
+/// it falls back to the system default, so a device that is renamed, unplugged,
+/// or briefly held/absent at launch does not permanently disable playback (#259).
+fn open_audio(device: &Option<DeviceRef>, volume: f32) -> Result<(OutputStream, Sink)> {
+    let resolved = match device {
+        Some(r) => match resolve_device(r) {
+            Some(d) => Some(d),
+            None => {
+                log::warn!(
+                    "audio device '{}' not found among current outputs; using default",
+                    r.description
+                );
+                None
+            }
+        },
+        None => None,
+    };
+
+    let had_specific = resolved.is_some();
+    let stream = match open_stream(resolved) {
+        Ok(s) => s,
+        // A configured device that resolves but will not open (e.g. held
+        // exclusively by another app) falls back to the default device rather
+        // than failing the whole command.
+        Err(e) if had_specific => {
+            log::warn!("configured audio device failed to open ({e}); falling back to default");
+            open_stream(None).context("open default output")?
+        }
+        Err(e) => return Err(e).context("open default output"),
+    };
+    let sink = Sink::connect_new(stream.mixer());
+    sink.set_volume(volume);
+    Ok((stream, sink))
+}
+
+/// Ensure the output stream+sink is open, (re)opening it on demand. Returns
+/// `None` — after emitting an `error` event — when no audio device can be
+/// opened at all, so the caller drops the current command instead of the whole
+/// worker thread exiting. A dead worker silently discards every later command
+/// (the `PlayerHandle::send` channel error is swallowed), disabling playback
+/// for the rest of the session; see issue #259.
+fn ensure_output<'a>(
+    output: &'a mut Option<(OutputStream, Sink)>,
+    device: &Option<DeviceRef>,
+    volume: f32,
+    app: &AppHandle,
+    topics: &Topics,
+) -> Option<&'a mut (OutputStream, Sink)> {
+    if output.is_none() {
+        match open_audio(device, volume) {
+            Ok(o) => *output = Some(o),
+            Err(e) => {
+                log::error!("player: no audio output available: {}", e);
+                let _ = app.emit(&topics.error, format!("audio output unavailable: {}", e));
+                return None;
+            }
+        }
+    }
+    output.as_mut()
+}
+
 fn run(
     app: AppHandle,
     rx: std::sync::mpsc::Receiver<Cmd>,
-    device: Option<cpal::Device>,
+    device: Option<DeviceRef>,
     topics: &Topics,
     cache: Arc<Cache>,
 ) -> Result<()> {
-    let stream = open_stream(device)?;
-    let mut sink = Sink::connect_new(stream.mixer());
+    // Output is opened lazily and re-opened on demand: a stream-open failure at
+    // launch (device not ready yet, briefly held, momentarily gone) must not
+    // kill the worker, which would silently disable playback for the whole
+    // session. The next command that needs audio retries the open (#259).
+    let mut output: Option<(OutputStream, Sink)> = None;
     // Completed background reads arrive here; `load_tx` is cloned per read.
     let (load_tx, load_rx) = channel::<LoadMsg>();
     let mut last_time_emit = Instant::now()
@@ -196,7 +263,7 @@ fn run(
         loop {
             match rx.try_recv() {
                 Ok(cmd) => apply(
-                    &app, &stream, &mut sink, &mut state, topics, &load_tx, &cache, cmd,
+                    &app, &mut output, &device, &mut state, topics, &load_tx, &cache, cmd,
                 ),
                 Err(std::sync::mpsc::TryRecvError::Empty) => break,
                 Err(std::sync::mpsc::TryRecvError::Disconnected) => return Ok(()),
@@ -205,7 +272,7 @@ fn run(
 
         // Drain any completed background reads.
         while let Ok(msg) = load_rx.try_recv() {
-            apply_load(&app, &stream, &mut sink, &mut state, topics, msg);
+            apply_load(&app, &mut output, &device, &mut state, topics, msg);
         }
 
         // Watchdog: a read that neither completed nor errored within the budget
@@ -215,16 +282,19 @@ fn run(
             handle_load_timeout(&app, &mut state, topics);
         }
 
-        if state.active && last_time_emit.elapsed() >= TIME_EMIT_INTERVAL {
-            last_time_emit = Instant::now();
-            let pos = state.seek_offset + sink.get_pos().as_secs_f64();
-            let _ = app.emit(&topics.time, pos);
-        }
+        // Time + ended detection are only meaningful with an open output.
+        if let Some((_, sink)) = output.as_ref() {
+            if state.active && last_time_emit.elapsed() >= TIME_EMIT_INTERVAL {
+                last_time_emit = Instant::now();
+                let pos = state.seek_offset + sink.get_pos().as_secs_f64();
+                let _ = app.emit(&topics.time, pos);
+            }
 
-        if state.active && !state.loading && sink.empty() {
-            state.active = false;
-            let _ = app.emit(&topics.pause_state, true);
-            let _ = app.emit(&topics.ended, ());
+            if state.active && !state.loading && sink.empty() {
+                state.active = false;
+                let _ = app.emit(&topics.pause_state, true);
+                let _ = app.emit(&topics.ended, ());
+            }
         }
 
         thread::sleep(TICK_INTERVAL);
@@ -234,8 +304,8 @@ fn run(
 #[allow(clippy::too_many_arguments)]
 fn apply(
     app: &AppHandle,
-    stream: &OutputStream,
-    sink: &mut Sink,
+    output: &mut Option<(OutputStream, Sink)>,
+    device: &Option<DeviceRef>,
     state: &mut State,
     topics: &Topics,
     load_tx: &Sender<LoadMsg>,
@@ -244,6 +314,14 @@ fn apply(
 ) {
     match cmd {
         Cmd::Load { id, path, duration } => {
+            // Open (or re-open) the output before committing to the load. If no
+            // device can be opened, surface it and drop the command — the worker
+            // stays alive so a later command retries the open (#259).
+            let Some((stream, sink)) = ensure_output(output, device, state.volume, app, topics)
+            else {
+                let _ = app.emit(&topics.load_failed, id);
+                return;
+            };
             // Stop current audio immediately; the new source arrives once the
             // background read completes.
             sink.stop();
@@ -292,6 +370,11 @@ fn apply(
             }
         }
         Cmd::Play => {
+            // Play is also a self-heal trigger: re-open the output if a launch
+            // failure left it closed. Drop silently if no device is available.
+            let Some((_, sink)) = ensure_output(output, device, state.volume, app, topics) else {
+                return;
+            };
             sink.play();
             // Only report playing if there is (or will be) something to play.
             if state.active || state.loading {
@@ -299,13 +382,18 @@ fn apply(
             }
         }
         Cmd::Pause => {
-            sink.pause();
+            // Nothing to pause without an open output; never open one just to pause.
+            if let Some((_, sink)) = output.as_mut() {
+                sink.pause();
+            }
             let _ = app.emit(&topics.pause_state, true);
         }
         Cmd::Stop => {
-            sink.stop();
-            *sink = Sink::connect_new(stream.mixer());
-            sink.set_volume(state.volume);
+            if let Some((stream, sink)) = output.as_mut() {
+                sink.stop();
+                *sink = Sink::connect_new(stream.mixer());
+                sink.set_volume(state.volume);
+            }
             // Invalidate any in-flight read.
             state.generation = state.generation.wrapping_add(1);
             state.active = false;
@@ -323,6 +411,10 @@ fn apply(
             let target = s.max(0.0);
             // Seek decodes from the in-RAM bytes — never re-reads the file.
             let Some(bytes) = state.current_bytes.clone() else {
+                return;
+            };
+            let Some((stream, sink)) = ensure_output(output, device, state.volume, app, topics)
+            else {
                 return;
             };
             let was_paused = sink.is_paused();
@@ -364,7 +456,10 @@ fn apply(
         Cmd::SetVolume(v) => {
             let clamped = v.clamp(0.0, 1.0);
             state.volume = clamped;
-            sink.set_volume(clamped);
+            // Remembered in `state.volume` and applied when the output next opens.
+            if let Some((_, sink)) = output.as_mut() {
+                sink.set_volume(clamped);
+            }
         }
     }
 }
@@ -373,8 +468,8 @@ fn apply(
 /// `Load`/`Stop`) are dropped.
 fn apply_load(
     app: &AppHandle,
-    _stream: &OutputStream,
-    sink: &mut Sink,
+    output: &mut Option<(OutputStream, Sink)>,
+    device: &Option<DeviceRef>,
     state: &mut State,
     topics: &Topics,
     msg: LoadMsg,
@@ -407,6 +502,15 @@ fn apply_load(
 
     match decode_bytes(bytes.clone()) {
         Ok((source, decoded_duration)) => {
+            // The output should already be open (Load opened it), but re-open
+            // defensively in case the device dropped while the read was in
+            // flight. Treat an unopenable output as a load failure.
+            let Some((_, sink)) = ensure_output(output, device, state.volume, app, topics) else {
+                reset_after_failure(state);
+                let _ = app.emit(&topics.load_failed, msg.id);
+                let _ = app.emit(&topics.pause_state, true);
+                return;
+            };
             let final_duration = msg.duration.or(decoded_duration);
             sink.append(source);
             sink.play();

--- a/src-tauri/src/audio/player.rs
+++ b/src-tauri/src/audio/player.rs
@@ -136,15 +136,33 @@ struct State {
 
 const AUDIO_BUFFER_FRAMES: u32 = 4096;
 
+fn stream_builder(device: &Option<cpal::Device>) -> Result<OutputStreamBuilder> {
+    match device {
+        Some(d) => OutputStreamBuilder::from_device(d.clone()).context("from_device"),
+        None => OutputStreamBuilder::from_default_device().context("from_default_device"),
+    }
+}
+
 fn open_stream(device: Option<cpal::Device>) -> Result<OutputStream> {
-    let builder = match device {
-        Some(d) => OutputStreamBuilder::from_device(d).context("from_device")?,
-        None => OutputStreamBuilder::from_default_device().context("from_default_device")?,
-    };
-    builder
+    // Prefer a fixed buffer size for predictable latency, but not every device
+    // (or host, e.g. CoreAudio) accepts `Fixed`. When it rejects the request the
+    // whole player thread would otherwise die at startup, so fall back to the
+    // device default buffer size instead of propagating the error.
+    match stream_builder(&device)?
         .with_buffer_size(cpal::BufferSize::Fixed(AUDIO_BUFFER_FRAMES))
         .open_stream()
-        .context("open_stream")
+    {
+        Ok(stream) => Ok(stream),
+        Err(e) => {
+            log::warn!(
+                "open_stream: fixed buffer {} rejected ({e}); retrying with default buffer size",
+                AUDIO_BUFFER_FRAMES
+            );
+            stream_builder(&device)?
+                .open_stream()
+                .context("open_stream")
+        }
+    }
 }
 
 fn run(

--- a/src-tauri/src/audio/player.rs
+++ b/src-tauri/src/audio/player.rs
@@ -306,7 +306,14 @@ fn run(
         loop {
             match rx.try_recv() {
                 Ok(cmd) => apply(
-                    &app, &mut output, &device, &mut state, topics, &load_tx, &cache, cmd,
+                    &app,
+                    &mut output,
+                    &device,
+                    &mut state,
+                    topics,
+                    &load_tx,
+                    &cache,
+                    cmd,
                 ),
                 Err(std::sync::mpsc::TryRecvError::Empty) => break,
                 Err(std::sync::mpsc::TryRecvError::Disconnected) => return Ok(()),
@@ -346,8 +353,16 @@ fn run(
                 if let Some(p) = state.pending_load.take() {
                     log::info!("player: audio output available; resuming deferred load");
                     start_load(
-                        &app, &mut output, &device, &mut state, topics, &load_tx, &cache, p.id,
-                        p.path, p.duration,
+                        &app,
+                        &mut output,
+                        &device,
+                        &mut state,
+                        topics,
+                        &load_tx,
+                        &cache,
+                        p.id,
+                        p.path,
+                        p.duration,
                     );
                 }
             }
@@ -463,7 +478,9 @@ fn apply(
 ) {
     match cmd {
         Cmd::Load { id, path, duration } => {
-            start_load(app, output, device, state, topics, load_tx, cache, id, path, duration);
+            start_load(
+                app, output, device, state, topics, load_tx, cache, id, path, duration,
+            );
         }
         Cmd::Play => {
             // Play is also a self-heal trigger: re-open the output if a launch
@@ -512,8 +529,7 @@ fn apply(
             let Some(bytes) = state.current_bytes.clone() else {
                 return;
             };
-            let Some((stream, sink)) = ensure_output(output, device, state, app, topics)
-            else {
+            let Some((stream, sink)) = ensure_output(output, device, state, app, topics) else {
                 return;
             };
             let was_paused = sink.is_paused();

--- a/src-tauri/src/audio/player.rs
+++ b/src-tauri/src/audio/player.rs
@@ -32,6 +32,20 @@ const READ_RETRY_BACKOFFS: [Duration; 3] = [
     Duration::from_millis(2000),
 ];
 
+/// While a load is deferred because no audio device could be opened, the worker
+/// retries opening the output on this cadence so playback self-heals without any
+/// user action (a stalled/absent device at launch — see issue #259).
+const OPEN_RETRY_INTERVAL: Duration = Duration::from_secs(2);
+
+/// A load that could not be started because no audio output was openable.
+/// Retained so the idle auto-retry loop can replay it once the device returns.
+#[derive(Clone)]
+struct PendingLoad {
+    id: i64,
+    path: PathBuf,
+    duration: Option<f64>,
+}
+
 /// Whole track file resident in RAM. Shared (cheaply cloned) between the
 /// playing `Decoder` and the retained copy used for seeking, so playback and
 /// seek never touch the (possibly networked) filesystem again after load.
@@ -134,6 +148,12 @@ struct State {
     /// `Load` and `Stop`; background reads carry the token they were issued for.
     generation: u64,
     volume: f32,
+    /// A load deferred because no audio output could be opened. The idle loop
+    /// retries the open and replays this load once a device is available (#259).
+    pending_load: Option<PendingLoad>,
+    /// Last time the idle loop attempted to (re)open a failed output. Paces the
+    /// retry to `OPEN_RETRY_INTERVAL`.
+    last_open_retry: Option<Instant>,
 }
 
 const AUDIO_BUFFER_FRAMES: u32 = 4096;
@@ -257,6 +277,8 @@ fn run(
         load_start: None,
         generation: 0,
         volume: 1.0,
+        pending_load: None,
+        last_open_retry: None,
     };
 
     loop {
@@ -282,6 +304,30 @@ fn run(
             handle_load_timeout(&app, &mut state, topics);
         }
 
+        // Idle auto-retry: a load deferred because the audio device could not be
+        // opened waits here. Retry the open on a timer (quietly — the initial
+        // failure already surfaced an error), and replay the load the moment an
+        // output becomes available, whether reopened here or by a command above
+        // (#259). No user action required.
+        if state.pending_load.is_some() {
+            if output.is_none() && open_retry_due(state.last_open_retry, Instant::now()) {
+                state.last_open_retry = Some(Instant::now());
+                match open_audio(&device, state.volume) {
+                    Ok(o) => output = Some(o),
+                    Err(e) => log::debug!("player: output reopen retry failed: {}", e),
+                }
+            }
+            if output.is_some() {
+                if let Some(p) = state.pending_load.take() {
+                    log::info!("player: audio output available; resuming deferred load");
+                    start_load(
+                        &app, &mut output, &device, &mut state, topics, &load_tx, &cache, p.id,
+                        p.path, p.duration,
+                    );
+                }
+            }
+        }
+
         // Time + ended detection are only meaningful with an open output.
         if let Some((_, sink)) = output.as_ref() {
             if state.active && last_time_emit.elapsed() >= TIME_EMIT_INTERVAL {
@@ -301,6 +347,84 @@ fn run(
     }
 }
 
+/// Start loading a track: (re)open the output, stop current audio, and kick off
+/// the background read (or route a cache hit). If no audio device can be opened,
+/// the load is *deferred* — stored in `state.pending_load` for the idle loop to
+/// replay once a device returns — rather than dropped, so playback self-heals
+/// without user action (#259).
+#[allow(clippy::too_many_arguments)]
+fn start_load(
+    app: &AppHandle,
+    output: &mut Option<(OutputStream, Sink)>,
+    device: &Option<DeviceRef>,
+    state: &mut State,
+    topics: &Topics,
+    load_tx: &Sender<LoadMsg>,
+    cache: &Arc<Cache>,
+    id: i64,
+    path: PathBuf,
+    duration: Option<f64>,
+) {
+    let Some((stream, sink)) = ensure_output(output, device, state.volume, app, topics) else {
+        // No device yet: remember the intent and let the idle loop retry the
+        // open. `ensure_output` already emitted the error; keep the buffering
+        // indicator up while we wait for the device.
+        state.pending_load = Some(PendingLoad { id, path, duration });
+        state.last_open_retry = Some(Instant::now());
+        state.current_id = Some(id);
+        let _ = app.emit(&topics.buffering, true);
+        return;
+    };
+    state.pending_load = None;
+
+    // Stop current audio immediately; the new source arrives once the
+    // background read completes.
+    sink.stop();
+    *sink = Sink::connect_new(stream.mixer());
+    sink.set_volume(state.volume);
+
+    state.generation = state.generation.wrapping_add(1);
+    state.current_id = Some(id);
+    state.current_path = Some(path.clone());
+    state.current_duration = duration;
+    state.current_bytes = None;
+    state.seek_offset = 0.0;
+    state.active = false;
+    state.loading = true;
+    state.load_start = Some(Instant::now());
+    let _ = app.emit(&topics.buffering, true);
+
+    let generation = state.generation;
+    let tx = load_tx.clone();
+    if let Some(bytes) = cache.get(id) {
+        // Cache hit: route the resident bytes through the same
+        // completion path as a background read — no filesystem access.
+        let _ = tx.send(LoadMsg {
+            generation,
+            id,
+            duration,
+            bytes: Ok(bytes),
+        });
+    } else {
+        // Miss: read the whole file off the worker thread so a
+        // slow/networked read never blocks transport commands. One read
+        // is in flight per deck at a time — a newer `Load` bumps
+        // `generation`, so a stale read's result is discarded rather
+        // than another thread being blocked on.
+        thread::spawn(move || {
+            // Retry transient failures with backoff; hangs are the
+            // watchdog's job (handled in the worker loop, not here).
+            let bytes = read_with_retry(|| read_file(&path), thread::sleep);
+            let _ = tx.send(LoadMsg {
+                generation,
+                id,
+                duration,
+                bytes,
+            });
+        });
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 fn apply(
     app: &AppHandle,
@@ -314,60 +438,7 @@ fn apply(
 ) {
     match cmd {
         Cmd::Load { id, path, duration } => {
-            // Open (or re-open) the output before committing to the load. If no
-            // device can be opened, surface it and drop the command — the worker
-            // stays alive so a later command retries the open (#259).
-            let Some((stream, sink)) = ensure_output(output, device, state.volume, app, topics)
-            else {
-                let _ = app.emit(&topics.load_failed, id);
-                return;
-            };
-            // Stop current audio immediately; the new source arrives once the
-            // background read completes.
-            sink.stop();
-            *sink = Sink::connect_new(stream.mixer());
-            sink.set_volume(state.volume);
-
-            state.generation = state.generation.wrapping_add(1);
-            state.current_id = Some(id);
-            state.current_path = Some(path.clone());
-            state.current_duration = duration;
-            state.current_bytes = None;
-            state.seek_offset = 0.0;
-            state.active = false;
-            state.loading = true;
-            state.load_start = Some(Instant::now());
-            let _ = app.emit(&topics.buffering, true);
-
-            let generation = state.generation;
-            let tx = load_tx.clone();
-            if let Some(bytes) = cache.get(id) {
-                // Cache hit: route the resident bytes through the same
-                // completion path as a background read — no filesystem access.
-                let _ = tx.send(LoadMsg {
-                    generation,
-                    id,
-                    duration,
-                    bytes: Ok(bytes),
-                });
-            } else {
-                // Miss: read the whole file off the worker thread so a
-                // slow/networked read never blocks transport commands. One read
-                // is in flight per deck at a time — a newer `Load` bumps
-                // `generation`, so a stale read's result is discarded rather
-                // than another thread being blocked on.
-                thread::spawn(move || {
-                    // Retry transient failures with backoff; hangs are the
-                    // watchdog's job (handled in the worker loop, not here).
-                    let bytes = read_with_retry(|| read_file(&path), thread::sleep);
-                    let _ = tx.send(LoadMsg {
-                        generation,
-                        id,
-                        duration,
-                        bytes,
-                    });
-                });
-            }
+            start_load(app, output, device, state, topics, load_tx, cache, id, path, duration);
         }
         Cmd::Play => {
             // Play is also a self-heal trigger: re-open the output if a launch
@@ -404,6 +475,9 @@ fn apply(
             state.current_duration = None;
             state.current_bytes = None;
             state.seek_offset = 0.0;
+            // Stop cancels a deferred load too — the user no longer wants it.
+            state.pending_load = None;
+            state.last_open_retry = None;
             let _ = app.emit(&topics.buffering, false);
             let _ = app.emit(&topics.pause_state, true);
         }
@@ -541,6 +615,8 @@ fn reset_after_failure(state: &mut State) {
     state.current_duration = None;
     state.current_bytes = None;
     state.seek_offset = 0.0;
+    state.pending_load = None;
+    state.last_open_retry = None;
 }
 
 /// Decide whether an in-flight read has exceeded the watchdog budget. Pure
@@ -548,6 +624,16 @@ fn reset_after_failure(state: &mut State) {
 /// A read is timed out only while `loading` is true, a `load_start` is recorded,
 /// and at least `READ_WATCHDOG_TIMEOUT` has elapsed. When a result has arrived
 /// the worker sets `loading = false`, so this returns false.
+/// Decide whether the idle loop should attempt another output-open. Pure (clock
+/// via `now`) so it is unit-testable. Fires immediately the first time
+/// (`None`), then no more often than `OPEN_RETRY_INTERVAL`.
+fn open_retry_due(last_open_retry: Option<Instant>, now: Instant) -> bool {
+    match last_open_retry {
+        None => true,
+        Some(last) => now.saturating_duration_since(last) >= OPEN_RETRY_INTERVAL,
+    }
+}
+
 fn watchdog_timed_out(loading: bool, load_start: Option<Instant>, now: Instant) -> bool {
     match load_start {
         Some(start) if loading => now.saturating_duration_since(start) >= READ_WATCHDOG_TIMEOUT,
@@ -770,5 +856,23 @@ mod tests {
         assert!(!watchdog_timed_out(false, Some(start), after));
         // No read in flight: never a timeout.
         assert!(!watchdog_timed_out(true, None, after));
+    }
+
+    #[test]
+    fn open_retry_fires_first_time_then_paces() {
+        let start = Instant::now();
+        let before = start
+            .checked_add(OPEN_RETRY_INTERVAL - Duration::from_millis(1))
+            .unwrap();
+        let after = start
+            .checked_add(OPEN_RETRY_INTERVAL + Duration::from_millis(1))
+            .unwrap();
+
+        // Never attempted before: retry immediately.
+        assert!(open_retry_due(None, start));
+        // Within the interval since the last attempt: hold off.
+        assert!(!open_retry_due(Some(start), before));
+        // Interval elapsed: retry again.
+        assert!(open_retry_due(Some(start), after));
     }
 }

--- a/src-tauri/src/audio/player.rs
+++ b/src-tauri/src/audio/player.rs
@@ -86,6 +86,7 @@ struct Topics {
     error: String,
     buffering: String,
     load_failed: String,
+    output_unavailable: String,
 }
 
 impl Topics {
@@ -98,6 +99,7 @@ impl Topics {
             error: format!("{prefix}:error"),
             buffering: format!("{prefix}:buffering"),
             load_failed: format!("{prefix}:load-failed"),
+            output_unavailable: format!("{prefix}:output-unavailable"),
         }
     }
 }
@@ -154,6 +156,10 @@ struct State {
     /// Last time the idle loop attempted to (re)open a failed output. Paces the
     /// retry to `OPEN_RETRY_INTERVAL`.
     last_open_retry: Option<Instant>,
+    /// Whether the output is currently believed openable. Tracked so the
+    /// `output-unavailable` event fires only on transitions (no per-retry spam).
+    /// Optimistic at start — nothing is emitted until the first real failure.
+    output_ok: bool,
 }
 
 const AUDIO_BUFFER_FRAMES: u32 = 4096;
@@ -232,21 +238,35 @@ fn open_audio(device: &Option<DeviceRef>, volume: f32) -> Result<(OutputStream, 
 fn ensure_output<'a>(
     output: &'a mut Option<(OutputStream, Sink)>,
     device: &Option<DeviceRef>,
-    volume: f32,
+    state: &mut State,
     app: &AppHandle,
     topics: &Topics,
 ) -> Option<&'a mut (OutputStream, Sink)> {
     if output.is_none() {
-        match open_audio(device, volume) {
-            Ok(o) => *output = Some(o),
+        match open_audio(device, state.volume) {
+            Ok(o) => {
+                *output = Some(o);
+                report_output(app, topics, state, true);
+            }
             Err(e) => {
                 log::error!("player: no audio output available: {}", e);
                 let _ = app.emit(&topics.error, format!("audio output unavailable: {}", e));
+                report_output(app, topics, state, false);
                 return None;
             }
         }
     }
     output.as_mut()
+}
+
+/// Emit an `output-unavailable` event only when the availability actually
+/// changes, so the idle retry loop's repeated failures don't spam the UI and a
+/// recovery reliably clears the banner.
+fn report_output(app: &AppHandle, topics: &Topics, state: &mut State, ok: bool) {
+    if state.output_ok != ok {
+        state.output_ok = ok;
+        let _ = app.emit(&topics.output_unavailable, !ok);
+    }
 }
 
 fn run(
@@ -279,6 +299,7 @@ fn run(
         volume: 1.0,
         pending_load: None,
         last_open_retry: None,
+        output_ok: true,
     };
 
     loop {
@@ -313,7 +334,11 @@ fn run(
             if output.is_none() && open_retry_due(state.last_open_retry, Instant::now()) {
                 state.last_open_retry = Some(Instant::now());
                 match open_audio(&device, state.volume) {
-                    Ok(o) => output = Some(o),
+                    Ok(o) => {
+                        output = Some(o);
+                        report_output(&app, topics, &mut state, true);
+                    }
+                    // Quiet: the initial failure already reported unavailable.
                     Err(e) => log::debug!("player: output reopen retry failed: {}", e),
                 }
             }
@@ -365,7 +390,7 @@ fn start_load(
     path: PathBuf,
     duration: Option<f64>,
 ) {
-    let Some((stream, sink)) = ensure_output(output, device, state.volume, app, topics) else {
+    let Some((stream, sink)) = ensure_output(output, device, state, app, topics) else {
         // No device yet: remember the intent and let the idle loop retry the
         // open. `ensure_output` already emitted the error; keep the buffering
         // indicator up while we wait for the device.
@@ -443,7 +468,7 @@ fn apply(
         Cmd::Play => {
             // Play is also a self-heal trigger: re-open the output if a launch
             // failure left it closed. Drop silently if no device is available.
-            let Some((_, sink)) = ensure_output(output, device, state.volume, app, topics) else {
+            let Some((_, sink)) = ensure_output(output, device, state, app, topics) else {
                 return;
             };
             sink.play();
@@ -487,7 +512,7 @@ fn apply(
             let Some(bytes) = state.current_bytes.clone() else {
                 return;
             };
-            let Some((stream, sink)) = ensure_output(output, device, state.volume, app, topics)
+            let Some((stream, sink)) = ensure_output(output, device, state, app, topics)
             else {
                 return;
             };
@@ -579,7 +604,7 @@ fn apply_load(
             // The output should already be open (Load opened it), but re-open
             // defensively in case the device dropped while the read was in
             // flight. Treat an unopenable output as a load failure.
-            let Some((_, sink)) = ensure_output(output, device, state.volume, app, topics) else {
+            let Some((_, sink)) = ensure_output(output, device, state, app, topics) else {
                 reset_after_failure(state);
                 let _ = app.emit(&topics.load_failed, msg.id);
                 let _ = app.emit(&topics.pause_state, true);

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -11,7 +11,7 @@ mod persist;
 mod playlist;
 
 use audio::cache::Cache;
-use audio::devices::{list_output_devices, resolve_device, resolve_main_device, DeviceInfo};
+use audio::devices::{list_output_devices, DeviceInfo};
 use audio::player::{Cmd, PlayerHandle};
 use broadcast::{service::default_now_playing_dir, BroadcastService};
 use library::db::{Db, LibraryStats, Track};
@@ -261,15 +261,11 @@ where
             .config
             .get_cue_device()
             .ok_or_else(|| "no cue device configured; pick one in Settings → Audio".to_string())?;
-        let device = resolve_device(&cue_ref).ok_or_else(|| {
-            format!(
-                "cue device '{}' not found among current outputs",
-                cue_ref.description
-            )
-        })?;
+        // The worker resolves the DeviceRef lazily and falls back to the default
+        // output, mirroring the main deck's self-healing open (#259).
         *guard = Some(PlayerHandle::spawn(
             state.app_handle.clone(),
-            Some(device),
+            Some(cue_ref),
             "cue",
             Arc::clone(&state.cache),
         ));
@@ -423,7 +419,11 @@ pub fn run() {
             let db = Db::open(&data_dir.join("diodedj.db"))?;
             let config = Config::open(&data_dir)?;
             let session = Session::open(&data_dir);
-            let main_device = resolve_main_device(config.get_main_device().as_ref());
+            // Pass the saved DeviceRef (not a pre-resolved device): the worker
+            // resolves it lazily on the audio thread and falls back to the
+            // system default, so a device unavailable at launch no longer kills
+            // playback for the whole session (#259).
+            let main_device = config.get_main_device();
             let cache = Cache::new(app.handle().clone());
             let main_deck = PlayerHandle::spawn(
                 app.handle().clone(),

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -11,9 +11,20 @@
   import { app } from "./shared/state.svelte";
 </script>
 
-{#if app.reconnecting}
+{#if app.outputUnavailable || app.cueOutputUnavailable || app.reconnecting}
   <div id="network-toast">
-    <ErrorBanner message="Reconnecting…" type="warning" />
+    {#if app.outputUnavailable}
+      <ErrorBanner
+        message="Audio output unavailable — retrying…"
+        type="error"
+      />
+    {/if}
+    {#if app.cueOutputUnavailable}
+      <ErrorBanner message="Cue output unavailable — retrying…" type="error" />
+    {/if}
+    {#if app.reconnecting}
+      <ErrorBanner message="Reconnecting…" type="warning" />
+    {/if}
   </div>
 {/if}
 
@@ -39,5 +50,9 @@
     transform: translateX(-50%);
     z-index: 1000;
     pointer-events: none;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    align-items: center;
   }
 </style>

--- a/src/features/deck/backend.ts
+++ b/src/features/deck/backend.ts
@@ -7,6 +7,7 @@ export type DeckEvent =
   | { type: "cache-state"; ids: number[] }
   | { type: "load-failed"; id: number }
   | { type: "prefetch-failed" }
+  | { type: "output-unavailable"; unavailable: boolean }
   | { type: "error"; message: string };
 
 export type DeckEventHandler = (event: DeckEvent) => void;

--- a/src/features/deck/nativeBackend.ts
+++ b/src/features/deck/nativeBackend.ts
@@ -60,6 +60,9 @@ export class NativeBackend implements DeckBackend {
       listen<null>(`${p}:prefetch-failed`, () =>
         this.emit({ type: "prefetch-failed" }),
       ),
+      listen<boolean>(`${p}:output-unavailable`, (e) =>
+        this.emit({ type: "output-unavailable", unavailable: e.payload }),
+      ),
     ]);
     this.unlisteners.push(...subs);
   }

--- a/src/shared/mockBackend.ts
+++ b/src/shared/mockBackend.ts
@@ -92,6 +92,10 @@ export class MockBackend implements DeckBackend {
     this.emit({ type: "prefetch-failed" });
   }
 
+  emitOutputUnavailable(unavailable: boolean): void {
+    this.emit({ type: "output-unavailable", unavailable });
+  }
+
   get lastLoadedId(): number | undefined {
     return this.loadedIds[this.loadedIds.length - 1];
   }

--- a/src/shared/state.svelte.ts
+++ b/src/shared/state.svelte.ts
@@ -86,6 +86,11 @@ export class AppState {
   // if the current in-RAM track keeps playing. Set by prefetch-failed events,
   // cleared by the next successful cache-state (a read succeeded).
   shareUnreachable = $state(false);
+  // True while the main deck cannot open an audio output device (none present,
+  // or the configured one won't open). The backend auto-retries every 2s and
+  // clears this on recovery. Distinct from a network outage: the device, not
+  // the media share, is the problem. See issue #259.
+  outputUnavailable = $state(false);
 
   // Cue deck (independent transport on a separate audio device)
   cueTrack = $state<Track | null>(null);
@@ -95,6 +100,9 @@ export class AppState {
   cueDuration = $state(0);
   cueVolume = $state(1);
   cueError = $state<string | null>(null);
+  // True while the cue deck cannot open its audio output device (see
+  // `outputUnavailable` for the main deck). Backend auto-retries and clears it.
+  cueOutputUnavailable = $state(false);
   // Amplitude-curve peaks for the current cue-deck track (see `waveform`).
   cueWaveform = $state<number[] | null>(null);
 
@@ -154,6 +162,11 @@ export class AppState {
           // can warn even while an in-RAM track keeps playing.
           this.shareUnreachable = true;
           break;
+        case "output-unavailable":
+          // No audio device could be opened (or it recovered). The backend
+          // auto-retries; the banner shows until a device is available.
+          this.outputUnavailable = event.unavailable;
+          break;
         case "error":
           this.isBuffering = false;
           logger.error("Audio error:", event.message);
@@ -198,6 +211,9 @@ export class AppState {
           // skip-to-cached handling is a later issue.
           this.cueIsBuffering = false;
           logger.error("Cue audio load failed for track:", event.id);
+          break;
+        case "output-unavailable":
+          this.cueOutputUnavailable = event.unavailable;
           break;
         case "cache-state":
         case "prefetch-failed":

--- a/src/shared/state.test.ts
+++ b/src/shared/state.test.ts
@@ -638,9 +638,10 @@ describe("AppState backend events", () => {
 describe("AppState outage recovery (skip-to-cached)", () => {
   let app: AppState;
   let mock: MockBackend;
+  let cueMock: MockBackend;
   beforeEach(() => {
     resetApi();
-    ({ app, mock } = makeApp());
+    ({ app, mock, cueMock } = makeApp());
   });
 
   it("on ended, skips an uncached track to the first cached one and keeps the skipped track queued", async () => {
@@ -782,6 +783,29 @@ describe("AppState outage recovery (skip-to-cached)", () => {
     expect(app.shareUnreachable).toBe(false);
     expect(app.reconnecting).toBe(false);
     expect(app.currentTrack?.id).toBe(1); // still not interrupted
+  });
+
+  it("output-unavailable toggles the main-deck flag and clears on recovery", () => {
+    expect(app.outputUnavailable).toBe(false);
+
+    // No audio device could be opened.
+    mock.emitOutputUnavailable(true);
+    expect(app.outputUnavailable).toBe(true);
+    // Distinct from a network outage — the media share is fine.
+    expect(app.reconnecting).toBe(false);
+
+    // Backend auto-retry recovered a device.
+    mock.emitOutputUnavailable(false);
+    expect(app.outputUnavailable).toBe(false);
+  });
+
+  it("output-unavailable on the cue deck sets only the cue flag", () => {
+    cueMock.emitOutputUnavailable(true);
+    expect(app.cueOutputUnavailable).toBe(true);
+    expect(app.outputUnavailable).toBe(false); // main deck unaffected
+
+    cueMock.emitOutputUnavailable(false);
+    expect(app.cueOutputUnavailable).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes #259. A stream-open failure at launch (device not ready, briefly held, momentarily gone, or a buffer config the device rejects) killed the player worker thread permanently. Since `PlayerHandle::send` swallows the closed-channel error, every later `load`/`play`/`seek`/`set_volume` became a silent no-op for the rest of the session — audio dead until restart.

## Changes

**`audio/player.rs`**
- Output is now lazy: `Option<(OutputStream, Sink)>`, opened on demand and **re-opened on the next command** when absent. The worker thread never exits on a stream failure.
- New `open_audio` helper resolves the device on the audio thread and **falls back to the default device** when the configured one can't be resolved or opened.
- `ensure_output` re-opens on demand; when no device is available at all, the command is dropped instead of killing the thread.
- **Idle auto-retry:** a load that can't start because no device is openable is *deferred* (`State::pending_load`); the worker retries opening the output every `OPEN_RETRY_INTERVAL` (2s) and **replays the load the moment a device returns**, with no user action. `Stop` cancels a deferred load.
- **`output-unavailable` event:** per-deck (bool), emitted only on transitions (true = no device, false = recovered) so the retry loop doesn't spam. Surfaces the "output unavailable" UI state.
- Worker takes `Option<DeviceRef>` and resolves lazily.
- `open_stream` falls back to the device default buffer size when a fixed buffer is rejected (`fixed buffer 4096 rejected`).

**`audio/devices.rs`** — removed now-dead `resolve_main_device` (inlined into `open_audio`) + its tests.

**`lib.rs`** — main deck and cue pass the saved `DeviceRef`; resolution + fallback happen lazily on the audio thread.

**Frontend** — new `DeckEvent` variant + native listener; `outputUnavailable` / `cueOutputUnavailable` state; App shows the same `ErrorBanner` used for the reconnecting toast (error type), stacked above the network warning. Distinct messaging: device vs media-share outage.

## Verification

- `cargo build`, `cargo clippy --all-targets`: clean
- `cargo test --lib`: 91 passed (added `open_retry_due` unit test)
- `svelte-check`: 0 errors
- `vitest`: 120 passed (added main toggle/recovery + cue isolation tests)

Not exercised end-to-end: the self-heal / auto-retry / banner paths need a real device-open failure to trigger, which can't be forced in this environment. State logic is unit-covered; template validated by svelte-check; normal playback path is structurally unchanged.

Closes #259