### PR TITLE
feat(settings): expose hard-coded tuning constants in AppConfig

### DIFF
--- a/src-tauri/src/audio/cache.rs
+++ b/src-tauri/src/audio/cache.rs
@@ -26,8 +26,10 @@ use std::sync::Arc;
 use std::thread;
 use tauri::{AppHandle, Emitter};
 
-/// Hard cap on total resident bytes. The whole playlist is attempted, but only
-/// as many leading tracks as fit under this cap stay resident.
+/// Default hard cap on total resident bytes, used when no configured value is
+/// supplied (tests, and the config default). The live cap is held per-`Cache`.
+/// The whole playlist is attempted, but only as many leading tracks as fit
+/// under the cap stay resident.
 pub const MAX_CACHE_BYTES: usize = 150 * 1024 * 1024;
 
 /// Event topic on which cache membership changes are broadcast. Prefetch is a
@@ -55,14 +57,17 @@ struct Inner {
     /// Bumped on every `set_window`; lets the prefetch worker abort a run whose
     /// window has been superseded.
     generation: u64,
+    /// Hard cap on total resident bytes for this cache (from config).
+    cap: usize,
 }
 
 impl Inner {
-    fn new() -> Self {
+    fn new(cap: usize) -> Self {
         Self {
             entries: HashMap::new(),
             window: Vec::new(),
             generation: 0,
+            cap,
         }
     }
 
@@ -78,7 +83,7 @@ impl Inner {
     /// Enforce the byte cap by dropping entries beyond the cap, front-first.
     /// Returns `true` if membership changed.
     fn enforce_cap(&mut self) -> bool {
-        let keep = retain_within_cap(&self.window, &self.entries, MAX_CACHE_BYTES);
+        let keep = retain_within_cap(&self.window, &self.entries, self.cap);
         let before = self.entries.len();
         self.entries.retain(|id, _| keep.contains(id));
         self.entries.len() != before
@@ -118,8 +123,8 @@ pub struct Cache {
 }
 
 impl Cache {
-    pub fn new(app: AppHandle) -> Arc<Self> {
-        let inner = Arc::new(Mutex::new(Inner::new()));
+    pub fn new(app: AppHandle, max_cache_bytes: usize) -> Arc<Self> {
+        let inner = Arc::new(Mutex::new(Inner::new(max_cache_bytes)));
         let (prefetch_tx, prefetch_rx) = channel::<()>();
         {
             let inner = Arc::clone(&inner);
@@ -183,10 +188,10 @@ fn prefetch_worker(inner: Arc<Mutex<Inner>>, app: AppHandle, rx: Receiver<()>) {
 }
 
 fn run_prefetch(inner: &Arc<Mutex<Inner>>, app: &AppHandle) {
-    // Snapshot the window and generation we are fetching for.
-    let (window, generation) = {
+    // Snapshot the window, generation, and byte cap we are fetching for.
+    let (window, generation, cap) = {
         let guard = inner.lock();
-        (guard.window.clone(), guard.generation)
+        (guard.window.clone(), guard.generation, guard.cap)
     };
 
     let mut retained_bytes: usize = 0;
@@ -219,7 +224,7 @@ fn run_prefetch(inner: &Arc<Mutex<Inner>>, app: &AppHandle) {
 
         // Stop once the cap would be exceeded — leading entries are prioritised
         // and later ones would only be evicted anyway.
-        if retained_bytes + bytes.len() > MAX_CACHE_BYTES {
+        if retained_bytes + bytes.len() > cap {
             break;
         }
 
@@ -267,7 +272,7 @@ mod tests {
 
     #[test]
     fn evict_out_of_window_drops_ids_outside_window() {
-        let mut inner = Inner::new();
+        let mut inner = Inner::new(MAX_CACHE_BYTES);
         inner.entries.insert(1, bytes(10));
         inner.entries.insert(2, bytes(10));
         inner.entries.insert(3, bytes(10));
@@ -282,7 +287,7 @@ mod tests {
 
     #[test]
     fn evict_out_of_window_is_noop_when_all_in_window() {
-        let mut inner = Inner::new();
+        let mut inner = Inner::new(MAX_CACHE_BYTES);
         inner.entries.insert(1, bytes(10));
         inner.entries.insert(2, bytes(10));
         inner.window = win(&[1, 2, 3]);
@@ -295,7 +300,7 @@ mod tests {
     fn enforce_cap_retains_nearest_first_until_full() {
         // Three ~60 MB entries, cap 150 MB → only the first two fit.
         let big = 60 * 1024 * 1024;
-        let mut inner = Inner::new();
+        let mut inner = Inner::new(MAX_CACHE_BYTES);
         inner.window = win(&[1, 2, 3]);
         inner.entries.insert(1, bytes(big));
         inner.entries.insert(2, bytes(big));
@@ -309,7 +314,7 @@ mod tests {
 
     #[test]
     fn enforce_cap_noop_when_under_cap() {
-        let mut inner = Inner::new();
+        let mut inner = Inner::new(MAX_CACHE_BYTES);
         inner.window = win(&[1, 2]);
         inner.entries.insert(1, bytes(1024));
         inner.entries.insert(2, bytes(1024));

--- a/src-tauri/src/audio/player.rs
+++ b/src-tauri/src/audio/player.rs
@@ -37,6 +37,29 @@ const READ_RETRY_BACKOFFS: [Duration; 3] = [
 /// user action (a stalled/absent device at launch — see issue #259).
 const OPEN_RETRY_INTERVAL: Duration = Duration::from_secs(2);
 
+/// Network-resilience timeouts for the player worker, supplied at spawn from the
+/// stored config. Captured for the worker's lifetime. Clamped on write (see
+/// `persist::config::set_tuning`), so `read_retry_backoffs` is always non-empty.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PlayerTuning {
+    /// See [`READ_WATCHDOG_TIMEOUT`].
+    pub read_watchdog_timeout: Duration,
+    /// See [`OPEN_RETRY_INTERVAL`].
+    pub open_retry_interval: Duration,
+    /// See [`READ_RETRY_BACKOFFS`]. Must be non-empty (enforced on write).
+    pub read_retry_backoffs: Vec<Duration>,
+}
+
+impl Default for PlayerTuning {
+    fn default() -> Self {
+        Self {
+            read_watchdog_timeout: READ_WATCHDOG_TIMEOUT,
+            open_retry_interval: OPEN_RETRY_INTERVAL,
+            read_retry_backoffs: READ_RETRY_BACKOFFS.to_vec(),
+        }
+    }
+}
+
 /// A load that could not be started because no audio output was openable.
 /// Retained so the idle auto-retry loop can replay it once the device returns.
 #[derive(Clone)]
@@ -114,11 +137,12 @@ impl PlayerHandle {
         device: Option<DeviceRef>,
         event_prefix: &'static str,
         cache: Arc<Cache>,
+        tuning: PlayerTuning,
     ) -> Self {
         let (tx, rx) = channel();
         let topics = Topics::new(event_prefix);
         thread::spawn(move || {
-            if let Err(e) = run(app.clone(), rx, device, &topics, cache) {
+            if let Err(e) = run(app.clone(), rx, device, &topics, cache, tuning) {
                 log::error!("[{}] player thread exited: {}", event_prefix, e);
                 let _ = app.emit(&topics.error, e.to_string());
             }
@@ -275,6 +299,7 @@ fn run(
     device: Option<DeviceRef>,
     topics: &Topics,
     cache: Arc<Cache>,
+    tuning: PlayerTuning,
 ) -> Result<()> {
     // Output is opened lazily and re-opened on demand: a stream-open failure at
     // launch (device not ready yet, briefly held, momentarily gone) must not
@@ -313,6 +338,7 @@ fn run(
                     topics,
                     &load_tx,
                     &cache,
+                    &tuning.read_retry_backoffs,
                     cmd,
                 ),
                 Err(std::sync::mpsc::TryRecvError::Empty) => break,
@@ -328,8 +354,13 @@ fn run(
         // Watchdog: a read that neither completed nor errored within the budget
         // is a wedged mount. Declare a timeout and abandon the detached read
         // thread — the worker never blocks waiting on it.
-        if watchdog_timed_out(state.loading, state.load_start, Instant::now()) {
-            handle_load_timeout(&app, &mut state, topics);
+        if watchdog_timed_out(
+            state.loading,
+            state.load_start,
+            Instant::now(),
+            tuning.read_watchdog_timeout,
+        ) {
+            handle_load_timeout(&app, &mut state, topics, tuning.read_watchdog_timeout);
         }
 
         // Idle auto-retry: a load deferred because the audio device could not be
@@ -338,7 +369,13 @@ fn run(
         // output becomes available, whether reopened here or by a command above
         // (#259). No user action required.
         if state.pending_load.is_some() {
-            if output.is_none() && open_retry_due(state.last_open_retry, Instant::now()) {
+            if output.is_none()
+                && open_retry_due(
+                    state.last_open_retry,
+                    Instant::now(),
+                    tuning.open_retry_interval,
+                )
+            {
                 state.last_open_retry = Some(Instant::now());
                 match open_audio(&device, state.volume) {
                     Ok(o) => {
@@ -360,6 +397,7 @@ fn run(
                         topics,
                         &load_tx,
                         &cache,
+                        &tuning.read_retry_backoffs,
                         p.id,
                         p.path,
                         p.duration,
@@ -401,6 +439,7 @@ fn start_load(
     topics: &Topics,
     load_tx: &Sender<LoadMsg>,
     cache: &Arc<Cache>,
+    read_retry_backoffs: &[Duration],
     id: i64,
     path: PathBuf,
     duration: Option<f64>,
@@ -451,10 +490,11 @@ fn start_load(
         // is in flight per deck at a time — a newer `Load` bumps
         // `generation`, so a stale read's result is discarded rather
         // than another thread being blocked on.
+        let backoffs = read_retry_backoffs.to_vec();
         thread::spawn(move || {
             // Retry transient failures with backoff; hangs are the
             // watchdog's job (handled in the worker loop, not here).
-            let bytes = read_with_retry(|| read_file(&path), thread::sleep);
+            let bytes = read_with_retry(|| read_file(&path), thread::sleep, &backoffs);
             let _ = tx.send(LoadMsg {
                 generation,
                 id,
@@ -474,12 +514,23 @@ fn apply(
     topics: &Topics,
     load_tx: &Sender<LoadMsg>,
     cache: &Arc<Cache>,
+    read_retry_backoffs: &[Duration],
     cmd: Cmd,
 ) {
     match cmd {
         Cmd::Load { id, path, duration } => {
             start_load(
-                app, output, device, state, topics, load_tx, cache, id, path, duration,
+                app,
+                output,
+                device,
+                state,
+                topics,
+                load_tx,
+                cache,
+                read_retry_backoffs,
+                id,
+                path,
+                duration,
             );
         }
         Cmd::Play => {
@@ -668,16 +719,21 @@ fn reset_after_failure(state: &mut State) {
 /// Decide whether the idle loop should attempt another output-open. Pure (clock
 /// via `now`) so it is unit-testable. Fires immediately the first time
 /// (`None`), then no more often than `OPEN_RETRY_INTERVAL`.
-fn open_retry_due(last_open_retry: Option<Instant>, now: Instant) -> bool {
+fn open_retry_due(last_open_retry: Option<Instant>, now: Instant, interval: Duration) -> bool {
     match last_open_retry {
         None => true,
-        Some(last) => now.saturating_duration_since(last) >= OPEN_RETRY_INTERVAL,
+        Some(last) => now.saturating_duration_since(last) >= interval,
     }
 }
 
-fn watchdog_timed_out(loading: bool, load_start: Option<Instant>, now: Instant) -> bool {
+fn watchdog_timed_out(
+    loading: bool,
+    load_start: Option<Instant>,
+    now: Instant,
+    timeout: Duration,
+) -> bool {
     match load_start {
-        Some(start) if loading => now.saturating_duration_since(start) >= READ_WATCHDOG_TIMEOUT,
+        Some(start) if loading => now.saturating_duration_since(start) >= timeout,
         _ => false,
     }
 }
@@ -686,7 +742,7 @@ fn watchdog_timed_out(loading: bool, load_start: Option<Instant>, now: Instant) 
 /// plus a `:load-failed` carrying the track id, and reset load state. The
 /// generation is bumped so a late `LoadMsg` from the abandoned thread is
 /// discarded rather than played.
-fn handle_load_timeout(app: &AppHandle, state: &mut State, topics: &Topics) {
+fn handle_load_timeout(app: &AppHandle, state: &mut State, topics: &Topics, timeout: Duration) {
     let id = state.current_id;
     let path = state
         .current_path
@@ -696,7 +752,7 @@ fn handle_load_timeout(app: &AppHandle, state: &mut State, topics: &Topics) {
     log::error!(
         "player: read {} timed out after {:?}; abandoning read",
         path,
-        READ_WATCHDOG_TIMEOUT
+        timeout
     );
     state.generation = state.generation.wrapping_add(1);
     reset_after_failure(state);
@@ -713,20 +769,20 @@ fn handle_load_timeout(app: &AppHandle, state: &mut State, topics: &Topics) {
 /// matching backoff between attempts, and returns the first success or the last
 /// error. `read`/`sleep` are injected so tests exercise the schedule without
 /// touching the filesystem or actually sleeping.
-fn read_with_retry<R, S>(mut read: R, mut sleep: S) -> Result<Bytes>
+fn read_with_retry<R, S>(mut read: R, mut sleep: S, backoffs: &[Duration]) -> Result<Bytes>
 where
     R: FnMut() -> Result<Bytes>,
     S: FnMut(Duration),
 {
     let mut last_err: Option<anyhow::Error> = None;
     // Attempt indices 0..=len: index 0 is the initial try, and after a failing
-    // attempt `i` we back off by `READ_RETRY_BACKOFFS[i]` if one exists.
-    for attempt in 0..=READ_RETRY_BACKOFFS.len() {
+    // attempt `i` we back off by `backoffs[i]` if one exists.
+    for attempt in 0..=backoffs.len() {
         match read() {
             Ok(bytes) => return Ok(bytes),
             Err(e) => {
                 last_err = Some(e);
-                if let Some(delay) = READ_RETRY_BACKOFFS.get(attempt) {
+                if let Some(delay) = backoffs.get(attempt) {
                     sleep(*delay);
                 }
             }
@@ -851,6 +907,7 @@ mod tests {
                 }
             },
             |d| slept.push(d),
+            &READ_RETRY_BACKOFFS,
         );
         assert!(result.is_ok());
         assert_eq!(attempts, 3, "initial attempt + 2 retries");
@@ -873,6 +930,7 @@ mod tests {
                 Err::<Bytes, _>(anyhow::anyhow!("always fails"))
             },
             |d| slept.push(d),
+            &READ_RETRY_BACKOFFS,
         );
         assert!(result.is_err());
         assert_eq!(attempts, READ_RETRY_BACKOFFS.len() as u32 + 1);
@@ -890,13 +948,63 @@ mod tests {
             .unwrap();
 
         // Under budget: not timed out.
-        assert!(!watchdog_timed_out(true, Some(start), before));
+        assert!(!watchdog_timed_out(
+            true,
+            Some(start),
+            before,
+            READ_WATCHDOG_TIMEOUT
+        ));
         // Over budget while loading: timed out.
-        assert!(watchdog_timed_out(true, Some(start), after));
+        assert!(watchdog_timed_out(
+            true,
+            Some(start),
+            after,
+            READ_WATCHDOG_TIMEOUT
+        ));
         // A result arrived (loading == false): never a timeout.
-        assert!(!watchdog_timed_out(false, Some(start), after));
+        assert!(!watchdog_timed_out(
+            false,
+            Some(start),
+            after,
+            READ_WATCHDOG_TIMEOUT
+        ));
         // No read in flight: never a timeout.
-        assert!(!watchdog_timed_out(true, None, after));
+        assert!(!watchdog_timed_out(
+            true,
+            None,
+            after,
+            READ_WATCHDOG_TIMEOUT
+        ));
+    }
+
+    /// `PlayerTuning::default` equals the module constants, so an untouched
+    /// config runs with these exact timeouts.
+    #[test]
+    fn player_tuning_default_matches_constants() {
+        let t = PlayerTuning::default();
+        assert_eq!(t.read_watchdog_timeout, READ_WATCHDOG_TIMEOUT);
+        assert_eq!(t.open_retry_interval, OPEN_RETRY_INTERVAL);
+        assert_eq!(t.read_retry_backoffs, READ_RETRY_BACKOFFS.to_vec());
+    }
+
+    /// The supplied backoff slice drives the retry count: one attempt per entry
+    /// plus the initial try.
+    #[test]
+    fn read_with_retry_honours_custom_backoffs() {
+        let mut attempts = 0u32;
+        let mut slept: Vec<Duration> = Vec::new();
+        let backoffs = [Duration::from_millis(10)];
+        let result = read_with_retry(
+            || {
+                attempts += 1;
+                Err::<Bytes, _>(anyhow::anyhow!("always fails"))
+            },
+            |d| slept.push(d),
+            &backoffs,
+        );
+        assert!(result.is_err());
+        assert_eq!(attempts, 2, "initial attempt + 1 retry");
+        assert_eq!(slept, vec![Duration::from_millis(10)]);
     }
 
     #[test]
@@ -910,10 +1018,10 @@ mod tests {
             .unwrap();
 
         // Never attempted before: retry immediately.
-        assert!(open_retry_due(None, start));
+        assert!(open_retry_due(None, start, OPEN_RETRY_INTERVAL));
         // Within the interval since the last attempt: hold off.
-        assert!(!open_retry_due(Some(start), before));
+        assert!(!open_retry_due(Some(start), before, OPEN_RETRY_INTERVAL));
         // Interval elapsed: retry again.
-        assert!(open_retry_due(Some(start), after));
+        assert!(open_retry_due(Some(start), after, OPEN_RETRY_INTERVAL));
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -15,13 +15,40 @@ use audio::devices::{list_output_devices, DeviceInfo};
 
 pub const APP_NAME: &str = "RadiodioDJ";
 
-use audio::player::{Cmd, PlayerHandle};
+use audio::player::{Cmd, PlayerHandle, PlayerTuning};
 use broadcast::{service::default_now_playing_dir, BroadcastService};
 use library::db::{Db, LibraryStats, Track};
 use library::scan_state::{ScanState, ScanStatus, StartResult};
 use library::waveform_scan::{WaveformJob, WaveformStatus};
-use persist::config::{Config, DeviceRef, NowPlayingConfig};
+use persist::config::{Config, DeviceRef, NowPlayingConfig, TuningConfig};
 use persist::session::{PlaylistItem, Session, SessionState};
+use playlist::Interleave;
+use std::time::Duration;
+
+/// Build the playlist interleave params from the stored tuning section.
+fn interleave_from(t: &TuningConfig) -> Interleave {
+    Interleave {
+        jingle_every: t.interleave.jingle_every,
+        commercial_every: t.interleave.commercial_every,
+        commercial_bucket_multiplier: t.interleave.commercial_bucket_multiplier,
+        commercial_bucket_min: t.interleave.commercial_bucket_min,
+    }
+}
+
+/// Build the audio-player network-resilience tuning from the stored tuning
+/// section. Values are already clamped on write, so the lists are non-empty.
+fn player_tuning_from(t: &TuningConfig) -> PlayerTuning {
+    PlayerTuning {
+        read_watchdog_timeout: Duration::from_millis(t.player.read_watchdog_timeout_ms),
+        open_retry_interval: Duration::from_millis(t.player.open_retry_interval_ms),
+        read_retry_backoffs: t
+            .player
+            .read_retry_backoffs_ms
+            .iter()
+            .map(|ms| Duration::from_millis(*ms))
+            .collect(),
+    }
+}
 
 pub struct AppState {
     db: Arc<Db>,
@@ -146,7 +173,10 @@ fn generate_playlist(
     count: i64,
     exclude_ids: Vec<i64>,
 ) -> Result<Vec<Track>, String> {
-    playlist::generate(&app.db, count, &exclude_ids).map_err(err)
+    // Read interleave live per-call so a settings change takes effect on the
+    // next generated block without a restart (cheap — one config lock).
+    let il = interleave_from(&app.config.get_tuning());
+    playlist::generate(&app.db, count, &exclude_ids, &il).map_err(err)
 }
 
 #[tauri::command(rename_all = "camelCase")]
@@ -154,7 +184,8 @@ fn pick_filler(
     app: State<'_, AppState>,
     content_type: playlist::ContentType,
 ) -> Result<Option<Track>, String> {
-    playlist::pick_filler(&app.db, content_type).map_err(err)
+    let il = interleave_from(&app.config.get_tuning());
+    playlist::pick_filler(&app.db, content_type, &il).map_err(err)
 }
 
 #[tauri::command(rename_all = "camelCase")]
@@ -284,6 +315,7 @@ where
             Some(cue_ref),
             "cue",
             Arc::clone(&state.cache),
+            player_tuning_from(&state.config.get_tuning()),
         ));
     }
     if let Some(handle) = guard.as_ref() {
@@ -348,6 +380,23 @@ fn set_now_playing_config(
     config: NowPlayingConfig,
 ) -> Result<(), String> {
     state.config.set_now_playing(config).map_err(err)
+}
+
+#[tauri::command(rename_all = "camelCase")]
+fn get_tuning_config(state: State<'_, AppState>) -> TuningConfig {
+    state.config.get_tuning()
+}
+
+/// Persist new tuning values and return the clamped result the UI should
+/// display. Interleave/auto-playlist changes apply live; cache/player changes
+/// (which are captured by long-lived worker threads at startup) take effect on
+/// the next restart — the UI surfaces that hint.
+#[tauri::command(rename_all = "camelCase")]
+fn set_tuning_config(
+    state: State<'_, AppState>,
+    config: TuningConfig,
+) -> Result<TuningConfig, String> {
+    state.config.set_tuning(config).map_err(err)
 }
 
 #[tauri::command(rename_all = "camelCase")]
@@ -440,12 +489,17 @@ pub fn run() {
             // system default, so a device unavailable at launch no longer kills
             // playback for the whole session (#259).
             let main_device = config.get_main_device();
-            let cache = Cache::new(app.handle().clone());
+            // The cache cap and player timeouts are read once here and captured
+            // by their worker threads for the process lifetime; editing them
+            // takes effect on the next launch.
+            let tuning = config.get_tuning();
+            let cache = Cache::new(app.handle().clone(), tuning.cache.max_cache_bytes);
             let main_deck = PlayerHandle::spawn(
                 app.handle().clone(),
                 main_device,
                 "main-deck",
                 Arc::clone(&cache),
+                player_tuning_from(&tuning),
             );
             let config = Arc::new(config);
             let broadcast = Arc::new(BroadcastService::new(
@@ -512,6 +566,8 @@ pub fn run() {
             get_cover_art,
             get_now_playing_config,
             set_now_playing_config,
+            get_tuning_config,
+            set_tuning_config,
             now_playing_test,
             broadcast_shutdown,
         ])

--- a/src-tauri/src/persist/config.rs
+++ b/src-tauri/src/persist/config.rs
@@ -42,6 +42,159 @@ impl Default for NowPlayingConfig {
     }
 }
 
+/// User-tunable playback behaviour. Each field carries `serde(default)` so a
+/// `config.json` missing the section (or any single field) still loads. Values
+/// are clamped to sane ranges by `normalize_tuning` whenever they are written.
+#[derive(Serialize, Deserialize, Default, Clone, PartialEq, Eq, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct TuningConfig {
+    #[serde(default)]
+    pub interleave: InterleaveConfig,
+    #[serde(default)]
+    pub auto_playlist: AutoPlaylistConfig,
+    #[serde(default)]
+    pub cache: CacheConfig,
+    #[serde(default)]
+    pub player: PlayerConfig,
+}
+
+/// Playlist interleave cadence — how often jingles/commercials are woven into a
+/// generated block of music, and how the commercial bucket is sized.
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct InterleaveConfig {
+    #[serde(default = "default_jingle_every")]
+    pub jingle_every: i64,
+    #[serde(default = "default_commercial_every")]
+    pub commercial_every: i64,
+    #[serde(default = "default_commercial_bucket_multiplier")]
+    pub commercial_bucket_multiplier: i64,
+    #[serde(default = "default_commercial_bucket_min")]
+    pub commercial_bucket_min: i64,
+}
+
+fn default_jingle_every() -> i64 {
+    4
+}
+fn default_commercial_every() -> i64 {
+    8
+}
+fn default_commercial_bucket_multiplier() -> i64 {
+    3
+}
+fn default_commercial_bucket_min() -> i64 {
+    10
+}
+
+impl Default for InterleaveConfig {
+    fn default() -> Self {
+        Self {
+            jingle_every: default_jingle_every(),
+            commercial_every: default_commercial_every(),
+            commercial_bucket_multiplier: default_commercial_bucket_multiplier(),
+            commercial_bucket_min: default_commercial_bucket_min(),
+        }
+    }
+}
+
+/// Renderer-side auto-playlist + session tuning. Read by `state.svelte.ts`.
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct AutoPlaylistConfig {
+    #[serde(default = "default_auto_playlist_buffer")]
+    pub auto_playlist_buffer: usize,
+    #[serde(default = "default_auto_playlist_threshold")]
+    pub auto_playlist_threshold: usize,
+    #[serde(default = "default_history_cap")]
+    pub history_cap: usize,
+    #[serde(default = "default_session_save_throttle_ms")]
+    pub session_save_throttle_ms: u64,
+    #[serde(default = "default_net_retry_backoffs_ms")]
+    pub net_retry_backoffs_ms: Vec<u64>,
+}
+
+fn default_auto_playlist_buffer() -> usize {
+    20
+}
+fn default_auto_playlist_threshold() -> usize {
+    5
+}
+fn default_history_cap() -> usize {
+    100
+}
+fn default_session_save_throttle_ms() -> u64 {
+    500
+}
+fn default_net_retry_backoffs_ms() -> Vec<u64> {
+    vec![1000, 2000, 5000]
+}
+
+impl Default for AutoPlaylistConfig {
+    fn default() -> Self {
+        Self {
+            auto_playlist_buffer: default_auto_playlist_buffer(),
+            auto_playlist_threshold: default_auto_playlist_threshold(),
+            history_cap: default_history_cap(),
+            session_save_throttle_ms: default_session_save_throttle_ms(),
+            net_retry_backoffs_ms: default_net_retry_backoffs_ms(),
+        }
+    }
+}
+
+/// Prefetch byte-cache tuning.
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct CacheConfig {
+    #[serde(default = "default_max_cache_bytes")]
+    pub max_cache_bytes: usize,
+}
+
+fn default_max_cache_bytes() -> usize {
+    // Reuse the cache module's constant so the default cannot drift from it.
+    crate::audio::cache::MAX_CACHE_BYTES
+}
+
+impl Default for CacheConfig {
+    fn default() -> Self {
+        Self {
+            max_cache_bytes: default_max_cache_bytes(),
+        }
+    }
+}
+
+/// Audio-player network-resilience timeouts: read watchdog, output open-retry
+/// cadence, and per-attempt read backoffs (all in milliseconds).
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct PlayerConfig {
+    #[serde(default = "default_read_watchdog_timeout_ms")]
+    pub read_watchdog_timeout_ms: u64,
+    #[serde(default = "default_open_retry_interval_ms")]
+    pub open_retry_interval_ms: u64,
+    #[serde(default = "default_read_retry_backoffs_ms")]
+    pub read_retry_backoffs_ms: Vec<u64>,
+}
+
+fn default_read_watchdog_timeout_ms() -> u64 {
+    10_000
+}
+fn default_open_retry_interval_ms() -> u64 {
+    2_000
+}
+fn default_read_retry_backoffs_ms() -> Vec<u64> {
+    vec![500, 1000, 2000]
+}
+
+impl Default for PlayerConfig {
+    fn default() -> Self {
+        Self {
+            read_watchdog_timeout_ms: default_read_watchdog_timeout_ms(),
+            open_retry_interval_ms: default_open_retry_interval_ms(),
+            read_retry_backoffs_ms: default_read_retry_backoffs_ms(),
+        }
+    }
+}
+
 #[derive(Serialize, Deserialize, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct AppConfig {
@@ -57,6 +210,8 @@ pub struct AppConfig {
     pub cue_device: Option<DeviceRef>,
     #[serde(default)]
     pub now_playing: NowPlayingConfig,
+    #[serde(default)]
+    pub tuning: TuningConfig,
 }
 
 pub struct Config {
@@ -167,6 +322,21 @@ impl Config {
         self.save_locked(&cfg)
     }
 
+    pub fn get_tuning(&self) -> TuningConfig {
+        self.inner.lock().tuning.clone()
+    }
+
+    /// Persist a new tuning section. Values are clamped to sane ranges first, so
+    /// a bad UI input (zero cadence, empty backoff list, tiny cache) can never
+    /// wedge playlist generation or the player. Returns the clamped config the
+    /// caller can echo back to the UI.
+    pub fn set_tuning(&self, tuning: TuningConfig) -> Result<TuningConfig> {
+        let mut cfg = self.inner.lock();
+        cfg.tuning = normalize_tuning(tuning);
+        self.save_locked(&cfg)?;
+        Ok(cfg.tuning.clone())
+    }
+
     pub fn remove_path(&self, kind: &str, dir_path: &str) -> Result<bool> {
         let resolved = canonicalize_lossy(dir_path);
         let mut cfg = self.inner.lock();
@@ -183,6 +353,49 @@ impl Config {
         }
         Ok(false)
     }
+}
+
+/// Clamp tuning values to ranges that keep the backend and renderer safe:
+/// cadences/counters must be >= 1 (a `0` would divide-by-zero or spin), the
+/// refill threshold cannot exceed its buffer, the cache needs a floor so at
+/// least one track can stay resident, and retry/backoff lists must be non-empty
+/// with non-zero delays. Defaults are already in range, so an untouched config
+/// is unchanged.
+fn normalize_tuning(mut t: TuningConfig) -> TuningConfig {
+    let il = &mut t.interleave;
+    // 0 disables jingle/commercial insertion entirely.
+    il.jingle_every = il.jingle_every.max(0);
+    il.commercial_every = il.commercial_every.max(0);
+    il.commercial_bucket_multiplier = il.commercial_bucket_multiplier.max(1);
+    il.commercial_bucket_min = il.commercial_bucket_min.max(0);
+
+    let ap = &mut t.auto_playlist;
+    ap.auto_playlist_buffer = ap.auto_playlist_buffer.max(1);
+    ap.auto_playlist_threshold = ap.auto_playlist_threshold.clamp(1, ap.auto_playlist_buffer);
+    ap.history_cap = ap.history_cap.max(1);
+    if ap.net_retry_backoffs_ms.is_empty() {
+        ap.net_retry_backoffs_ms = default_net_retry_backoffs_ms();
+    } else {
+        for b in &mut ap.net_retry_backoffs_ms {
+            *b = (*b).max(1);
+        }
+    }
+
+    // Floor of 16 MiB: enough for at least one whole track to stay resident.
+    t.cache.max_cache_bytes = t.cache.max_cache_bytes.max(16 * 1024 * 1024);
+
+    let p = &mut t.player;
+    p.read_watchdog_timeout_ms = p.read_watchdog_timeout_ms.max(1);
+    p.open_retry_interval_ms = p.open_retry_interval_ms.max(1);
+    if p.read_retry_backoffs_ms.is_empty() {
+        p.read_retry_backoffs_ms = default_read_retry_backoffs_ms();
+    } else {
+        for b in &mut p.read_retry_backoffs_ms {
+            *b = (*b).max(1);
+        }
+    }
+
+    t
 }
 
 fn canonicalize_lossy(p: &str) -> String {
@@ -291,6 +504,51 @@ mod tests {
         assert_eq!(np.webhook_url.as_deref(), Some("https://x"));
         assert!(np.file_enabled);
         assert!(np.webhook_enabled);
+    }
+
+    #[test]
+    fn tuning_defaults_when_missing() {
+        let dir = tempdir().unwrap();
+        let cfg = Config::open(dir.path()).unwrap();
+        assert_eq!(cfg.get_tuning(), TuningConfig::default());
+    }
+
+    #[test]
+    fn tuning_partial_json_fills_defaults() {
+        // Old config with only an interleave override still loads; every other
+        // field falls back to its default (additive schema, no version bump).
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("config.json");
+        fs::write(&path, r#"{"tuning":{"interleave":{"jingleEvery":6}}}"#).unwrap();
+        let cfg = Config::open(dir.path()).unwrap();
+        let t = cfg.get_tuning();
+        assert_eq!(t.interleave.jingle_every, 6);
+        assert_eq!(t.interleave.commercial_every, 8); // default
+        assert_eq!(t.cache.max_cache_bytes, 150 * 1024 * 1024); // default
+    }
+
+    #[test]
+    fn set_tuning_clamps_and_round_trips() {
+        let dir = tempdir().unwrap();
+        let cfg = Config::open(dir.path()).unwrap();
+        let mut t = TuningConfig::default();
+        t.interleave.jingle_every = -3; // -> 0 (disabled floor)
+        t.interleave.commercial_every = 0; // -> 0 (disabled, stays)
+        t.auto_playlist.auto_playlist_buffer = 4;
+        t.auto_playlist.auto_playlist_threshold = 99; // -> clamped to buffer (4)
+        t.cache.max_cache_bytes = 1; // -> 16 MiB floor
+        t.player.read_retry_backoffs_ms = vec![0, 5]; // 0 -> 1
+        let clamped = cfg.set_tuning(t).unwrap();
+        assert_eq!(clamped.interleave.jingle_every, 0);
+        assert_eq!(clamped.interleave.commercial_every, 0);
+        assert_eq!(clamped.auto_playlist.auto_playlist_threshold, 4);
+        assert_eq!(clamped.cache.max_cache_bytes, 16 * 1024 * 1024);
+        assert_eq!(clamped.player.read_retry_backoffs_ms, vec![1, 5]);
+
+        // Reopen reads the persisted (clamped) values.
+        drop(cfg);
+        let cfg2 = Config::open(dir.path()).unwrap();
+        assert_eq!(cfg2.get_tuning(), clamped);
     }
 
     #[test]

--- a/src-tauri/src/playlist.rs
+++ b/src-tauri/src/playlist.rs
@@ -14,22 +14,51 @@ pub enum ContentType {
     Commercial,
 }
 
-const JINGLE_EVERY: i64 = 4;
-const COMMERCIAL_EVERY: i64 = 8;
-const COMMERCIAL_BUCKET_MULTIPLIER: i64 = 3;
-const COMMERCIAL_BUCKET_MIN: i64 = 10;
-
-fn commercial_bucket_size(count: i64) -> i64 {
-    (count * COMMERCIAL_BUCKET_MULTIPLIER).max(COMMERCIAL_BUCKET_MIN)
+/// Interleave cadence for a generated block: how often jingles/commercials are
+/// woven into the music, and how the commercial pick-from-bottom bucket is
+/// sized. Supplied per call from the stored config; clamped on write (see
+/// `persist::config::set_tuning`), so the values here are always in range.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Interleave {
+    pub jingle_every: i64,
+    pub commercial_every: i64,
+    pub commercial_bucket_multiplier: i64,
+    pub commercial_bucket_min: i64,
 }
 
-pub fn generate(db: &Db, count: i64, exclude_ids: &[i64]) -> Result<Vec<Track>> {
+impl Default for Interleave {
+    fn default() -> Self {
+        Self {
+            jingle_every: 4,
+            commercial_every: 8,
+            commercial_bucket_multiplier: 3,
+            commercial_bucket_min: 10,
+        }
+    }
+}
+
+/// How many jingles/commercials to insert into `count` slots at the given
+/// cadence. An `every` of 0 disables the content type (no insertions, no
+/// divide-by-zero).
+fn cadence_count(count: i64, every: i64) -> i64 {
+    if every > 0 {
+        count / every
+    } else {
+        0
+    }
+}
+
+fn commercial_bucket_size(count: i64, il: &Interleave) -> i64 {
+    (count * il.commercial_bucket_multiplier).max(il.commercial_bucket_min)
+}
+
+pub fn generate(db: &Db, count: i64, exclude_ids: &[i64], il: &Interleave) -> Result<Vec<Track>> {
     if count <= 0 {
         return Ok(vec![]);
     }
 
-    let jingle_count = count / JINGLE_EVERY;
-    let commercial_count = count / COMMERCIAL_EVERY;
+    let jingle_count = cadence_count(count, il.jingle_every);
+    let commercial_count = cadence_count(count, il.commercial_every);
     let music_count = (count - jingle_count - commercial_count).max(0);
 
     // Exclusion happens in SQL (`NOT IN`), so each query returns exactly the
@@ -39,14 +68,14 @@ pub fn generate(db: &Db, count: i64, exclude_ids: &[i64]) -> Result<Vec<Track>> 
     let commercials = db.pick_random_from_bottom(
         ContentType::Commercial.as_ref(),
         commercial_count,
-        commercial_bucket_size(commercial_count),
+        commercial_bucket_size(commercial_count, il),
         exclude_ids,
     )?;
 
     Ok(interleave_evenly(music, jingles, commercials))
 }
 
-pub fn pick_filler(db: &Db, content_type: ContentType) -> Result<Option<Track>> {
+pub fn pick_filler(db: &Db, content_type: ContentType, il: &Interleave) -> Result<Option<Track>> {
     match content_type {
         ContentType::Jingle => Ok(db
             .get_random_tracks(ContentType::Jingle.as_ref(), 1, &[])?
@@ -55,7 +84,7 @@ pub fn pick_filler(db: &Db, content_type: ContentType) -> Result<Option<Track>> 
             .pick_random_from_bottom(
                 ContentType::Commercial.as_ref(),
                 1,
-                commercial_bucket_size(1),
+                commercial_bucket_size(1, il),
                 &[],
             )?
             .pop()),
@@ -164,10 +193,32 @@ mod tests {
     #[test]
     fn music_count_is_clamped_for_small_totals() {
         // count=3 → no jingles, no commercials, 3 music
+        let il = Interleave::default();
         let total = 3i64;
-        let jingle_count = total / JINGLE_EVERY;
-        let commercial_count = total / COMMERCIAL_EVERY;
+        let jingle_count = total / il.jingle_every;
+        let commercial_count = total / il.commercial_every;
         assert_eq!(jingle_count, 0);
         assert_eq!(commercial_count, 0);
+    }
+
+    #[test]
+    fn commercial_bucket_size_respects_multiplier_and_min() {
+        let il = Interleave::default(); // x3, min 10
+        assert_eq!(commercial_bucket_size(1, &il), 10); // min wins
+        assert_eq!(commercial_bucket_size(5, &il), 15); // multiplier wins
+        let custom = Interleave {
+            commercial_bucket_multiplier: 2,
+            commercial_bucket_min: 4,
+            ..Interleave::default()
+        };
+        assert_eq!(commercial_bucket_size(1, &custom), 4);
+        assert_eq!(commercial_bucket_size(10, &custom), 20);
+    }
+
+    #[test]
+    fn cadence_count_zero_disables_without_dividing() {
+        assert_eq!(cadence_count(100, 0), 0); // disabled: none inserted
+        assert_eq!(cadence_count(100, 4), 25); // normal cadence
+        assert_eq!(cadence_count(3, 4), 0); // fewer slots than cadence
     }
 }

--- a/src/features/settings/SettingsOverlay.svelte
+++ b/src/features/settings/SettingsOverlay.svelte
@@ -6,6 +6,7 @@
     DeviceInfo,
     DeviceRef,
     NowPlayingConfig,
+    TuningConfig,
   } from "../../shared/types";
 
   const sections: { type: ContentType; label: string }[] = [
@@ -14,8 +15,13 @@
     { type: "jingle", label: "Jingles" },
   ];
 
-  type ActiveTab = "library" | "audio" | "now-playing";
+  type ActiveTab = "library" | "audio" | "now-playing" | "advanced";
   let activeTab = $state<ActiveTab>("library");
+  const MIB = 1024 * 1024;
+  // Editable draft of the tuning config. Synced from `app.tuning` whenever the
+  // overlay opens; each edit persists via `app.saveTuning`, then re-syncs so the
+  // backend's clamped values are reflected in the inputs.
+  let tuning = $state<TuningConfig>($state.snapshot(app.tuning));
   let mainDeviceChanged = $state(false);
   let nowPlaying = $state<NowPlayingConfig>({
     webhookUrl: null,
@@ -32,9 +38,33 @@
     if (app.settingsOpen) {
       void app.loadAudioConfig();
       void loadNowPlayingConfig();
+      tuning = $state.snapshot(app.tuning);
       mainDeviceChanged = false;
     }
   });
+
+  // Persist the current draft, then adopt the backend's clamped result so the
+  // inputs snap to any coerced values.
+  async function saveTuning(): Promise<void> {
+    await app.saveTuning($state.snapshot(tuning));
+    tuning = $state.snapshot(app.tuning);
+  }
+
+  // Parse a number input, ignoring empty/NaN so a mid-edit blank doesn't wipe
+  // the field; the min-clamp is enforced by the backend on save.
+  function numInput(e: Event, apply: (v: number) => void): void {
+    const v = Number((e.currentTarget as HTMLInputElement).value);
+    if (Number.isFinite(v)) apply(v);
+  }
+
+  // Parse a comma/space separated list of positive integers (backoff schedules).
+  function listInput(e: Event, apply: (v: number[]) => void): void {
+    const parsed = (e.currentTarget as HTMLInputElement).value
+      .split(/[,\s]+/)
+      .map((s) => Number(s))
+      .filter((n) => Number.isFinite(n) && n > 0);
+    if (parsed.length > 0) apply(parsed);
+  }
 
   async function loadNowPlayingConfig(): Promise<void> {
     nowPlaying = await api.getNowPlayingConfig();
@@ -164,6 +194,16 @@
           <span class="material-symbols-outlined">rss_feed</span>
           Now Playing
         </button>
+        <button
+          class="settings-tab"
+          class:active={activeTab === "advanced"}
+          role="tab"
+          aria-selected={activeTab === "advanced"}
+          onclick={() => (activeTab = "advanced")}
+        >
+          <span class="material-symbols-outlined">tune</span>
+          Advanced
+        </button>
       </div>
 
       <div id="settings-content">
@@ -283,7 +323,7 @@
               </button>
             </div>
           </div>
-        {:else}
+        {:else if activeTab === "now-playing"}
           <div class="settings-section">
             <h4>Now Playing Metadata</h4>
             <p class="settings-section-desc">
@@ -420,6 +460,250 @@
                 <code>now_playing.json</code> atomically. TXT is truncated on stop;
                 JSON keeps the Stopped event payload.
               </div>
+            </div>
+          </div>
+        {:else}
+          <div class="settings-section settings-section--tuning">
+            <h4>Advanced Tuning</h4>
+            <p class="settings-section-desc">
+              Fine-tune playlist rotation, buffering, and network resilience.
+              Out-of-range values are clamped on save.
+            </p>
+
+            <h5 class="tuning-group-title">Interleave</h5>
+            <div class="device-row">
+              <label for="tune-jingle-every">Jingle every N tracks</label>
+              <input
+                id="tune-jingle-every"
+                type="number"
+                min="0"
+                value={tuning.interleave.jingleEvery}
+                oninput={(e) =>
+                  numInput(e, (v) => (tuning.interleave.jingleEvery = v))}
+                onchange={saveTuning}
+              />
+              <div class="hint">
+                One jingle after this many music tracks. 0 disables jingles.
+              </div>
+            </div>
+            <div class="device-row">
+              <label for="tune-commercial-every"
+                >Commercial every N tracks</label
+              >
+              <input
+                id="tune-commercial-every"
+                type="number"
+                min="0"
+                value={tuning.interleave.commercialEvery}
+                oninput={(e) =>
+                  numInput(e, (v) => (tuning.interleave.commercialEvery = v))}
+                onchange={saveTuning}
+              />
+              <div class="hint">
+                One commercial break after this many music tracks. 0 disables
+                commercials.
+              </div>
+            </div>
+            <div class="device-row">
+              <label for="tune-bucket-mult">Commercial bucket multiplier</label>
+              <input
+                id="tune-bucket-mult"
+                type="number"
+                min="1"
+                value={tuning.interleave.commercialBucketMultiplier}
+                oninput={(e) =>
+                  numInput(
+                    e,
+                    (v) => (tuning.interleave.commercialBucketMultiplier = v),
+                  )}
+                onchange={saveTuning}
+              />
+              <div class="hint">
+                Commercials per break scale with playlist length times this
+                factor. Higher = more ads per break.
+              </div>
+            </div>
+            <div class="device-row">
+              <label for="tune-bucket-min">Commercial bucket minimum</label>
+              <input
+                id="tune-bucket-min"
+                type="number"
+                min="0"
+                value={tuning.interleave.commercialBucketMin}
+                oninput={(e) =>
+                  numInput(
+                    e,
+                    (v) => (tuning.interleave.commercialBucketMin = v),
+                  )}
+                onchange={saveTuning}
+              />
+              <div class="hint">
+                Floor on commercials per break, regardless of playlist length. 0
+                disables the floor.
+              </div>
+            </div>
+
+            <h5 class="tuning-group-title">Auto-playlist</h5>
+            <div class="device-row">
+              <label for="tune-buffer">Buffer (tracks kept queued)</label>
+              <input
+                id="tune-buffer"
+                type="number"
+                min="1"
+                value={tuning.autoPlaylist.autoPlaylistBuffer}
+                oninput={(e) =>
+                  numInput(
+                    e,
+                    (v) => (tuning.autoPlaylist.autoPlaylistBuffer = v),
+                  )}
+                onchange={saveTuning}
+              />
+              <div class="hint">
+                Target queue length the auto-playlist tops up to. Minimum 1.
+              </div>
+            </div>
+            <div class="device-row">
+              <label for="tune-threshold">Refill threshold</label>
+              <input
+                id="tune-threshold"
+                type="number"
+                min="1"
+                value={tuning.autoPlaylist.autoPlaylistThreshold}
+                oninput={(e) =>
+                  numInput(
+                    e,
+                    (v) => (tuning.autoPlaylist.autoPlaylistThreshold = v),
+                  )}
+                onchange={saveTuning}
+              />
+              <div class="hint">
+                Refill kicks in when the queue drops to this many tracks.
+                Clamped to at most the buffer size.
+              </div>
+            </div>
+            <div class="device-row">
+              <label for="tune-history">History cap</label>
+              <input
+                id="tune-history"
+                type="number"
+                min="1"
+                value={tuning.autoPlaylist.historyCap}
+                oninput={(e) =>
+                  numInput(e, (v) => (tuning.autoPlaylist.historyCap = v))}
+                onchange={saveTuning}
+              />
+              <div class="hint">
+                Recently played tracks remembered to avoid quick repeats.
+                Minimum 1.
+              </div>
+            </div>
+            <div class="device-row">
+              <label for="tune-save-throttle">Session save throttle (ms)</label>
+              <input
+                id="tune-save-throttle"
+                type="number"
+                min="0"
+                value={tuning.autoPlaylist.sessionSaveThrottleMs}
+                oninput={(e) =>
+                  numInput(
+                    e,
+                    (v) => (tuning.autoPlaylist.sessionSaveThrottleMs = v),
+                  )}
+                onchange={saveTuning}
+              />
+              <div class="hint">
+                Minimum gap between session writes to disk. 0 saves on every
+                change (more disk I/O).
+              </div>
+            </div>
+            <div class="device-row">
+              <label for="tune-net-backoffs">Network retry backoffs (ms)</label>
+              <input
+                id="tune-net-backoffs"
+                type="text"
+                value={tuning.autoPlaylist.netRetryBackoffsMs.join(", ")}
+                oninput={(e) =>
+                  listInput(
+                    e,
+                    (v) => (tuning.autoPlaylist.netRetryBackoffsMs = v),
+                  )}
+                onchange={saveTuning}
+              />
+              <div class="hint">
+                Comma-separated wait times between refill retries. The last
+                value repeats until recovery.
+              </div>
+            </div>
+
+            <h5 class="tuning-group-title">Network &amp; cache</h5>
+            <div class="device-row">
+              <label for="tune-cache">Prefetch cache size (MiB)</label>
+              <input
+                id="tune-cache"
+                type="number"
+                min="16"
+                value={Math.round(tuning.cache.maxCacheBytes / MIB)}
+                oninput={(e) =>
+                  numInput(
+                    e,
+                    (v) => (tuning.cache.maxCacheBytes = Math.round(v * MIB)),
+                  )}
+                onchange={saveTuning}
+              />
+              <div class="hint">
+                RAM budget for prefetched track files. Minimum 16 MiB.
+              </div>
+            </div>
+            <div class="device-row">
+              <label for="tune-watchdog">Read watchdog timeout (ms)</label>
+              <input
+                id="tune-watchdog"
+                type="number"
+                min="1"
+                value={tuning.player.readWatchdogTimeoutMs}
+                oninput={(e) =>
+                  numInput(e, (v) => (tuning.player.readWatchdogTimeoutMs = v))}
+                onchange={saveTuning}
+              />
+              <div class="hint">
+                A read stalled longer than this counts as a network hiccup and
+                triggers recovery.
+              </div>
+            </div>
+            <div class="device-row">
+              <label for="tune-open-retry"
+                >Output open-retry interval (ms)</label
+              >
+              <input
+                id="tune-open-retry"
+                type="number"
+                min="1"
+                value={tuning.player.openRetryIntervalMs}
+                oninput={(e) =>
+                  numInput(e, (v) => (tuning.player.openRetryIntervalMs = v))}
+                onchange={saveTuning}
+              />
+              <div class="hint">
+                Wait between attempts to reopen the audio output device.
+              </div>
+            </div>
+            <div class="device-row">
+              <label for="tune-read-backoffs">Read retry backoffs (ms)</label>
+              <input
+                id="tune-read-backoffs"
+                type="text"
+                value={tuning.player.readRetryBackoffsMs.join(", ")}
+                oninput={(e) =>
+                  listInput(e, (v) => (tuning.player.readRetryBackoffsMs = v))}
+                onchange={saveTuning}
+              />
+              <div class="hint">
+                Comma-separated wait times between file-read retries. The last
+                value repeats until recovery.
+              </div>
+            </div>
+            <div class="hint">
+              Cache and player settings apply on next restart.
             </div>
           </div>
         {/if}

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,6 +19,9 @@ void attachConsole();
 
 mount(App, { target: document.getElementById("app")! });
 
+// Load user tuning first so runtime values (auto-playlist buffer, save
+// throttle, retry backoffs) are in effect before session/playlist logic runs.
+void app.loadTuning();
 void app.search();
 void app.loadStats();
 void app.loadSession();

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -11,6 +11,7 @@ import type {
   SortColumn,
   SortDir,
   Track,
+  TuningConfig,
 } from "./types";
 
 export type PersistedPlaylistItem =
@@ -173,6 +174,14 @@ export const api = {
   },
   setNowPlayingConfig(config: NowPlayingConfig): Promise<void> {
     return invoke<void>("set_now_playing_config", { config });
+  },
+  getTuningConfig(): Promise<TuningConfig> {
+    return invoke<TuningConfig>("get_tuning_config");
+  },
+  // Returns the clamped config the backend actually persisted, so the UI can
+  // reflect any values that were coerced into range.
+  setTuningConfig(config: TuningConfig): Promise<TuningConfig> {
+    return invoke<TuningConfig>("set_tuning_config", { config });
   },
   testNowPlayingWebhook(): Promise<number> {
     return invoke<number>("now_playing_test");

--- a/src/shared/state.svelte.ts
+++ b/src/shared/state.svelte.ts
@@ -7,6 +7,7 @@ import type {
   SortColumn,
   SortDir,
   Track,
+  TuningConfig,
 } from "./types";
 import { isStopMarker, isTrackItem, stopMarker, trackItem } from "./types";
 import {
@@ -28,15 +29,34 @@ const logger = {
 
 export type { Track };
 
-// Auto playlist configuration
-const AUTO_PLAYLIST_BUFFER = 20;
-// Threshold at which the auto playlist will be refilled. Should be lower than AUTO_PLAYLIST_BUFFER to avoid excessive refilling.
-const AUTO_PLAYLIST_THRESHOLD = 5;
-const HISTORY_CAP = 100;
-const SESSION_SAVE_THROTTLE_MS = 500;
-// Backoff schedule (ms) for retrying advancement while nothing playable is
-// cached (network outage). The last value repeats until recovery.
-const NET_RETRY_BACKOFFS_MS = [1000, 2000, 5000];
+// Tuning defaults. Used until `loadTuning()` fetches the persisted config from
+// the backend, and as the fallback if that call fails.
+const DEFAULT_TUNING: TuningConfig = {
+  interleave: {
+    jingleEvery: 4,
+    commercialEvery: 8,
+    commercialBucketMultiplier: 3,
+    commercialBucketMin: 10,
+  },
+  autoPlaylist: {
+    // Number of upcoming tracks kept queued by the auto-playlist.
+    autoPlaylistBuffer: 20,
+    // Refill threshold — below this the auto-playlist tops back up. Kept lower
+    // than the buffer to avoid excessive refilling.
+    autoPlaylistThreshold: 5,
+    historyCap: 100,
+    sessionSaveThrottleMs: 500,
+    // Backoff schedule (ms) for retrying advancement while nothing playable is
+    // cached (network outage). The last value repeats until recovery.
+    netRetryBackoffsMs: [1000, 2000, 5000],
+  },
+  cache: { maxCacheBytes: 150 * 1024 * 1024 },
+  player: {
+    readWatchdogTimeoutMs: 10000,
+    openRetryIntervalMs: 2000,
+    readRetryBackoffsMs: [500, 1000, 2000],
+  },
+};
 
 export type PlaylistTab = "playlist" | "history";
 
@@ -115,6 +135,11 @@ export class AppState {
   mainDevice = $state<DeviceRef | null>(null);
   cueDevice = $state<DeviceRef | null>(null);
 
+  // Initialized to defaults; `loadTuning()` replaces it with the persisted
+  // config at startup. Read for auto-playlist/history/retry behaviour and
+  // edited by the Settings → Advanced tab.
+  tuning = $state<TuningConfig>(structuredClone(DEFAULT_TUNING));
+
   hoveredTrack = $state<Track | null>(null);
   hoverX = $state(0);
   hoverY = $state(0);
@@ -132,7 +157,7 @@ export class AppState {
     this.cueBackend = cueBackend ?? new NativeBackend("cue");
     this.throttledSave = throttle(
       () => void this.persistSession(),
-      SESSION_SAVE_THROTTLE_MS,
+      this.tuning.autoPlaylist.sessionSaveThrottleMs,
     );
 
     this.backend.on((event) => {
@@ -372,9 +397,10 @@ export class AppState {
   }
 
   appendHistory(track: Track): void {
+    const cap = this.tuning.autoPlaylist.historyCap;
     this.history.push(track);
-    if (this.history.length > HISTORY_CAP) {
-      this.history.splice(0, this.history.length - HISTORY_CAP);
+    if (this.history.length > cap) {
+      this.history.splice(0, this.history.length - cap);
     }
     this.scheduleSave();
   }
@@ -555,8 +581,9 @@ export class AppState {
   async maybeRefillPlaylist(): Promise<void> {
     if (!this.autoPlaylistActive) return;
     if (this.playlist.some(isStopMarker)) return;
-    if (this.playlist.length < AUTO_PLAYLIST_THRESHOLD) {
-      const count = AUTO_PLAYLIST_BUFFER - this.playlist.length;
+    if (this.playlist.length < this.tuning.autoPlaylist.autoPlaylistThreshold) {
+      const count =
+        this.tuning.autoPlaylist.autoPlaylistBuffer - this.playlist.length;
       const excludeIds = this.playlist
         .filter(isTrackItem)
         .map((i) => i.track.id);
@@ -682,6 +709,34 @@ export class AppState {
     this.audioDevices = devices;
     this.mainDevice = main;
     this.cueDevice = cue;
+  }
+
+  /// Fetch persisted tuning from the backend. Falls back to defaults (already in
+  /// place) on error so a backend hiccup never leaves the app unusable.
+  async loadTuning(): Promise<void> {
+    try {
+      this.applyTuning(await api.getTuningConfig());
+    } catch (err) {
+      logger.error("Failed to load tuning config", err);
+    }
+  }
+
+  /// Persist edited tuning and adopt the backend's clamped result. Cache/player
+  /// fields only take effect on restart (their worker threads capture them at
+  /// startup); the renderer-side fields applied here take effect immediately.
+  async saveTuning(next: TuningConfig): Promise<void> {
+    this.applyTuning(await api.setTuningConfig(next));
+  }
+
+  /// Adopt a tuning config: store it and rebuild the session-save throttle,
+  /// since its interval is derived from `sessionSaveThrottleMs`.
+  private applyTuning(tuning: TuningConfig): void {
+    this.tuning = tuning;
+    this.throttledSave.cancel();
+    this.throttledSave = throttle(
+      () => void this.persistSession(),
+      tuning.autoPlaylist.sessionSaveThrottleMs,
+    );
   }
 
   async setMainDeviceConfig(device: DeviceRef | null): Promise<void> {
@@ -911,7 +966,8 @@ export class AppState {
   private scheduleNetRetry(): void {
     this.awaitingNetwork = true;
     if (this.netRetryTimer !== null) return;
-    const i = Math.min(this.netRetryAttempt, NET_RETRY_BACKOFFS_MS.length - 1);
+    const backoffs = this.tuning.autoPlaylist.netRetryBackoffsMs;
+    const i = Math.min(this.netRetryAttempt, backoffs.length - 1);
     this.netRetryAttempt += 1;
     this.netRetryTimer = setTimeout(() => {
       this.netRetryTimer = null;
@@ -921,7 +977,7 @@ export class AppState {
       // successful read the resulting cache-state advances playback.
       this.updatePrefetch();
       this.advancePlan(true);
-    }, NET_RETRY_BACKOFFS_MS[i]);
+    }, backoffs[i]);
   }
 
   private clearNetRetry(): void {

--- a/src/shared/state.test.ts
+++ b/src/shared/state.test.ts
@@ -34,9 +34,36 @@ const { api } = vi.hoisted(() => {
     setMainDevice: vi.fn(),
     getCueDevice: vi.fn(),
     setCueDevice: vi.fn(),
+    getTuningConfig: vi.fn(),
+    setTuningConfig: vi.fn(),
   };
   return { api };
 });
+
+// Default tuning config as returned by the backend.
+function defaultTuning() {
+  return {
+    interleave: {
+      jingleEvery: 4,
+      commercialEvery: 8,
+      commercialBucketMultiplier: 3,
+      commercialBucketMin: 10,
+    },
+    autoPlaylist: {
+      autoPlaylistBuffer: 20,
+      autoPlaylistThreshold: 5,
+      historyCap: 100,
+      sessionSaveThrottleMs: 500,
+      netRetryBackoffsMs: [1000, 2000, 5000],
+    },
+    cache: { maxCacheBytes: 150 * 1024 * 1024 },
+    player: {
+      readWatchdogTimeoutMs: 10000,
+      openRetryIntervalMs: 2000,
+      readRetryBackoffsMs: [500, 1000, 2000],
+    },
+  };
+}
 
 vi.mock("./api", () => ({ api }));
 
@@ -132,6 +159,8 @@ function resetApi(): void {
   api.getCueDevice.mockResolvedValue(null);
   api.setMainDevice.mockResolvedValue(undefined);
   api.setCueDevice.mockResolvedValue(undefined);
+  api.getTuningConfig.mockResolvedValue(defaultTuning());
+  api.setTuningConfig.mockImplementation((c: unknown) => Promise.resolve(c));
 }
 
 interface TestApp {
@@ -959,6 +988,63 @@ describe("AppState library + paths", () => {
       processed: 7,
       total: 10,
     });
+  });
+});
+
+describe("AppState tuning", () => {
+  let app: AppState;
+
+  beforeEach(() => {
+    resetApi();
+    app = makeApp().app;
+  });
+
+  it("defaults to the built-in tuning before load", () => {
+    expect(app.tuning.autoPlaylist.autoPlaylistBuffer).toBe(20);
+    expect(app.tuning.autoPlaylist.autoPlaylistThreshold).toBe(5);
+  });
+
+  it("loadTuning adopts backend values", async () => {
+    const cfg = defaultTuning();
+    cfg.autoPlaylist.autoPlaylistBuffer = 8;
+    cfg.autoPlaylist.autoPlaylistThreshold = 3;
+    api.getTuningConfig.mockResolvedValueOnce(cfg);
+    await app.loadTuning();
+    expect(app.tuning.autoPlaylist.autoPlaylistBuffer).toBe(8);
+  });
+
+  it("loaded buffer/threshold drive refill sizing", async () => {
+    const cfg = defaultTuning();
+    cfg.autoPlaylist.autoPlaylistBuffer = 8;
+    cfg.autoPlaylist.autoPlaylistThreshold = 3;
+    api.getTuningConfig.mockResolvedValueOnce(cfg);
+    api.generatePlaylist.mockResolvedValue([]);
+    await app.loadTuning();
+
+    app.autoPlaylistActive = true;
+    await app.maybeRefillPlaylist();
+    expect(api.generatePlaylist).toHaveBeenCalledWith(8, []);
+  });
+
+  it("loadTuning keeps defaults when the backend errors", async () => {
+    api.getTuningConfig.mockRejectedValueOnce(new Error("boom"));
+    await app.loadTuning();
+    expect(app.tuning.autoPlaylist.autoPlaylistBuffer).toBe(20);
+  });
+
+  it("saveTuning persists and adopts the clamped result", async () => {
+    const requested = defaultTuning();
+    requested.autoPlaylist.autoPlaylistBuffer = 4;
+    requested.autoPlaylist.autoPlaylistThreshold = 99;
+    // Backend clamps threshold down to the buffer.
+    const clamped = defaultTuning();
+    clamped.autoPlaylist.autoPlaylistBuffer = 4;
+    clamped.autoPlaylist.autoPlaylistThreshold = 4;
+    api.setTuningConfig.mockResolvedValueOnce(clamped);
+
+    await app.saveTuning(requested);
+    expect(api.setTuningConfig).toHaveBeenCalledWith(requested);
+    expect(app.tuning.autoPlaylist.autoPlaylistThreshold).toBe(4);
   });
 });
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -63,6 +63,43 @@ export interface DeviceRef {
   description: string;
 }
 
+/// Playlist interleave cadence.
+export interface InterleaveConfig {
+  jingleEvery: number;
+  commercialEvery: number;
+  commercialBucketMultiplier: number;
+  commercialBucketMin: number;
+}
+
+/// Renderer-side auto-playlist + session tuning. Read by `state.svelte.ts`.
+export interface AutoPlaylistConfig {
+  autoPlaylistBuffer: number;
+  autoPlaylistThreshold: number;
+  historyCap: number;
+  sessionSaveThrottleMs: number;
+  netRetryBackoffsMs: number[];
+}
+
+/// Prefetch byte-cache tuning (bytes).
+export interface CacheConfig {
+  maxCacheBytes: number;
+}
+
+/// Audio-player network-resilience timeouts (ms).
+export interface PlayerConfig {
+  readWatchdogTimeoutMs: number;
+  openRetryIntervalMs: number;
+  readRetryBackoffsMs: number[];
+}
+
+/// User-tunable playback behaviour, persisted in `config.json`.
+export interface TuningConfig {
+  interleave: InterleaveConfig;
+  autoPlaylist: AutoPlaylistConfig;
+  cache: CacheConfig;
+  player: PlayerConfig;
+}
+
 export interface DeviceInfo {
   name: string;
   description: string;

--- a/src/styles.css
+++ b/src/styles.css
@@ -1785,6 +1785,75 @@ body {
   margin-bottom: var(--sp-lg);
 }
 
+/* Sub-group heading within the Advanced tuning tab. */
+.tuning-group-title {
+  font-size: 13px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--on-surface-variant);
+  margin: var(--sp-xl) 0 var(--sp-sm);
+  padding-bottom: var(--sp-xs);
+  border-bottom: 1px solid var(--outline-variant);
+}
+.tuning-group-title:first-of-type {
+  margin-top: 0;
+}
+
+/* Advanced tuning rows: label left, control right, hint spanning below. */
+.settings-section--tuning .device-row {
+  display: grid;
+  grid-template-columns: 1fr 132px;
+  align-items: center;
+  column-gap: var(--sp-lg);
+  row-gap: var(--sp-xs);
+  margin-bottom: var(--sp-md);
+}
+
+.settings-section--tuning .device-row label {
+  font-family: inherit;
+  font-size: 13px;
+  letter-spacing: 0;
+  text-transform: none;
+  color: var(--on-surface);
+}
+
+.settings-section--tuning .device-row input {
+  width: 100%;
+  padding: var(--sp-sm) var(--sp-md);
+  background: var(--surface-container-lowest);
+  border: 1px solid var(--outline-variant);
+  border-radius: var(--r-lg);
+  color: var(--on-surface);
+  font-size: 13px;
+  font-family: var(--font-mono);
+  text-align: right;
+}
+
+.settings-section--tuning .device-row input[type="text"] {
+  text-align: left;
+}
+
+.settings-section--tuning .device-row input:focus {
+  outline: none;
+  border-color: var(--primary);
+}
+
+.settings-section--tuning .device-row input:hover {
+  border-color: var(--outline);
+}
+
+/* Hint sits under the row, spanning both columns. */
+.settings-section--tuning .device-row .hint {
+  grid-column: 1 / -1;
+  margin-top: 0;
+}
+
+/* Trailing group-level hint (restart notice). */
+.settings-section--tuning > .hint {
+  margin-top: var(--sp-lg);
+}
+
 #settings-footer {
   display: flex;
   align-items: center;


### PR DESCRIPTION
Closes #284.

Promotes scattered compile-time tuning constants to user-configurable `AppConfig` values, with a Settings UI tab to edit them.

## What
- **Additive serde schema** — `TuningConfig` (interleave / auto-playlist / cache / player) with per-field `#[serde(default)]`. Missing keys fall back to current values, so existing `config.json` keeps working; current constants are the defaults.
- **Validated & clamped on save** — `set_tuning` normalizes inputs (min/floors, threshold ≤ buffer, cache ≥ 16 MiB, non-empty backoffs) and returns the clamped config the UI re-reads.
- **0 disables** — `jingle_every` / `commercial_every` of `0` turns off that content type, guarded against divide-by-zero via `cadence_count`.
- **Config-owned, not global** — tuning threaded through constructors (cache, player decks, playlist interleave); no `static mut` / atomics.
- **Advanced settings tab** — every value exposed with per-field explainers, clamp hints, and a restart notice for cache/player fields. Two-column styled layout.

## Testing
- Backend: `cargo test --lib` → 101 passed. `cargo clippy` clean.
- Frontend: `vitest` → 125 passed. svelte-check 0 errors, eslint clean, prettier formatted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)