### PR TITLE
feat(deck): prefetch whole playlist to RAM, bounded by byte cap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,6 @@ dist/
 e2e-results/
 node_modules/
 src-tauri/target/
-src-tauri/gen/schemas/
+src-tauri/gen/
 *.db
 *.tgz

--- a/src-tauri/src/audio/cache.rs
+++ b/src-tauri/src/audio/cache.rs
@@ -4,16 +4,18 @@
 //! deck loads an upcoming track the bytes are already available and no
 //! (possibly networked) filesystem read is needed on the hot path.
 //!
-//! Residency is governed by a *keep-window* policy — NOT an LRU:
-//! - The renderer pushes the "window" of upcoming track ids (current + the next
-//!   [`WINDOW_SIZE`]) via `set_window`. Entries whose id falls outside the
-//!   latest window are evicted immediately.
+//! Residency is governed by a *whole-playlist* policy — NOT an LRU:
+//! - The renderer pushes the whole playlist of upcoming track ids (current
+//!   track first, then playlist order) via `set_window`. Entries whose id falls
+//!   outside the latest window are evicted immediately.
 //! - Total resident bytes are capped at [`MAX_CACHE_BYTES`]. When the window's
-//!   entries would exceed the cap, the nearest entries win: the window is
-//!   walked nearest-first and entries are retained until the cap is reached.
+//!   entries would exceed the cap, the tracks first on the list win: the window
+//!   is walked front-first and entries are retained until the cap is reached.
+//!   The whole playlist is therefore attempted, but only as many leading tracks
+//!   as fit in the cap stay resident.
 //!
 //! A single background worker fetches missing window entries sequentially,
-//! nearest-first — never in parallel, to avoid hammering the (network) share.
+//! front-first — never in parallel, to avoid hammering the (network) share.
 
 use anyhow::{Context, Result};
 use parking_lot::Mutex;
@@ -24,11 +26,8 @@ use std::sync::Arc;
 use std::thread;
 use tauri::{AppHandle, Emitter};
 
-/// Number of upcoming tracks kept resident: the current track plus the next 15.
-pub const WINDOW_SIZE: usize = 15;
-
-/// Hard cap on total resident bytes. Whichever of the window size / byte cap is
-/// hit first bounds residency.
+/// Hard cap on total resident bytes. The whole playlist is attempted, but only
+/// as many leading tracks as fit under this cap stay resident.
 pub const MAX_CACHE_BYTES: usize = 150 * 1024 * 1024;
 
 /// Event topic on which cache membership changes are broadcast. Prefetch is a
@@ -50,8 +49,8 @@ type Bytes = Arc<[u8]>;
 struct Inner {
     /// Cached file bytes by track id.
     entries: HashMap<i64, Bytes>,
-    /// Desired residency window, ordered nearest-first (current track first),
-    /// paired with the path to read on a miss.
+    /// Desired residency window — the whole playlist, ordered front-first
+    /// (current track first), paired with the path to read on a miss.
     window: Vec<(i64, PathBuf)>,
     /// Bumped on every `set_window`; lets the prefetch worker abort a run whose
     /// window has been superseded.
@@ -76,7 +75,7 @@ impl Inner {
         self.entries.len() != before
     }
 
-    /// Enforce the byte cap by dropping entries beyond the cap, nearest-first.
+    /// Enforce the byte cap by dropping entries beyond the cap, front-first.
     /// Returns `true` if membership changed.
     fn enforce_cap(&mut self) -> bool {
         let keep = retain_within_cap(&self.window, &self.entries, MAX_CACHE_BYTES);
@@ -86,8 +85,8 @@ impl Inner {
     }
 }
 
-/// Walk `window` nearest-first, keeping ids whose cached bytes fit under `cap`.
-/// Stops at the first entry that would exceed the cap (nearest entries win).
+/// Walk `window` front-first, keeping ids whose cached bytes fit under `cap`.
+/// Stops at the first entry that would exceed the cap (leading entries win).
 /// Ids not present in `entries` are ignored (not yet fetched).
 fn retain_within_cap(
     window: &[(i64, PathBuf)],
@@ -142,10 +141,9 @@ impl Cache {
     /// Replace the residency window. Evicts out-of-window entries, enforces the
     /// byte cap, emits a cache-state event if membership changed, and wakes the
     /// prefetch worker to fetch any still-missing window entries.
-    pub fn set_window(&self, mut window: Vec<(i64, PathBuf)>) {
-        // Defensively enforce the keep-window bound (current + next
-        // WINDOW_SIZE) regardless of how many ids the renderer pushes.
-        window.truncate(WINDOW_SIZE + 1);
+    pub fn set_window(&self, window: Vec<(i64, PathBuf)>) {
+        // The whole playlist is accepted; the byte cap (enforced below) bounds
+        // how many leading tracks actually stay resident.
         let changed = {
             let mut inner = self.inner.lock();
             inner.window = window;
@@ -174,7 +172,7 @@ impl Cache {
 }
 
 /// Background prefetch loop. Woken by `set_window`; reads missing window entries
-/// sequentially, nearest-first, one at a time.
+/// sequentially, front-first, one at a time.
 fn prefetch_worker(inner: Arc<Mutex<Inner>>, app: AppHandle, rx: Receiver<()>) {
     while rx.recv().is_ok() {
         // Coalesce a burst of wake-ups into a single run against the latest
@@ -219,8 +217,8 @@ fn run_prefetch(inner: &Arc<Mutex<Inner>>, app: &AppHandle) {
             }
         };
 
-        // Stop once the cap would be exceeded — nearest entries are prioritised
-        // and farther ones would only be evicted anyway.
+        // Stop once the cap would be exceeded — leading entries are prioritised
+        // and later ones would only be evicted anyway.
         if retained_bytes + bytes.len() > MAX_CACHE_BYTES {
             break;
         }

--- a/src/shared/state.svelte.ts
+++ b/src/shared/state.svelte.ts
@@ -33,9 +33,6 @@ const AUTO_PLAYLIST_BUFFER = 20;
 const AUTO_PLAYLIST_THRESHOLD = 5;
 const HISTORY_CAP = 100;
 const SESSION_SAVE_THROTTLE_MS = 500;
-// Number of upcoming playlist tracks to prefetch ahead of the current track.
-// Mirrors the backend cache keep-window (audio/cache.rs WINDOW_SIZE).
-const PREFETCH_WINDOW = 15;
 // Backoff schedule (ms) for retrying advancement while nothing playable is
 // cached (network outage). The last value repeats until recovery.
 const NET_RETRY_BACKOFFS_MS = [1000, 2000, 5000];
@@ -534,14 +531,14 @@ export class AppState {
   }
 
   /**
-   * Push the upcoming-track window to the backend prefetch cache: the current
-   * track followed by the next `PREFETCH_WINDOW` playlist tracks (stop markers
-   * skipped). Called after every playlist mutation and on track changes.
+   * Push the whole upcoming playlist to the backend prefetch cache: the current
+   * track followed by every playlist track in order (stop markers skipped).
+   * Called after every playlist mutation and on track changes. The backend byte
+   * cap bounds how many leading tracks actually stay resident in RAM.
    */
   private updatePrefetch(): void {
     const upcoming: number[] = this.playlist
       .filter(isTrackItem)
-      .slice(0, PREFETCH_WINDOW)
       .map((i) => i.track.id);
     const ids = this.currentTrack
       ? [this.currentTrack.id, ...upcoming]

--- a/src/shared/state.test.ts
+++ b/src/shared/state.test.ts
@@ -832,12 +832,12 @@ describe("AppState prefetch window", () => {
     expect(api.prefetch).toHaveBeenLastCalledWith([1, 2, 3]);
   });
 
-  it("caps the prefetch window at PREFETCH_WINDOW upcoming tracks", () => {
+  it("prefetches the whole playlist, in order, with no count cap", () => {
     for (let i = 1; i <= 20; i++) app.addToPlaylist(t(i));
     const last = api.prefetch.mock.calls.at(-1)?.[0] as number[];
-    expect(last).toHaveLength(15);
+    expect(last).toHaveLength(20);
     expect(last[0]).toBe(1);
-    expect(last[14]).toBe(15);
+    expect(last[19]).toBe(20);
   });
 });
 


### PR DESCRIPTION
## Summary

Replace the fixed 15-track keep-window prefetch with **whole-playlist residency**, bounded by the existing byte cap.

- Renderer pushes every upcoming playlist id (current track first, then playlist order).
- Backend byte cap (`MAX_CACHE_BYTES`, 150MB) bounds how many leading tracks stay resident — tracks first on the list win, cap walked front-first.

## Changes

- **`state.svelte.ts`** — `updatePrefetch` pushes all playlist ids (no `.slice`); dropped `PREFETCH_WINDOW` constant.
- **`cache.rs`** — dropped `WINDOW_SIZE` constant and the `set_window` truncation; kept front-first byte-cap eviction. Docs updated keep-window → whole-playlist.
- **`state.test.ts`** — assert whole-playlist prefetch, in order, no count cap.

## Behavior

- Instant play of a far (uncached) track still buffers: cache miss → off-thread read (retry + watchdog).
- Reorder re-pushes the window, re-prioritizing the resident set front-first; promoted track fetched, demoted-past-cap track evicted.
- Playing track never interrupted by eviction — decoder holds its own `Arc`.

## Gates

120 vitest, 91 Rust, clippy clean, typecheck 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)