### PR TITLE
feat(signing): ad-hoc sign macOS, scaffold Windows + Linux signing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,10 @@ on:
         description: Name of the uploaded artifact bundle
         type: string
         required: true
+      sign-windows:
+        description: Sign Windows bundles via signing.windows.conf.json overlay (needs signing secrets). See docs/signing.md
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -27,6 +31,15 @@ jobs:
   build:
     name: Build ${{ inputs.target }}
     runs-on: ${{ inputs.platform }}
+    env:
+      # Signing secrets — empty until configured; see docs/signing.md.
+      # Available to this reusable workflow because callers pass `secrets: inherit`.
+      GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+      GPG_KEY_ID: ${{ secrets.GPG_KEY_ID }}
+      APPIMAGETOOL_SIGN_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/setup
@@ -52,10 +65,24 @@ jobs:
         with:
           workspaces: src-tauri
 
+      # Linux AppImage GPG signing. No-op unless GPG_PRIVATE_KEY secret is set.
+      - name: Import GPG signing key (Linux AppImage)
+        if: startsWith(inputs.platform, 'ubuntu') && env.GPG_PRIVATE_KEY != ''
+        shell: bash
+        run: |
+          echo "$GPG_PRIVATE_KEY" | gpg --batch --import
+          {
+            echo "SIGN=1"
+            echo "APPIMAGETOOL_FORCE_SIGN=1"
+          } >> "$GITHUB_ENV"
+          [ -n "$GPG_KEY_ID" ] && echo "SIGN_KEY=$GPG_KEY_ID" >> "$GITHUB_ENV"
+
       - uses: tauri-apps/tauri-action@1deb371b0cd8bd54025b384f1cd735e725c4060f # v1.0.0
         id: tauri
         with:
-          args: ${{ inputs.args }}
+          # `--config signing.windows.conf.json` overlays the Authenticode signCommand
+          # only when sign-windows is enabled. See docs/signing.md.
+          args: ${{ inputs.sign-windows && format('{0} --config src-tauri/signing.windows.conf.json', inputs.args) || inputs.args }}
           tauriScript: pnpm tauri
 
       - name: Stage bundles

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -92,6 +92,16 @@ jobs:
           path: artifacts
           merge-multiple: false
 
+      # Publish the GPG public key so users can verify the signed Linux
+      # AppImage. The key is public by definition; no-op if the var is unset.
+      - name: Stage GPG public key
+        if: vars.GPG_PUBLIC_KEY != ''
+        shell: bash
+        env:
+          GPG_PUBLIC_KEY: ${{ vars.GPG_PUBLIC_KEY }}
+        run: |
+          printf '%s\n' "$GPG_PUBLIC_KEY" > radiodiodj-signing-key.asc
+
       - name: Upload bundles to release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -100,7 +110,7 @@ jobs:
         shell: bash
         run: |
           shopt -s nullglob globstar
-          files=(artifacts/**/*.dmg artifacts/**/*.app.tar.gz artifacts/**/*.AppImage artifacts/**/*.deb artifacts/**/*.rpm artifacts/**/*.msi artifacts/**/*.exe artifacts/**/*.nsis.zip)
+          files=(artifacts/**/*.dmg artifacts/**/*.app.tar.gz artifacts/**/*.AppImage artifacts/**/*.deb artifacts/**/*.rpm artifacts/**/*.msi artifacts/**/*.exe artifacts/**/*.nsis.zip radiodiodj-signing-key.asc)
           if [ ${#files[@]} -eq 0 ]; then
             echo "No bundle artifacts found" >&2
             find artifacts -type f >&2

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -38,6 +38,7 @@ jobs:
       target: aarch64-apple-darwin
       args: --target aarch64-apple-darwin
       artifact-name: bundle-macos-arm64
+    secrets: inherit
 
   build-macos-x64:
     needs: release-please
@@ -48,6 +49,7 @@ jobs:
       target: x86_64-apple-darwin
       args: --target x86_64-apple-darwin
       artifact-name: bundle-macos-x64
+    secrets: inherit
 
   build-linux-x64:
     needs: release-please
@@ -58,6 +60,7 @@ jobs:
       target: x86_64-unknown-linux-gnu
       args: ""
       artifact-name: bundle-linux-x64
+    secrets: inherit
 
   build-windows-x64:
     needs: release-please
@@ -68,6 +71,9 @@ jobs:
       target: x86_64-pc-windows-msvc
       args: ""
       artifact-name: bundle-windows-x64
+      # Flip to true once a Windows signing cert + secrets exist. See docs/signing.md.
+      sign-windows: false
+    secrets: inherit
 
   upload-release:
     needs:

--- a/docs/signing.md
+++ b/docs/signing.md
@@ -1,0 +1,106 @@
+# Application signing
+
+Status of code signing across the three release platforms.
+
+| Platform | State                                   | OS warning removed?                                                       |
+| -------- | --------------------------------------- | ------------------------------------------------------------------------- |
+| macOS    | **Ad-hoc signed** (live)                | No — download still quarantined; user must allow the app once.            |
+| Linux    | GPG AppImage signing **wired, dormant** | N/A — Linux has no Gatekeeper; signature is for manual verification only. |
+| Windows  | Authenticode **scaffolded, dormant**    | No — needs a real certificate before SmartScreen goes away.               |
+
+Only ad-hoc macOS signing is active. Linux and Windows are fully wired but stay inert
+until their secrets are added — no secret means an ordinary unsigned build, exactly as
+before.
+
+---
+
+## macOS — ad-hoc (active)
+
+Configured in `src-tauri/tauri.conf.json`:
+
+```json
+"bundle": { "macOS": { "signingIdentity": "-" } }
+```
+
+`"-"` is the ad-hoc identity. It gives the `.app` a valid signature (required for the
+binary to launch at all on Apple Silicon when downloaded) but **does not** notarize it.
+A downloaded `.dmg` is still quarantined, so first launch shows "unidentified developer".
+Users open it once via **System Settings → Privacy & Security → Open Anyway**, or run:
+
+```sh
+xattr -dr com.apple.quarantine /Applications/RadiodioDJ.app
+```
+
+Upgrade path: a paid Apple Developer account ($99/yr) + Developer ID Application cert +
+notarization removes the warning entirely. Set `APPLE_CERTIFICATE`,
+`APPLE_CERTIFICATE_PASSWORD`, `APPLE_SIGNING_IDENTITY`, `APPLE_ID`, `APPLE_PASSWORD`,
+`APPLE_TEAM_ID` as secrets and drop the `signingIdentity: "-"` override.
+
+---
+
+## Linux — GPG AppImage signing (wired, needs secrets)
+
+The build workflow imports a GPG key and enables signing only when `GPG_PRIVATE_KEY` is
+present. Signature covers the AppImage target; users verify it manually with the AppImage
+validate tool, so it only adds value if you publish the key ID on a trusted channel.
+
+### Activate
+
+1. Generate a signing key (do this yourself — the private key must never come from an
+   agent or land in the repo):
+
+   ```sh
+   gpg --full-generate-key            # pick RSA 4096, set a passphrase
+   gpg --list-secret-keys --keyid-format=long   # note the long key ID
+   gpg --armor --export-secret-keys <KEY_ID> > private.asc
+   ```
+
+2. Add repo secrets (Settings → Secrets and variables → Actions):
+
+   | Secret            | Value                                                         |
+   | ----------------- | ------------------------------------------------------------- |
+   | `GPG_PRIVATE_KEY` | contents of `private.asc`                                     |
+   | `GPG_KEY_ID`      | the long key ID (optional; picks the key if you hold several) |
+   | `GPG_PASSPHRASE`  | the key passphrase (maps to `APPIMAGETOOL_SIGN_PASSPHRASE`)   |
+
+3. Delete `private.asc` locally and publish the **public** key + key ID somewhere
+   authenticated (README / site) so users can verify.
+
+Next release signs the AppImage automatically. No workflow edit needed.
+
+---
+
+## Windows — Authenticode (scaffolded, needs a certificate)
+
+There is **no free way** to remove the SmartScreen warning — it requires a real
+code-signing certificate. Self-signed certs do not help (still warn, worse UX).
+
+The signing hook is `src-tauri/signing.windows.conf.json`, applied as a Tauri `--config`
+overlay only when the release workflow's `sign-windows` input is `true`. It currently
+targets **Azure Trusted Signing** via [`trusted-signing-cli`].
+
+### Certificate options
+
+- **Azure Trusted Signing** — ~$10/mo, individual identity now allowed (needs a few years
+  of verifiable history). Works with the scaffolded `signCommand` below.
+- **SignPath Foundation** — free for approved OSS projects. Note: SignPath signs artifacts
+  **after** the build via its own GitHub Action, so it does _not_ use this `signCommand`
+  overlay — you would add a post-build signing step instead. The repo is currently
+  `UNLICENSED`, which likely disqualifies it until relicensed as OSS.
+- **OV/EV certificate** — $100–400/yr from a CA; use `certificateThumbprint` +
+  `digestAlgorithm` + `timestampUrl` under `bundle.windows` instead of `signCommand`.
+
+### Activate (Azure Trusted Signing route)
+
+1. Set up a Trusted Signing account + certificate profile in Azure and a service principal.
+2. Edit `src-tauri/signing.windows.conf.json` — replace the endpoint, account
+   (`REPLACE_WITH_TRUSTED_SIGNING_ACCOUNT`), and cert profile
+   (`REPLACE_WITH_CERTIFICATE_PROFILE`).
+3. Add repo secrets: `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`
+   (already read as env by the build workflow).
+4. Ensure `trusted-signing-cli` is installed on the Windows runner (add an install step
+   to `build.yml`, e.g. `cargo install trusted-signing-cli`).
+5. Set `sign-windows: true` on the `build-windows-x64` job in
+   `.github/workflows/release-please.yml`.
+
+[`trusted-signing-cli`]: https://github.com/Levminer/trusted-signing-cli

--- a/src-tauri/signing.windows.conf.json
+++ b/src-tauri/signing.windows.conf.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "bundle": {
+    "windows": {
+      "signCommand": {
+        "cmd": "trusted-signing-cli",
+        "args": [
+          "-e",
+          "https://weu.codesigning.azure.net/",
+          "-a",
+          "REPLACE_WITH_TRUSTED_SIGNING_ACCOUNT",
+          "-c",
+          "REPLACE_WITH_CERTIFICATE_PROFILE",
+          "%1"
+        ]
+      }
+    }
+  }
+}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -29,6 +29,9 @@
     "active": true,
     "category": "Music",
     "targets": "all",
+    "macOS": {
+      "signingIdentity": "-"
+    },
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",


### PR DESCRIPTION
## What

Solves application signing across the three release platforms, given no signing certs exist yet.

| Platform | State | OS warning removed? |
| --- | --- | --- |
| macOS | **Ad-hoc signed** (live, verified) | No — download still quarantined; user allows once. |
| Linux | GPG AppImage signing **wired, dormant** | N/A — no Gatekeeper on Linux. |
| Windows | Authenticode **scaffolded, dormant** | No — needs a real certificate. |

## Changes

- `src-tauri/tauri.conf.json` — `bundle.macOS.signingIdentity: "-"` (ad-hoc). Applies to CI + local. Verified: real bundle signs with identity `-`, `codesign --verify` passes (`Signature=adhoc`, `adhoc,runtime` flags).
- `.github/workflows/build.yml` — Linux GPG key import + `SIGN=1` (only when `GPG_PRIVATE_KEY` secret present); `sign-windows` input applies the Windows overlay via `--config`; signing secrets read as env.
- `src-tauri/signing.windows.conf.json` — Authenticode `signCommand` overlay (Azure Trusted Signing route, placeholders).
- `.github/workflows/release-please.yml` — `secrets: inherit` on all 4 build jobs; `sign-windows: false`.
- `docs/signing.md` — per-platform activation steps + upgrade paths.

## Behavior

No change to current unsigned Linux/Windows builds until secrets are added — no secret means an ordinary unsigned build. Only macOS ad-hoc is active now.

## Follow-up

Remaining signing work (certs, notarization, activation) tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)